### PR TITLE
fix: correct RELEASES.md and release workflow (stale squash merge)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,44 +10,24 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: pnpm
-          registry-url: https://npm.pkg.github.com
-
-      - run: pnpm install --frozen-lockfile
-
       - name: Get version from package.json
         id: version
         run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
-      - name: Determine npm tag
-        id: tag
+      - name: Determine if prerelease
+        id: pre
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          if [[ "$VERSION" == *"-alpha"* ]]; then
-            echo "tag=alpha" >> "$GITHUB_OUTPUT"
-          elif [[ "$VERSION" == *"-beta"* ]]; then
-            echo "tag=beta" >> "$GITHUB_OUTPUT"
-          elif [[ "$VERSION" == *"-rc"* ]]; then
-            echo "tag=rc" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" == *"-"* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Publish to GitHub Packages
-        run: pnpm publish --no-git-checks --tag ${{ steps.tag.outputs.tag }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create git tag
         run: |
@@ -61,6 +41,6 @@ jobs:
           gh release create "v${{ steps.version.outputs.version }}" \
             --title "v${{ steps.version.outputs.version }}" \
             --generate-notes \
-            --prerelease=${{ steps.tag.outputs.tag != 'latest' }}
+            --prerelease=${{ steps.pre.outputs.prerelease }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -50,21 +50,23 @@ alpha → beta → rc → stable
 Releases are **label-triggered**. Add the `release` label to a PR before merging.
 
 On merge, CI will automatically:
-1. Bump the version in `package.json`
-2. Create a git tag (e.g. `v0.1.0-alpha.2`)
-3. Create a GitHub Release with auto-generated changelog
+1. Create a git tag (e.g. `v0.1.0-alpha.2`)
+2. Create a GitHub Release with auto-generated changelog
+3. Alpha/beta/rc versions are marked as prerelease
 
-PRs without the `release` label do not trigger a version bump.
+PRs without the `release` label do not trigger a release.
 
-### Stage transitions (manual)
+The PR author should bump `version` in `package.json` before adding the `release` label.
 
-To move between stages (e.g. alpha → beta), a maintainer manually sets the version in `package.json` and creates the tag:
+### npm publishing
+
+Not published to npm during pre-release stages (alpha/beta/rc). Apps install directly from git:
 
 ```bash
-# in package.json: "version": "0.1.0-beta.1"
-git tag v0.1.0-beta.1
-git push origin v0.1.0-beta.1
+pnpm add github:mirrorstack-ai/web-ui-kit
 ```
+
+npm publishing will be enabled at stable `1.0.0`.
 
 ## Milestones
 


### PR DESCRIPTION
## Summary
- PR #41 squash merge used stale first-commit content instead of latest
- Fix RELEASES.md: no npm publish during pre-release, install from git
- Fix release.yml: remove GitHub Packages publish step

## Test plan
- [ ] RELEASES.md matches intended content
- [ ] release.yml has no publish step

🤖 Generated with [Claude Code](https://claude.com/claude-code)