### PR TITLE
fix: use workflow_run for Storybook deploy (fork PR support)

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -1,0 +1,125 @@
+name: Storybook Deploy
+
+on:
+  workflow_run:
+    workflows: [Storybook]
+    types: [completed]
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy-main:
+    if: >
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+
+      - name: Download Storybook build
+        uses: actions/download-artifact@v4
+        with:
+          name: storybook-build
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: /tmp/storybook-static
+
+      - name: Deploy to GitHub Pages
+        run: |
+          find . -maxdepth 1 ! -name '.' ! -name '.git' ! -name 'pr' -exec rm -rf {} +
+          cp -r /tmp/storybook-static/* .
+          rm -f PR_NUMBER
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet || git commit -m "deploy: update Storybook from ${{ github.event.workflow_run.head_sha }}"
+          git push origin gh-pages
+
+  deploy-pr-preview:
+    if: >
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+
+      - name: Download Storybook build
+        uses: actions/download-artifact@v4
+        with:
+          name: storybook-build
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: /tmp/storybook-static
+
+      - name: Get PR number
+        id: pr
+        run: echo "number=$(cat /tmp/storybook-static/PR_NUMBER)" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy PR preview
+        run: |
+          rm -rf pr/${{ steps.pr.outputs.number }}
+          mkdir -p pr/${{ steps.pr.outputs.number }}
+          cp -r /tmp/storybook-static/* pr/${{ steps.pr.outputs.number }}/
+          rm -f pr/${{ steps.pr.outputs.number }}/PR_NUMBER
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet || git commit -m "deploy: PR #${{ steps.pr.outputs.number }} preview"
+          git push origin gh-pages
+
+      - name: Comment PR link
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const prNumber = parseInt('${{ steps.pr.outputs.number }}');
+            const url = `https://mirrorstack-ai.github.io/web-ui-kit/pr/${prNumber}/`;
+            const body = `**Storybook Preview:** ${url}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(c => c.body.includes('Storybook Preview:'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+  cleanup-pr:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+
+      - name: Remove PR preview
+        run: |
+          rm -rf pr/${{ github.event.pull_request.number }}
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git diff --cached --quiet || git commit -m "chore: clean up PR #${{ github.event.pull_request.number }} preview"
+          git push

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -4,13 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, closed]
-
-permissions:
-  contents: write
-  pull-requests: write
-  pages: write
-  id-token: write
+    types: [opened, synchronize, reopened]
 
 concurrency:
   group: storybook-${{ github.event.pull_request.number || 'main' }}
@@ -18,7 +12,6 @@ concurrency:
 
 jobs:
   build:
-    if: github.event.action != 'closed'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -36,98 +29,13 @@ jobs:
 
       - run: pnpm build-storybook
 
+      - name: Save PR number
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > storybook-static/PR_NUMBER
+
       - name: Upload Storybook build
         uses: actions/upload-artifact@v4
         with:
-          name: storybook-${{ github.event.pull_request.number || 'main' }}
+          name: storybook-build
           path: storybook-static/
           retention-days: 7
-
-      - name: Deploy to GitHub Pages (main)
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: |
-          cp -r storybook-static /tmp/storybook-static
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin gh-pages:gh-pages || git checkout --orphan gh-pages
-          git checkout gh-pages
-          find . -maxdepth 1 ! -name '.' ! -name '.git' ! -name 'pr' -exec rm -rf {} +
-          cp -r /tmp/storybook-static/* .
-          git add -A
-          git diff --cached --quiet || git commit -m "deploy: update Storybook from ${{ github.sha }}"
-          git push origin gh-pages
-
-  deploy-pr-preview:
-    if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: gh-pages
-
-      - name: Download Storybook build
-        uses: actions/download-artifact@v4
-        with:
-          name: storybook-${{ github.event.pull_request.number }}
-          path: /tmp/storybook-static
-
-      - name: Deploy PR preview
-        run: |
-          rm -rf pr/${{ github.event.pull_request.number }}
-          mkdir -p pr/${{ github.event.pull_request.number }}
-          cp -r /tmp/storybook-static/* pr/${{ github.event.pull_request.number }}/
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git diff --cached --quiet || git commit -m "deploy: PR #${{ github.event.pull_request.number }} preview"
-          git push origin gh-pages
-
-      - name: Comment PR link
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const prNumber = context.payload.pull_request.number;
-            const url = `https://mirrorstack-ai.github.io/web-ui-kit/pr/${prNumber}/`;
-            const body = `**Storybook Preview:** ${url}`;
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-            });
-            const existing = comments.find(c => c.body.includes('Storybook Preview:'));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body,
-              });
-            }
-
-  cleanup-pr:
-    if: github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: gh-pages
-
-      - name: Remove PR preview
-        run: |
-          rm -rf pr/${{ github.event.pull_request.number }}
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git diff --cached --quiet || git commit -m "chore: clean up PR #${{ github.event.pull_request.number }} preview"
-          git push


### PR DESCRIPTION
## Summary
Fork PRs always get read-only GITHUB_TOKEN — splitting jobs in the same workflow doesn't help.

Fix: use `workflow_run` trigger which runs in the **base repo's context** with full write permissions.

- `storybook.yml` — build only, uploads artifact (works for forks)
- `storybook-deploy.yml` — triggered by workflow_run, deploys artifact to gh-pages, posts comment

## Flow
```
Fork PR → Storybook (build + upload artifact)
       → Storybook Deploy (workflow_run, base repo context)
         → download artifact → deploy to gh-pages → comment link
```

## Test plan
- [ ] Fork PR gets Storybook preview link
- [ ] Internal PR gets Storybook preview link  
- [ ] Push to main deploys to gh-pages root
- [ ] Closed PR cleans up preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)