### PR TITLE
fix: update issue template title prefixes to match convention

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report something that isn't working
-title: "[Bug] "
+title: "bug: "
 labels: ["bug"]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/component-port.yml
+++ b/.github/ISSUE_TEMPLATE/component-port.yml
@@ -1,6 +1,6 @@
 name: Component Port
 description: Port a component from reference/v2-restored
-title: "[Port] "
+title: "feat: port "
 labels: ["feature"]
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Suggest a new component or feature
-title: "[Feature] "
+title: "feat: "
 labels: ["feature"]
 body:
   - type: textarea


### PR DESCRIPTION
## Summary
- `bug-report.yml`: `[Bug] ` → `bug: `
- `feature-request.yml`: `[Feature] ` → `feat: `
- `component-port.yml`: `[Port] ` → `feat: port `

Closes #47

## Test plan
- [ ] Create a new issue using each template and verify the title prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)