### PR TITLE
chore: add CODEOWNERS and SECURITY.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default: all PRs require review from the maintainer
+* @I-am-nothing

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please **do not** open a public issue.
+
+Instead, email us at **security@mirrorstack.ai** with:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected versions or components
+
+We will acknowledge your report within 48 hours and work with you to resolve it.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| latest main | Yes |
+| older commits | No |


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` — auto-assigns @I-am-nothing as reviewer on all PRs
- Add `SECURITY.md` — vulnerability reporting policy (email security@mirrorstack.ai)

## Test plan
- [ ] CODEOWNERS syntax is valid
- [ ] SECURITY.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)