### PR TITLE
feat: add Alert component

### DIFF
--- a/src/components/ui/feedback/alert/Alert.stories.tsx
+++ b/src/components/ui/feedback/alert/Alert.stories.tsx
@@ -1,0 +1,89 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Alert } from "./Alert";
+
+const meta: Meta<typeof Alert> = {
+  title: "UI/Feedback/Alert",
+  component: Alert,
+  args: {
+    variant: "info",
+    title: "Heads up",
+    children: "This is an informational alert with some helpful details.",
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["error", "success", "warning", "info"],
+    },
+    title: { control: "text" },
+    children: { control: "text" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Alert>;
+
+/** Interactive playground — all controls work here */
+export const Playground: Story = {};
+
+/** All four variants */
+export const Variants: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-3">
+      <Alert {...args} variant="info" title="Info">
+        This is an informational message.
+      </Alert>
+      <Alert {...args} variant="success" title="Success">
+        Your changes have been saved successfully.
+      </Alert>
+      <Alert {...args} variant="warning" title="Warning">
+        Please review before proceeding.
+      </Alert>
+      <Alert {...args} variant="error" title="Error">
+        Something went wrong. Please try again.
+      </Alert>
+    </div>
+  ),
+};
+
+/** Dismissible alert with controlled visibility */
+export const Dismissible: Story = {
+  render: (args) => {
+    const [visible, setVisible] = useState(true);
+
+    return (
+      <div className="flex flex-col gap-3">
+        {visible ? (
+          <Alert
+            {...args}
+            variant="warning"
+            title="Dismissible alert"
+            onDismiss={() => setVisible(false)}
+          >
+            Click the close button to dismiss this alert.
+          </Alert>
+        ) : (
+          <p className="text-sm text-on-surface-variant">
+            Alert dismissed.{" "}
+            <button
+              type="button"
+              onClick={() => setVisible(true)}
+              className="underline cursor-pointer text-primary"
+            >
+              Show again
+            </button>
+          </p>
+        )}
+      </div>
+    );
+  },
+};
+
+/** Without title — body only */
+export const WithoutTitle: Story = {
+  args: {
+    variant: "success",
+    title: undefined,
+    children: "Operation completed without a title heading.",
+  },
+};

