### PR TITLE
chore: force Node.js 24 for all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, reopened, closed]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   set-in-review:
     if: github.event.action != 'closed'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [closed]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [closed]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: storybook-${{ github.event.pull_request.number || 'main' }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env to all 5 workflow files
- Suppresses Node.js 20 deprecation warnings from transitive action dependencies (e.g. `pnpm/action-setup`, `create-github-app-token`)

Follows up on #62 which bumped artifact action versions.

## Test plan
- [ ] CI passes with no Node.js 20 deprecation warnings
- [ ] Storybook build + deploy still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)