### PR TITLE
refactor: simplify env to isDev/isProd constants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,6 @@ src/utils/                                   Helpers
 - Every component must export `meta: ComponentMeta` with `name` and `description`
 - No `"use client"` in component files
 - Use `cn()` from `@/utils/cn` for class merging
-- Use `const isDev = process.env.NODE_ENV === ENV.DEV` from `@/utils/env` — never use raw strings
+- Use `isDev` / `isProd` from `@/utils/env` for environment checks — never use raw strings
 - Add dev-only warnings: `if (isDev) { console.warn("[ComponentName] message"); }` for accessibility, invalid props, wrong usage
 - See CONTRIBUTING.md for full details

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,11 +101,9 @@ Rules:
 - **Use `cn()`** for class merging (clsx + tailwind-merge)
 - **Use Material Symbols Rounded** for icons (`<span className="material-symbols-rounded">icon_name</span>`)
 - **Export the props interface** alongside the component
-- **Use `ENV` for environment checks** — never use raw `"production"` / `"development"` strings:
+- **Use `isDev` / `isProd`** from `@/utils/env` for environment checks — never use raw strings:
   ```tsx
-  import { ENV } from "@/utils/env";
-
-  const isDev = process.env.NODE_ENV === ENV.DEV;
+  import { isDev, isProd } from "@/utils/env";
   ```
 - **Add dev-only warnings** for common mistakes. Use `isDev` guard and prefix with `[ComponentName]`:
   ```tsx
@@ -122,7 +120,7 @@ Components should include dev-only warnings for:
 - **Wrong component usage** — e.g. icon-only `Button` should use `IconButton` instead
 - **Production guard** — components that should not render in production (e.g. DevToolbar):
   ```tsx
-  if (process.env.NODE_ENV === ENV.PROD) return null;
+  if (isProd) return null;
   ```
 
 ### 3. Write the story

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { cn } from "./utils/cn";
-export { ENV } from "./utils/env";
+export { isDev, isProd } from "./utils/env";
 export { Button, type ButtonProps } from "./components/ui/actions/button/Button";
 export {
   Progress,

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,4 +1,2 @@
-export const ENV = {
-  PROD: "production",
-  DEV: "development",
-} as const;
+export const isDev = process.env.NODE_ENV === "development";
+export const isProd = process.env.NODE_ENV === "production";


### PR DESCRIPTION
## Summary
- Remove `ENV` enum, replace with `isDev` and `isProd` constants
- Update CONTRIBUTING.md and CLAUDE.md docs
- Update issues #35, #36, #37

Before:
```ts
import { ENV } from "@/utils/env";
const isDev = process.env.NODE_ENV === ENV.DEV;
```

After:
```ts
import { isDev, isProd } from "@/utils/env";
```

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)