### PR TITLE
fix: repair Claude Code hooks schema and port to Node.js

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,7 +3,9 @@
     "PostToolUse": [
       {
         "matcher": "Write|Edit",
-        "hook": "scripts/hooks/check-file-length.sh"
+        "hooks": [
+          { "type": "command", "command": "node scripts/hooks/check-file-length.js" }
+        ]
       }
     ]
   }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/scripts/hooks/check-file-length.js
+++ b/scripts/hooks/check-file-length.js
@@ -1,0 +1,38 @@
+// Hook: block files over 250 lines (skip files with @generated marker)
+
+const fs = require("fs");
+const path = require("path");
+
+const MAX_LINES = 250;
+
+const toolInput = process.env.CLAUDE_TOOL_INPUT;
+if (!toolInput) process.exit(0);
+
+let filePath;
+try {
+  const parsed = JSON.parse(toolInput);
+  filePath = parsed.file_path || parsed.file;
+} catch {
+  process.exit(0);
+}
+
+if (!filePath || !fs.existsSync(filePath)) process.exit(0);
+
+const ext = path.extname(filePath);
+if (ext !== ".ts" && ext !== ".tsx") process.exit(0);
+
+const content = fs.readFileSync(filePath, "utf8");
+const lines = content.split("\n");
+
+// Skip files with @generated marker in first 5 lines
+const header = lines.slice(0, 5).join("\n");
+if (header.includes("@generated")) process.exit(0);
+
+if (lines.length > MAX_LINES) {
+  console.log(`BLOCKED: ${filePath} has ${lines.length} lines (max ${MAX_LINES}).`);
+  console.log("Run /simplify to break it into smaller modules.");
+  console.log("Or add '// @generated' in the first 5 lines to skip this check.");
+  process.exit(1);
+}
+
+process.exit(0);


### PR DESCRIPTION
## Summary
- Fix invalid `"hook"` (singular string) → `"hooks"` (array with `{ type, command }` objects) in `.claude/settings.json`
- Rewrite `check-file-length` as Node.js script for cross-platform portability (Windows compatibility)
- Add `.gitattributes` with `*.sh text eol=lf` to prevent CRLF shebang corruption

## Verification
- Tested hook script: correctly passes files under 250 lines, blocks files over 250 lines
- Multi-agent review: schema validated, CONTRIBUTING.md compliance confirmed, no security issues

## Test plan
- [ ] Open Claude Code — no settings.json validation warning
- [ ] Edit a `.tsx` file — hook fires and checks line count
- [ ] Create a 260-line `.ts` file — hook blocks with clear message
- [ ] Verify on Windows (if available) — Node.js script runs without bash dependency

Closes #46