### PR TITLE
docs: update Slack link to invite URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ pnpm storybook
 
 Storybook opens at [http://localhost:6006](http://localhost:6006).
 
-Questions? Join us on [Slack](https://mirrorstackai.slack.com).
+Questions? Join us on [Slack](https://join.slack.com/t/mirrorstackai/shared_invite/zt-3twmj15cm-EPfQscE71I~JJj0yHK6EZg).
 
 ## Branch naming
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Shared React UI component library for [MirrorStack](https://mirrorstack.com).
 
 Built with React 19, TypeScript, Tailwind CSS v4, and Material Design 3.
 
-**[Storybook Demo](https://mirrorstack-ai.github.io/web-ui-kit/)** | **[Contributing](CONTRIBUTING.md)** | **[Good First Issues](https://github.com/mirrorstack-ai/web-ui-kit/issues?q=is%3Aopen+label%3A%22good+first+issue%22)** | **[Slack](https://mirrorstackai.slack.com)**
+**[Storybook Demo](https://mirrorstack-ai.github.io/web-ui-kit/)** | **[Contributing](CONTRIBUTING.md)** | **[Good First Issues](https://github.com/mirrorstack-ai/web-ui-kit/issues?q=is%3Aopen+label%3A%22good+first+issue%22)** | **[Slack](https://join.slack.com/t/mirrorstackai/shared_invite/zt-3twmj15cm-EPfQscE71I~JJj0yHK6EZg)**
 
 ## Getting started
 


### PR DESCRIPTION
## Summary
- Update Slack link from workspace URL to invite link in README.md and CONTRIBUTING.md
- New contributors can now join directly without needing an invite

🤖 Generated with [Claude Code](https://claude.com/claude-code)