### PR TITLE
docs: add dev warnings guideline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,5 +35,6 @@ src/utils/                                   Helpers
 - Every component must export `meta: ComponentMeta` with `name` and `description`
 - No `"use client"` in component files
 - Use `cn()` from `@/utils/cn` for class merging
-- Use `ENV.PROD` / `ENV.DEV` from `@/utils/env` for environment checks — never use raw strings
+- Use `const isDev = process.env.NODE_ENV === ENV.DEV` from `@/utils/env` — never use raw strings
+- Add dev-only warnings: `if (isDev) { console.warn("[ComponentName] message"); }` for accessibility, invalid props, wrong usage
 - See CONTRIBUTING.md for full details

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,12 +105,23 @@ Rules:
   ```tsx
   import { ENV } from "@/utils/env";
 
-  // dev-only warnings
-  if (process.env.NODE_ENV === ENV.DEV) {
-    console.warn("[ComponentName] helpful warning message");
+  const isDev = process.env.NODE_ENV === ENV.DEV;
+  ```
+- **Add dev-only warnings** for common mistakes. Use `isDev` guard and prefix with `[ComponentName]`:
+  ```tsx
+  if (isDev) {
+    console.warn("[Button] loading button should have aria-label");
   }
+  ```
 
-  // production guard
+### Dev warnings
+
+Components should include dev-only warnings for:
+- **Accessibility** — missing `aria-label`, `role`, or accessible text
+- **Invalid props** — value out of range, conflicting props
+- **Wrong component usage** — e.g. icon-only `Button` should use `IconButton` instead
+- **Production guard** — components that should not render in production (e.g. DevToolbar):
+  ```tsx
   if (process.env.NODE_ENV === ENV.PROD) return null;
   ```
 


### PR DESCRIPTION
## Summary
- Add dev warnings section to CONTRIBUTING.md: when to warn (accessibility, invalid props, wrong usage)
- Use `const isDev` pattern with `[ComponentName]` prefix
- Update CLAUDE.md for AI agents

## Test plan
- [ ] Docs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)