### PR TITLE
revert: remove FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
     branches: [main]
   pull_request:
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     types: [opened, reopened, closed]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   set-in-review:
     if: github.event.action != 'closed'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     types: [closed]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   release:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
     types: [closed]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 concurrency:
   group: storybook-${{ github.event.pull_request.number || 'main' }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Remove `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` from all 5 workflows
- Deprecation warnings come from GitHub's built-in Pages deployment workflow, not ours

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)