### PR TITLE
chore: upgrade artifact actions to Node.js 24

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -25,7 +25,7 @@ jobs:
           ref: gh-pages
 
       - name: Download Storybook build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: storybook-build
           run-id: ${{ github.event.workflow_run.id }}
@@ -55,7 +55,7 @@ jobs:
           ref: gh-pages
 
       - name: Download Storybook build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: storybook-build
           run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -34,7 +34,7 @@ jobs:
         run: echo "${{ github.event.pull_request.number }}" > storybook-static/PR_NUMBER
 
       - name: Upload Storybook build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: storybook-build
           path: storybook-static/


### PR DESCRIPTION
## Summary
- `actions/upload-artifact@v4` → `@v6`
- `actions/download-artifact@v4` → `@v7`

Resolves Node.js 20 deprecation warning. Actions will be forced to Node.js 24 by default on June 2, 2026.

## Test plan
- [ ] CI workflow passes (storybook build + upload artifact)
- [ ] Storybook deploy workflow can download artifacts from the new upload version

🤖 Generated with [Claude Code](https://claude.com/claude-code)