### PR TITLE
feat: add SegmentedButton component

### DIFF
--- a/src/components/ui/inputs/segmented-button/SegmentedButton.stories.tsx
+++ b/src/components/ui/inputs/segmented-button/SegmentedButton.stories.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { SegmentedButton } from "./SegmentedButton";
+
+const sizeOptions = [
+  { value: "sm", label: "Small" },
+  { value: "md", label: "Medium" },
+  { value: "lg", label: "Large" },
+] as const;
+
+const meta: Meta<typeof SegmentedButton> = {
+  title: "UI/Inputs/SegmentedButton",
+  component: SegmentedButton,
+  args: {
+    options: sizeOptions,
+    value: "md",
+    "aria-label": "Select size",
+    disabled: false,
+  },
+  argTypes: {
+    value: {
+      control: "select",
+      options: ["sm", "md", "lg"],
+    },
+    disabled: { control: "boolean" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SegmentedButton>;
+
+/** Interactive playground — all controls work here */
+export const Playground: Story = {};
+
+/** Controlled example with live state */
+export const Controlled: Story = {
+  render: (args) => {
+    const [selected, setSelected] = useState(args.value ?? "md");
+
+    return (
+      <div className="flex flex-col gap-3">
+        <SegmentedButton
+          {...args}
+          value={selected}
+          onChange={setSelected}
+        />
+        <p className="text-sm text-on-surface-variant">
+          Selected: <strong>{selected}</strong>
+        </p>
+      </div>
+    );
+  },
+};
+
+/** Two options */
+export const TwoOptions: Story = {
+  args: {
+    options: [
+      { value: "list", label: "List" },
+      { value: "grid", label: "Grid" },
+    ],
+    value: "list",
+    "aria-label": "Select view",
+  },
+};
+
+/** Many options */
+export const ManyOptions: Story = {
+  args: {
+    options: [
+      { value: "day", label: "Day" },
+      { value: "week", label: "Week" },
+      { value: "month", label: "Month" },
+      { value: "quarter", label: "Quarter" },
+      { value: "year", label: "Year" },
+    ],
+    value: "month",
+    "aria-label": "Select time range",
+  },
+};
+
+/** Disabled state */
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};

--- a/src/components/ui/inputs/segmented-button/SegmentedButton.test.tsx
+++ b/src/components/ui/inputs/segmented-button/SegmentedButton.test.tsx
@@ -1,0 +1,115 @@
+import { render, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { SegmentedButton } from "./SegmentedButton";
+
+const options = [
+  { value: "a", label: "Option A" },
+  { value: "b", label: "Option B" },
+  { value: "c", label: "Option C" },
+] as const;
+
+function renderSegmented(props: Partial<Parameters<typeof SegmentedButton>[0]> = {}) {
+  return render(
+    <SegmentedButton
+      options={options}
+      value="a"
+      onChange={() => {}}
+      aria-label="Test group"
+      {...props}
+    />,
+  );
+}
+
+function getButtons(container: HTMLElement) {
+  return Array.from(container.querySelectorAll("button"));
+}
+
+describe("SegmentedButton", () => {
+  it("renders all options", () => {
+    const { container } = renderSegmented();
+    const buttons = getButtons(container);
+    expect(buttons).toHaveLength(3);
+    expect(buttons[0].textContent).toBe("Option A");
+    expect(buttons[1].textContent).toBe("Option B");
+    expect(buttons[2].textContent).toBe("Option C");
+  });
+
+  it("has group role with aria-label", () => {
+    const { container } = renderSegmented();
+    const group = container.querySelector("[role='group']");
+    expect(group).toBeInTheDocument();
+    expect(group?.getAttribute("aria-label")).toBe("Test group");
+  });
+
+  describe("selection", () => {
+    it("marks selected option with aria-pressed", () => {
+      const { container } = renderSegmented({ value: "b" });
+      const buttons = getButtons(container);
+      expect(buttons[0].getAttribute("aria-pressed")).toBe("false");
+      expect(buttons[1].getAttribute("aria-pressed")).toBe("true");
+      expect(buttons[2].getAttribute("aria-pressed")).toBe("false");
+    });
+
+    it("applies selected styles to active option", () => {
+      const { container } = renderSegmented({ value: "a" });
+      const buttons = getButtons(container);
+      expect(buttons[0].getAttribute("class")).toContain("bg-secondary-container");
+    });
+
+    it("applies unselected styles to inactive options", () => {
+      const { container } = renderSegmented({ value: "a" });
+      const buttons = getButtons(container);
+      expect(buttons[1].getAttribute("class")).toContain("bg-surface");
+    });
+  });
+
+  describe("onChange", () => {
+    it("calls onChange when clicking an unselected option", () => {
+      const handler = vi.fn();
+      const { container } = renderSegmented({ value: "a", onChange: handler });
+      const buttons = getButtons(container);
+      fireEvent.click(buttons[1]);
+      expect(handler).toHaveBeenCalledWith("b");
+    });
+
+    it("does not call onChange when clicking the selected option", () => {
+      const handler = vi.fn();
+      const { container } = renderSegmented({ value: "a", onChange: handler });
+      const buttons = getButtons(container);
+      fireEvent.click(buttons[0]);
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("disabled", () => {
+    it("disables all buttons when disabled", () => {
+      const { container } = renderSegmented({ disabled: true });
+      const buttons = getButtons(container);
+      for (const button of buttons) {
+        expect(button).toBeDisabled();
+      }
+    });
+
+    it("applies opacity when disabled", () => {
+      const { container } = renderSegmented({ disabled: true });
+      const group = container.querySelector("[role='group']");
+      expect(group?.getAttribute("class")).toContain("opacity-50");
+    });
+
+    it("does not call onChange when disabled", () => {
+      const handler = vi.fn();
+      const { container } = renderSegmented({ disabled: true, onChange: handler });
+      const buttons = getButtons(container);
+      fireEvent.click(buttons[1]);
+      expect(handler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("className", () => {
+    it("applies custom className to the container", () => {
+      const { container } = renderSegmented({ className: "custom-class" });
+      const group = container.querySelector("[role='group']");
+      expect(group?.getAttribute("class")).toContain("custom-class");
+    });
+  });
+});

--- a/src/components/ui/inputs/segmented-button/SegmentedButton.tsx
+++ b/src/components/ui/inputs/segmented-button/SegmentedButton.tsx
@@ -1,0 +1,81 @@
+import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "SegmentedButton",
+  description:
+    "Horizontal group of toggle buttons where exactly one option is selected at a time",
+};
+
+export interface SegmentedButtonOption<T extends string> {
+  readonly value: T;
+  readonly label: string;
+}
+
+export interface SegmentedButtonProps<T extends string> {
+  options: readonly SegmentedButtonOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  "aria-label": string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function SegmentedButton<T extends string>({
+  options,
+  value,
+  onChange,
+  "aria-label": ariaLabel,
+  disabled = false,
+  className,
+}: SegmentedButtonProps<T>) {
+  if (isDev) {
+    if (!ariaLabel) {
+      console.warn("[SegmentedButton] aria-label is required for accessibility");
+    }
+    if (options.length === 0) {
+      console.warn("[SegmentedButton] options array should not be empty");
+    }
+  }
+
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className={cn(
+        "inline-flex rounded-lg border border-outline-variant overflow-hidden",
+        disabled && "opacity-50 cursor-not-allowed",
+        className,
+      )}
+    >
+      {options.map((option, index) => {
+        const isSelected = option.value === value;
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-pressed={isSelected}
+            disabled={disabled}
+            onClick={() => {
+              if (!isSelected) {
+                onChange(option.value);
+              }
+            }}
+            className={cn(
+              "px-4 py-2 text-sm font-medium transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+              "disabled:cursor-not-allowed",
+              index > 0 && "border-l border-outline-variant",
+              isSelected
+                ? "bg-secondary-container text-on-secondary-container"
+                : "bg-surface text-on-surface hover:bg-surface-container-highest",
+            )}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,8 @@ export {
   type ProgressVariant,
   type ProgressSize,
 } from "./components/ui/feedback/progress/Progress";
+export {
+  SegmentedButton,
+  type SegmentedButtonProps,
+  type SegmentedButtonOption,
+} from "./components/ui/inputs/segmented-button/SegmentedButton";


### PR DESCRIPTION
## Summary
- Add `SegmentedButton` component — horizontal toggle button group with single selection
- Generic over `T extends string`, uses `aria-pressed` for accessibility
- Includes Playground story with Controlled, TwoOptions, ManyOptions, and Disabled showcase stories
- Full test coverage (11 tests): rendering, selection, onChange, disabled state, className

## Checklist
- [x] Component with `meta` export
- [x] Story with Playground (`UI/Inputs/SegmentedButton`)
- [x] Tests (11 passing)
- [x] Export from `index.ts`
- [x] Dev warnings with `[SegmentedButton]` prefix
- [x] No `"use client"`
- [x] `cn()` for class merging, `@/` path alias
- [x] TypeScript strict — typecheck passes
- [x] `pnpm components validate` passes

## Verification
Multi-agent review performed:
- **Code review**: Fixed conflicting ARIA pattern (removed `role="radio"` + `aria-checked`, kept `aria-pressed` per spec)
- **CONTRIBUTING.md compliance**: All 12 rules PASS
- **Security review**: No issues found

## Test plan
- [ ] Verify Storybook renders all stories correctly
- [ ] Test keyboard interaction (Tab between options)
- [ ] Verify disabled state prevents interaction
- [ ] Check dark mode styling

Closes #31