### PR TITLE
feat: add DevToolbar component

### DIFF
--- a/src/components/ui/state/dev-toolbar/DevToolbar.stories.tsx
+++ b/src/components/ui/state/dev-toolbar/DevToolbar.stories.tsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { DevToolbar } from "./DevToolbar";
+
+const meta: Meta<typeof DevToolbar> = {
+  title: "UI/State/DevToolbar",
+  component: DevToolbar,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    items: [
+      { label: "State A", value: "a" },
+      { label: "State B", value: "b" },
+      { label: "State C", value: "c" },
+    ],
+    value: "a",
+    showError: false,
+  },
+  argTypes: {
+    value: {
+      control: "select",
+      options: ["a", "b", "c"],
+    },
+    showError: { control: "boolean" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DevToolbar>;
+
+/** Interactive playground — all controls work here */
+export const Playground: Story = {};
+
+/** Controlled example with live state */
+export const Controlled: Story = {
+  render: (args) => {
+    const [selected, setSelected] = useState(args.value ?? "a");
+    const [showError, setShowError] = useState(false);
+
+    return (
+      <div className="h-screen w-full bg-surface-container-lowest flex items-center justify-center font-sans text-on-surface">
+        <DevToolbar
+          {...args}
+          value={selected}
+          onChange={setSelected}
+          showError={showError}
+          onToggleError={() => setShowError((prev) => !prev)}
+        />
+        <div className="flex flex-col items-center gap-2 p-6 rounded-2xl bg-surface-container border border-outline-variant">
+          <h2 className="text-xl font-medium tracking-tight">
+            Main Content Area
+          </h2>
+          <p className="text-on-surface-variant">
+            Selected: <strong className="text-primary">{selected}</strong>
+          </p>
+          <p className="text-on-surface-variant">
+            Error:{" "}
+            <strong className={showError ? "text-error font-medium" : ""}>
+              {showError ? "Active" : "Inactive"}
+            </strong>
+          </p>
+        </div>
+      </div>
+    );
+  },
+};
+
+/** Without error toggle */
+export const WithoutErrorToggle: Story = {
+  args: {
+    onToggleError: undefined,
+    showError: undefined,
+  },
+};
+
+/** With error active */
+export const ErrorActive: Story = {
+  args: {
+    showError: true,
+  },
+};

--- a/src/components/ui/state/dev-toolbar/DevToolbar.test.tsx
+++ b/src/components/ui/state/dev-toolbar/DevToolbar.test.tsx
@@ -1,0 +1,94 @@
+import { render, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { DevToolbar } from "./DevToolbar";
+
+const items = [
+  { label: "State A", value: "a" },
+  { label: "State B", value: "b" },
+];
+
+function renderToolbar(
+  props: Partial<Parameters<typeof DevToolbar>[0]> = {},
+) {
+  return render(
+    <DevToolbar
+      items={items}
+      value="a"
+      onChange={() => {}}
+      {...props}
+    />,
+  );
+}
+
+function getButtons(container: HTMLElement) {
+  return Array.from(container.querySelectorAll("button"));
+}
+
+describe("DevToolbar", () => {
+  it("renders all item buttons", () => {
+    const { container } = renderToolbar();
+    const buttons = getButtons(container);
+    expect(buttons[0].textContent).toBe("State A");
+    expect(buttons[1].textContent).toBe("State B");
+  });
+
+  it("renders DEV label", () => {
+    const { container } = renderToolbar();
+    expect(container.textContent).toContain("DEV:");
+  });
+
+  it("highlights the selected item", () => {
+    const { container } = renderToolbar({ value: "a" });
+    const buttons = getButtons(container);
+    expect(buttons[0].getAttribute("class")).toContain("bg-primary");
+    expect(buttons[1].getAttribute("class")).toContain(
+      "bg-surface-container-low",
+    );
+  });
+
+  it("calls onChange when clicking an item", () => {
+    const handler = vi.fn();
+    const { container } = renderToolbar({ onChange: handler });
+    const buttons = getButtons(container);
+    fireEvent.click(buttons[1]);
+    expect(handler).toHaveBeenCalledWith("b");
+  });
+
+  it("renders error toggle when onToggleError is provided", () => {
+    const { container } = renderToolbar({
+      onToggleError: vi.fn(),
+      showError: false,
+    });
+    const buttons = getButtons(container);
+    const errorButton = buttons[buttons.length - 1];
+    expect(errorButton.textContent).toBe("Error OFF");
+  });
+
+  it("shows Error ON when showError is true", () => {
+    const { container } = renderToolbar({
+      onToggleError: vi.fn(),
+      showError: true,
+    });
+    const buttons = getButtons(container);
+    const errorButton = buttons[buttons.length - 1];
+    expect(errorButton.textContent).toBe("Error ON");
+    expect(errorButton.getAttribute("class")).toContain("bg-error");
+  });
+
+  it("calls onToggleError when error button is clicked", () => {
+    const handler = vi.fn();
+    const { container } = renderToolbar({
+      onToggleError: handler,
+      showError: false,
+    });
+    const buttons = getButtons(container);
+    fireEvent.click(buttons[buttons.length - 1]);
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it("does not render error button without onToggleError", () => {
+    const { container } = renderToolbar();
+    const buttons = getButtons(container);
+    expect(buttons).toHaveLength(2);
+  });
+});

--- a/src/components/ui/state/dev-toolbar/DevToolbar.tsx
+++ b/src/components/ui/state/dev-toolbar/DevToolbar.tsx
@@ -1,0 +1,75 @@
+import { cn } from "@/utils/cn";
+import { isDev, isProd, isStorybook } from "@/utils/env";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "DevToolbar",
+  description: "Fixed floating toolbar for switching between dev states/views",
+};
+
+export interface DevToolbarItem {
+  label: string;
+  value: string;
+}
+
+export interface DevToolbarProps {
+  items: DevToolbarItem[];
+  value: string;
+  onChange: (value: string) => void;
+  showError?: boolean;
+  onToggleError?: () => void;
+}
+
+export function DevToolbar({
+  items,
+  value,
+  onChange,
+  showError,
+  onToggleError,
+}: DevToolbarProps) {
+  if (isProd && !isStorybook) return null;
+
+  if (isDev && items.length === 0) {
+    console.warn("[DevToolbar] items array should not be empty");
+  }
+
+  return (
+    <div className="fixed top-4 left-1/2 -translate-x-1/2 z-50 flex bg-surface-container border border-outline-variant rounded-2xl px-4 py-2 shadow-xl">
+      <div className="flex items-center gap-2 whitespace-nowrap">
+        <span className="text-xs font-mono text-on-surface-variant shrink-0">
+          DEV:
+        </span>
+        {items.map((item) => (
+          <button
+            key={item.value}
+            onClick={() => onChange(item.value)}
+            className={cn(
+              "px-2 py-1 text-xs rounded shrink-0 transition-colors cursor-pointer",
+              value === item.value
+                ? "bg-primary text-on-primary"
+                : "bg-surface-container-low text-on-surface-variant hover:bg-surface-container",
+            )}
+          >
+            {item.label}
+          </button>
+        ))}
+        {onToggleError && (
+          <>
+            <span className="w-px h-4 bg-outline-variant shrink-0" />
+            <button
+              onClick={onToggleError}
+              className={cn(
+                "px-2 py-1 text-xs rounded shrink-0 transition-colors cursor-pointer",
+                showError
+                  ? "bg-error text-on-error"
+                  : "bg-surface-container-low text-on-surface-variant hover:bg-surface-container",
+              )}
+            >
+              {showError ? "Error ON" : "Error OFF"}
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,8 @@ export {
   type ProgressVariant,
   type ProgressSize,
 } from "./components/ui/feedback/progress/Progress";
+export {
+  DevToolbar,
+  type DevToolbarProps,
+  type DevToolbarItem,
+} from "./components/ui/state/dev-toolbar/DevToolbar";


### PR DESCRIPTION
## Summary
- Port `DevToolbar` from `reference/v2-restored` with all CONTRIBUTING.md rules applied
- Fixed floating toolbar for switching between dev states/views, with optional error toggle
- Addresses all review feedback from PR #45

## Fixes applied (vs PR #45)
| Issue | PR #45 | This PR |
|-------|--------|---------|
| `"use client"` | Present | **Removed** |
| `meta` type | Untyped object | **`meta: ComponentMeta`** |
| Error button width | `px-3 h-8` (different from items) | **`px-2 py-1`** (matches reference) |
| Production guard | `if (isProd) return null` | **`if (isProd && !isStorybook) return null`** |
| `env.ts` modified | Added `ENV` object, removed `isStorybook` | **No changes to env.ts** |
| Test uses `declare const process` | Yes | **Removed, no raw process.env** |
| Story title | `Ui/State/DevToolbar` | **`UI/State/DevToolbar`** |
| `temp_ref_dev_toolbar.tsx` | Committed | **Not included** |
| Dev warning | Fires every render | **Only warns on empty items** |

## Verification
Multi-agent review (code review + CONTRIBUTING.md compliance): **All checks PASS**
- 8 tests passing
- Typecheck clean
- `pnpm components validate` passes

## Test plan
- [ ] Verify Storybook renders all stories (Playground, Controlled, WithoutErrorToggle, ErrorActive)
- [ ] Verify toolbar is hidden in production build
- [ ] Verify toolbar is visible in Storybook (isStorybook guard)
- [ ] Verify error button width matches item buttons
- [ ] Check dark mode styling

Closes #35
Supersedes #45