### PR TITLE
feat: add ActivityList component

### DIFF
--- a/src/components/ui/data/activity-list/ActivityList.stories.tsx
+++ b/src/components/ui/data/activity-list/ActivityList.stories.tsx
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ActivityList, type ActivityItem } from "./ActivityList";
+
+const sampleItems: ActivityItem[] = [
+  {
+    id: "1",
+    icon: "edit",
+    label: "Updated project settings",
+    timestamp: "2 min ago",
+  },
+  {
+    id: "2",
+    icon: "person_add",
+    label: "Invited a new team member",
+    timestamp: "15 min ago",
+  },
+  {
+    id: "3",
+    icon: "upload_file",
+    label: "Uploaded design assets",
+    timestamp: "1 hour ago",
+  },
+  {
+    id: "4",
+    icon: "deployed_code",
+    label: "Deployed to production",
+    timestamp: "3 hours ago",
+  },
+  {
+    id: "5",
+    icon: "bug_report",
+    label: "Resolved critical bug",
+    timestamp: "Yesterday",
+  },
+];
+
+const meta: Meta<typeof ActivityList> = {
+  title: "UI/Data/ActivityList",
+  component: ActivityList,
+  args: {
+    items: sampleItems,
+    loading: false,
+    hasMore: false,
+    loadingMore: false,
+    emptyMessage: "No activity recorded yet.",
+  },
+  argTypes: {
+    loading: { control: "boolean" },
+    hasMore: { control: "boolean" },
+    loadingMore: { control: "boolean" },
+    emptyMessage: { control: "text" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ActivityList>;
+
+/** Interactive playground — all controls work here */
+export const Playground: Story = {};
+
+/** Loading state with spinner */
+export const Loading: Story = {
+  args: {
+    loading: true,
+    items: [],
+  },
+};
+
+/** Empty state with custom message */
+export const Empty: Story = {
+  args: {
+    items: [],
+    emptyMessage: "No activity recorded yet.",
+  },
+};
+
+/** List with load-more button */
+export const WithLoadMore: Story = {
+  render: (args) => {
+    const [items, setItems] = useState<ActivityItem[]>(sampleItems.slice(0, 3));
+    const [loadingMore, setLoadingMore] = useState(false);
+
+    const handleLoadMore = () => {
+      setLoadingMore(true);
+      setTimeout(() => {
+        setItems((prev) => [...prev, ...sampleItems.slice(prev.length)]);
+        setLoadingMore(false);
+      }, 1000);
+    };
+
+    return (
+      <ActivityList
+        {...args}
+        items={items}
+        hasMore={items.length < sampleItems.length}
+        loadingMore={loadingMore}
+        onLoadMore={handleLoadMore}
+      />
+    );
+  },
+};

--- a/src/components/ui/data/activity-list/ActivityList.test.tsx
+++ b/src/components/ui/data/activity-list/ActivityList.test.tsx
@@ -1,0 +1,135 @@
+import { render, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { ActivityList, type ActivityItem } from "./ActivityList";
+
+const items: ActivityItem[] = [
+  { id: "1", icon: "edit", label: "Edited file", timestamp: "2 min ago" },
+  { id: "2", icon: "upload", label: "Uploaded image", timestamp: "5 min ago" },
+  { id: "3", icon: "delete", label: "Deleted item", timestamp: "1 hour ago" },
+];
+
+function renderList(
+  props: Partial<Parameters<typeof ActivityList>[0]> = {},
+) {
+  return render(<ActivityList items={items} {...props} />);
+}
+
+describe("ActivityList", () => {
+  it("renders all items", () => {
+    const { container } = renderList();
+    expect(container.textContent).toContain("Edited file");
+    expect(container.textContent).toContain("Uploaded image");
+    expect(container.textContent).toContain("Deleted item");
+  });
+
+  it("renders icon, label, and timestamp for each item", () => {
+    const { container } = renderList();
+    const rows = container.querySelectorAll(".bg-surface-container");
+    expect(rows).toHaveLength(3);
+
+    const firstRow = rows[0];
+    expect(firstRow.textContent).toContain("edit");
+    expect(firstRow.textContent).toContain("Edited file");
+    expect(firstRow.textContent).toContain("2 min ago");
+  });
+
+  it("marks icons as aria-hidden", () => {
+    const { container } = renderList();
+    const icons = container.querySelectorAll("[aria-hidden='true']");
+    expect(icons).toHaveLength(3);
+  });
+
+  describe("loading", () => {
+    it("shows spinner when loading", () => {
+      const { container } = renderList({ loading: true });
+      expect(container.querySelector("[role='progressbar']")).toBeInTheDocument();
+    });
+
+    it("does not render items when loading", () => {
+      const { container } = renderList({ loading: true });
+      expect(container.textContent).not.toContain("Edited file");
+    });
+  });
+
+  describe("empty", () => {
+    it("shows default empty message when no items", () => {
+      const { container } = renderList({ items: [] });
+      expect(container.textContent).toContain("No activity recorded yet.");
+    });
+
+    it("shows custom empty message", () => {
+      const { container } = renderList({
+        items: [],
+        emptyMessage: "Nothing here",
+      });
+      expect(container.textContent).toContain("Nothing here");
+    });
+  });
+
+  describe("load more", () => {
+    it("shows load-more button when hasMore and onLoadMore", () => {
+      const { container } = renderList({
+        hasMore: true,
+        onLoadMore: () => {},
+      });
+      const btn = container.querySelector("button");
+      expect(btn).toBeInTheDocument();
+      expect(btn?.textContent).toContain("Load more");
+    });
+
+    it("does not show load-more button when hasMore is false", () => {
+      const { container } = renderList({
+        hasMore: false,
+        onLoadMore: () => {},
+      });
+      const btn = container.querySelector("button");
+      expect(btn).not.toBeInTheDocument();
+    });
+
+    it("does not show load-more button when onLoadMore is not provided", () => {
+      const { container } = renderList({ hasMore: true });
+      const btn = container.querySelector("button");
+      expect(btn).not.toBeInTheDocument();
+    });
+
+    it("calls onLoadMore when button is clicked", () => {
+      const handler = vi.fn();
+      const { container } = renderList({
+        hasMore: true,
+        onLoadMore: handler,
+      });
+      const btn = container.querySelector("button") as HTMLButtonElement;
+      fireEvent.click(btn);
+      expect(handler).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("className", () => {
+    it("applies className to loading state", () => {
+      const { container } = renderList({
+        loading: true,
+        className: "custom-class",
+      });
+      expect(
+        container.firstElementChild?.getAttribute("class"),
+      ).toContain("custom-class");
+    });
+
+    it("applies className to empty state", () => {
+      const { container } = renderList({
+        items: [],
+        className: "custom-class",
+      });
+      expect(
+        container.firstElementChild?.getAttribute("class"),
+      ).toContain("custom-class");
+    });
+
+    it("applies className to list container", () => {
+      const { container } = renderList({ className: "custom-class" });
+      expect(
+        container.firstElementChild?.getAttribute("class"),
+      ).toContain("custom-class");
+    });
+  });
+});

--- a/src/components/ui/data/activity-list/ActivityList.tsx
+++ b/src/components/ui/data/activity-list/ActivityList.tsx
@@ -1,0 +1,102 @@
+import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
+import type { ComponentMeta } from "@/types/component-meta";
+import { Button } from "@/components/ui/actions/button/Button";
+import { Progress } from "@/components/ui/feedback/progress/Progress";
+
+export const meta: ComponentMeta = {
+  name: "ActivityList",
+  description:
+    "Vertical list of activity/event items with loading, empty, and load-more states",
+};
+
+export interface ActivityItem {
+  readonly id: string;
+  readonly icon: string;
+  readonly label: string;
+  readonly timestamp: string;
+}
+
+export interface ActivityListProps {
+  readonly items: readonly ActivityItem[];
+  readonly loading?: boolean;
+  readonly hasMore?: boolean;
+  readonly loadingMore?: boolean;
+  readonly onLoadMore?: () => void;
+  readonly emptyMessage?: string;
+  readonly className?: string;
+}
+
+export function ActivityList({
+  items,
+  loading = false,
+  hasMore = false,
+  loadingMore = false,
+  onLoadMore,
+  emptyMessage = "No activity recorded yet.",
+  className,
+}: ActivityListProps) {
+  if (isDev) {
+    if (hasMore && !onLoadMore) {
+      console.warn(
+        "[ActivityList] hasMore is true but onLoadMore is not provided",
+      );
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className={cn("py-8 text-center", className)}>
+        <Progress type="circular" size="lg" />
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <p
+        className={cn(
+          "text-sm text-on-surface-variant text-center py-8",
+          className,
+        )}
+      >
+        {emptyMessage}
+      </p>
+    );
+  }
+
+  return (
+    <div className={className}>
+      <div className="space-y-1">
+        {items.map((item) => (
+          <div
+            key={item.id}
+            className="flex items-center gap-3 px-3 py-2 rounded-lg bg-surface-container"
+          >
+            <span
+              className="material-symbols-rounded text-on-surface-variant shrink-0"
+              aria-hidden="true"
+              style={{ fontSize: 18 }}
+            >
+              {item.icon}
+            </span>
+            <span className="text-sm font-medium text-on-surface">
+              {item.label}
+            </span>
+            <span className="text-xs text-on-surface-variant ml-auto shrink-0">
+              {item.timestamp}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {hasMore && onLoadMore && (
+        <div className="mt-3 text-center">
+          <Button variant="text" onClick={onLoadMore} loading={loadingMore}>
+            Load more
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,11 @@ export {
   type SegmentedButtonOption,
 } from "./components/ui/inputs/segmented-button/SegmentedButton";
 export {
+  ActivityList,
+  type ActivityListProps,
+  type ActivityItem,
+} from "./components/ui/data/activity-list/ActivityList";
+export {
   DevToolbar,
   type DevToolbarProps,
   type DevToolbarItem,


### PR DESCRIPTION
## Summary
- Add `ActivityList` component with `ActivityItem[]` data display
- Loading state with `Progress` spinner, empty state with custom message
- "Load more" button using `Button` component (only when `hasMore` && `onLoadMore`)
- Dev-only warning when `hasMore` is true but `onLoadMore` is missing
- `aria-hidden` on decorative Material Symbol icons

Closes #33

## Verification

### Tests (73 pass, 14 new)
```
 ✓ src/components/ui/data/activity-list/ActivityList.test.tsx (14 tests) 33ms
 ✓ src/components/ui/inputs/segmented-button/SegmentedButton.test.tsx (10 tests)
 ✓ src/components/ui/actions/button/Button.test.tsx (24 tests)
 ✓ src/components/ui/feedback/progress/Progress.test.tsx (20 tests)
 ✓ src/components/ui/state/dev-toolbar/DevToolbar.test.tsx (5 tests)

 Test Files  5 passed (5)
      Tests  73 passed (73)
```

### Typecheck
```
tsc --noEmit  (clean)
```

### Component validation
```
PASS  src/components/ui/actions/button/Button.tsx
PASS  src/components/ui/data/activity-list/ActivityList.tsx
PASS  src/components/ui/feedback/progress/Progress.tsx
PASS  src/components/ui/inputs/segmented-button/SegmentedButton.tsx
PASS  src/components/ui/state/dev-toolbar/DevToolbar.tsx

All 5 component(s) have valid metadata.
```

### CONTRIBUTING.md compliance (12/12 PASS)
- Folder: `ui/data/activity-list/` ✓
- Files: `.tsx`, `.stories.tsx`, `.test.tsx` ✓
- `meta` export with `ComponentMeta` ✓
- No `"use client"` ✓
- `@/` path alias ✓
- `cn()` for class merging ✓
- `isDev` from `@/utils/env` ✓
- Dev warning with `[ActivityList]` prefix ✓
- Story title `UI/Data/ActivityList` ✓
- Playground story ✓
- Exported from `index.ts` with types ✓
- Props interface exported ✓

## Test plan
- [x] Verify Storybook renders ActivityList with sample items
- [ ] Test Loading story shows spinner
- [ ] Test Empty story shows empty message
- [ ] Test WithLoadMore story loads additional items on click
- [ ] Verify load-more button disappears when all items loaded