### PR TITLE
feat: add dev-only logging to Progress component

### DIFF
--- a/src/components/ui/feedback/progress/Progress.tsx
+++ b/src/components/ui/feedback/progress/Progress.tsx
@@ -2,14 +2,9 @@ import type { ComponentMeta } from "@/types/component-meta";
 import type { ProgressProps } from "./types";
 import { LinearProgress } from "./LinearProgress";
 import { CircularProgress } from "./CircularProgress";
-import { ENV } from "@/utils/env";
-declare const process: any;
+import { isDev } from "@/utils/env";
 
 export type { ProgressProps, ProgressType, ProgressColor, ProgressVariant, ProgressSize } from "./types";
-
-const isDev =
-  typeof process !== "undefined" &&
-  process?.env?.NODE_ENV === ENV.DEV;
 
 export const meta: ComponentMeta = {
   name: "Progress",
@@ -32,8 +27,6 @@ export function Progress(props: ProgressProps) {
     if (!isValidType || !isValidVariant) {
       console.warn("[Progress] invalid type/variant combination");
     }
-
-    console.log("[Progress props]", { value, type, variant });
   }
 
   return type === "circular" ? (


### PR DESCRIPTION
## What

Adds development-only console warnings and logs to the Progress component for debugging and validation.

Closes #36

## Changes
- Warns when value is outside 0-100 range in determinate mode
- Warns on invalid type/variant combinations
- Logs useful props for debugging in development mode only

## Checklist

- [ ] Component exports `meta` with `name` and `description`
- [ ] Story added with `Playground` story
- [ ] Test added (if component has logic)
- [ ] Exported from `src/index.ts`
- [ ] `pnpm components validate` passes
- [x] `pnpm test` passes
- [x] `pnpm typecheck` passes
- [ ] Storybook preview looks correct in light and dark mode