--- a/src/components/ui/feedback/alert/Alert.test.tsx
+++ b/src/components/ui/feedback/alert/Alert.test.tsx
@@ -1,0 +1,120 @@
+import { render, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { Alert } from "./Alert";
+
+function renderAlert(props: Partial<Parameters<typeof Alert>[0]> = {}) {
+  return render(
+    <Alert variant="info" {...props}>
+      {props.children ?? "Test body"}
+    </Alert>,
+  );
+}
+
+function getAlert(container: HTMLElement) {
+  return container.querySelector("[role='alert']") as HTMLElement;
+}
+
+describe("Alert", () => {
+  it("renders with role alert", () => {
+    const { container } = renderAlert();
+    expect(getAlert(container)).toBeInTheDocument();
+  });
+
+  it("renders children as body content", () => {
+    const { container } = renderAlert({ children: "Alert body text" });
+    expect(container.textContent).toContain("Alert body text");
+  });
+
+  it("renders title when provided", () => {
+    const { container } = renderAlert({ title: "Alert Title" });
+    const heading = container.querySelector("h3");
+    expect(heading).toBeInTheDocument();
+    expect(heading?.textContent).toBe("Alert Title");
+  });
+
+  it("does not render title when not provided", () => {
+    const { container } = renderAlert();
+    const heading = container.querySelector("h3");
+    expect(heading).not.toBeInTheDocument();
+  });
+
+  describe("variants", () => {
+    it("applies error styles", () => {
+      const { container } = renderAlert({ variant: "error" });
+      expect(getAlert(container).getAttribute("class")).toContain("bg-error/10");
+    });
+
+    it("applies success styles", () => {
+      const { container } = renderAlert({ variant: "success" });
+      expect(getAlert(container).getAttribute("class")).toContain(
+        "bg-success/10",
+      );
+    });
+
+    it("applies warning styles", () => {
+      const { container } = renderAlert({ variant: "warning" });
+      expect(getAlert(container).getAttribute("class")).toContain(
+        "bg-warning/10",
+      );
+    });
+
+    it("applies info styles", () => {
+      const { container } = renderAlert({ variant: "info" });
+      expect(getAlert(container).getAttribute("class")).toContain("bg-info/10");
+    });
+
+    it("renders correct icon for each variant", () => {
+      const icons: Record<string, string> = {
+        error: "error",
+        success: "check_circle",
+        warning: "warning",
+        info: "info",
+      };
+
+      for (const [variant, icon] of Object.entries(icons)) {
+        const { container } = renderAlert({
+          variant: variant as "error" | "success" | "warning" | "info",
+        });
+        const iconEl = container.querySelector(".material-symbols-rounded");
+        expect(iconEl?.textContent?.trim()).toBe(icon);
+      }
+    });
+  });
+
+  describe("dismiss", () => {
+    it("shows dismiss button when onDismiss is provided", () => {
+      const { container } = renderAlert({ onDismiss: () => {} });
+      const dismissBtn = container.querySelector(
+        "button[aria-label='Dismiss']",
+      );
+      expect(dismissBtn).toBeInTheDocument();
+    });
+
+    it("does not show dismiss button when onDismiss is not provided", () => {
+      const { container } = renderAlert();
+      const dismissBtn = container.querySelector(
+        "button[aria-label='Dismiss']",
+      );
+      expect(dismissBtn).not.toBeInTheDocument();
+    });
+
+    it("calls onDismiss when dismiss button is clicked", () => {
+      const handler = vi.fn();
+      const { container } = renderAlert({ onDismiss: handler });
+      const dismissBtn = container.querySelector(
+        "button[aria-label='Dismiss']",
+      ) as HTMLButtonElement;
+      fireEvent.click(dismissBtn);
+      expect(handler).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("className", () => {
+    it("applies custom className", () => {
+      const { container } = renderAlert({ className: "custom-class" });
+      expect(getAlert(container).getAttribute("class")).toContain(
+        "custom-class",
+      );
+    });
+  });
+});

--- a/src/components/ui/feedback/alert/Alert.tsx
+++ b/src/components/ui/feedback/alert/Alert.tsx
@@ -1,0 +1,93 @@
+import { type ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "Alert",
+  description:
+    "Dismissible inline alert banner with error/success/warning/info variants, icon, optional title, and body content",
+};
+
+export type AlertVariant = "error" | "success" | "warning" | "info";
+
+export interface AlertProps {
+  readonly variant: AlertVariant;
+  readonly title?: string;
+  readonly children: ReactNode;
+  readonly className?: string;
+  readonly onDismiss?: () => void;
+}
+
+const variantStyles: Record<AlertVariant, string> = {
+  error: "bg-error/10 border-error/30 text-error",
+  success: "bg-success/10 border-success/30 text-success",
+  warning: "bg-warning/10 border-warning/30 text-warning",
+  info: "bg-info/10 border-info/30 text-info",
+};
+
+const variantIcons: Record<AlertVariant, string> = {
+  error: "error",
+  success: "check_circle",
+  warning: "warning",
+  info: "info",
+};
+
+export function Alert({
+  variant,
+  title,
+  children,
+  className,
+  onDismiss,
+}: AlertProps) {
+  if (isDev) {
+    if (!children) {
+      console.warn("[Alert] children (body content) should not be empty");
+    }
+  }
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "rounded-xl border px-4 py-3",
+        variantStyles[variant],
+        className,
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <span
+          className="material-symbols-rounded shrink-0"
+          aria-hidden="true"
+          style={{ fontSize: 20 }}
+        >
+          {variantIcons[variant]}
+        </span>
+        <div className="flex-1 min-w-0">
+          {title && <h3 className="text-sm font-medium">{title}</h3>}
+          <div className={cn("text-sm", title && "mt-1")}>{children}</div>
+        </div>
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            aria-label="Dismiss"
+            className={cn(
+              "shrink-0 -my-1 rounded-full p-1 transition-opacity",
+              "text-current opacity-70 hover:opacity-100",
+              "cursor-pointer",
+            )}
+          >
+            <span
+              className="material-symbols-rounded"
+              aria-hidden="true"
+              style={{ fontSize: 18 }}
+            >
+              close
+            </span>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,11 @@ export {
   type SegmentedButtonOption,
 } from "./components/ui/inputs/segmented-button/SegmentedButton";
 export {
+  Alert,
+  type AlertProps,
+  type AlertVariant,
+} from "./components/ui/feedback/alert/Alert";
+export {
   DevToolbar,
   type DevToolbarProps,
   type DevToolbarItem,


### PR DESCRIPTION
## Summary
- Add `Alert` component with `error`/`success`/`warning`/`info` variants
- Dismissible via `onDismiss` callback with close button
- Accessible `role="alert"` with `aria-hidden` decorative icons
- Material Symbol icons per variant (error, check_circle, warning, info)
- Optional `title` heading with body content via `children`
- Dev-only warning for empty children

Closes #14

## Verification

### Tests (72 pass, 13 new)
```
 ✓ src/components/ui/feedback/alert/Alert.test.tsx (13 tests) 65ms
 ✓ src/components/ui/inputs/segmented-button/SegmentedButton.test.tsx (10 tests)
 ✓ src/components/ui/feedback/progress/Progress.test.tsx (20 tests)
 ✓ src/components/ui/actions/button/Button.test.tsx (24 tests)
 ✓ src/components/ui/state/dev-toolbar/DevToolbar.test.tsx (5 tests)

 Test Files  5 passed (5)
      Tests  72 passed (72)
```

### Typecheck
```
tsc --noEmit  (clean)
```

### Component validation
```
PASS  src/components/ui/actions/button/Button.tsx
PASS  src/components/ui/feedback/alert/Alert.tsx
PASS  src/components/ui/feedback/progress/Progress.tsx
PASS  src/components/ui/inputs/segmented-button/SegmentedButton.tsx
PASS  src/components/ui/state/dev-toolbar/DevToolbar.tsx

All 5 component(s) have valid metadata.
```

### CONTRIBUTING.md compliance (12/12 PASS)
- Folder: `ui/feedback/alert/` ✓
- Files: `.tsx`, `.stories.tsx`, `.test.tsx` ✓
- `meta` export with `ComponentMeta` ✓
- No `"use client"` ✓
- `@/` path alias ✓
- `cn()` for class merging ✓
- `isDev` from `@/utils/env` ✓
- Dev warning with `[Alert]` prefix ✓
- Story title `UI/Feedback/Alert` ✓
- Playground story ✓
- Exported from `index.ts` with types ✓
- Props interface exported ✓

## Test plan
- [ ] Verify Storybook renders Alert correctly
- [ ] Test all 4 variant colors and icons in Variants story
- [ ] Verify dismiss button shows/hides alert in Dismissible story
- [ ] Confirm WithoutTitle story renders body-only layout
- [ ] Check keyboard accessibility on dismiss button