### PR TITLE
fix: skip project-sync for fork PRs

### DIFF
--- a/.github/workflows/project-sync.yml
+++ b/.github/workflows/project-sync.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   set-in-review:
-    if: github.event.action != 'closed'
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Generate bot token
@@ -129,7 +129,7 @@ jobs:
             }
 
   set-target-date:
-    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Generate bot token


### PR DESCRIPTION
## Summary
- Skip `set-in-review` and `set-target-date` jobs when PR is from a fork
- Fork PRs can't access repo secrets, causing `create-github-app-token` to fail with `appId option is required`

## Test plan
- [ ] Fork PRs no longer fail on project-sync workflow
- [ ] Same-repo PRs still sync project status correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)