### PR TITLE
chore: remove repo-level FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-ko_fi: i_am_nothing


### PR DESCRIPTION
Use org-wide FUNDING.yml from mirrorstack-ai/.github instead.