### PR TITLE
feat: add ReauthDialog component

### DIFF
--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.stories.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.stories.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ReauthDialog } from "./ReauthDialog";
+import { Button } from "@/components/ui/actions/button/Button";
+
+const meta: Meta<typeof ReauthDialog> = {
+  title: "UI/Surfaces/ReauthDialog",
+  component: ReauthDialog,
+  args: {
+    open: true,
+    title: "Verify your identity",
+    description:
+      "For your security, please verify your identity before continuing.",
+    methods: ["passkey", "password"],
+  },
+  argTypes: {
+    open: { control: "boolean" },
+    title: { control: "text" },
+    description: { control: "text" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ReauthDialog>;
+
+/** Interactive playground — all controls work here */
+export const Playground: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(args.open ?? true);
+
+    return (
+      <div>
+        <Button onClick={() => setOpen(true)}>Open ReauthDialog</Button>
+        <ReauthDialog
+          {...args}
+          open={open}
+          onClose={() => setOpen(false)}
+          onSuccess={(token) => {
+            setOpen(false);
+            alert(`Verified! Token: ${token}`);
+          }}
+          onPasskeyVerify={async () => {
+            await new Promise((r) => setTimeout(r, 1500));
+            return "passkey-token-abc123";
+          }}
+          onPasswordVerify={async (password) => {
+            await new Promise((r) => setTimeout(r, 1000));
+            if (password !== "password") {
+              throw new Error("Incorrect password");
+            }
+            return "password-token-xyz789";
+          }}
+        />
+      </div>
+    );
+  },
+};
+
+/** Password-only mode */
+export const PasswordOnly: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(true);
+
+    return (
+      <div>
+        <Button onClick={() => setOpen(true)}>Open Password Dialog</Button>
+        <ReauthDialog
+          {...args}
+          open={open}
+          methods={["password"]}
+          onClose={() => setOpen(false)}
+          onSuccess={(token) => {
+            setOpen(false);
+            alert(`Verified! Token: ${token}`);
+          }}
+          onPasswordVerify={async (password) => {
+            await new Promise((r) => setTimeout(r, 1000));
+            if (password !== "password") {
+              throw new Error("Incorrect password");
+            }
+            return "password-token-xyz789";
+          }}
+        />
+      </div>
+    );
+  },
+};
+
+/** Passkey-only mode */
+export const PasskeyOnly: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(true);
+
+    return (
+      <div>
+        <Button onClick={() => setOpen(true)}>Open Passkey Dialog</Button>
+        <ReauthDialog
+          {...args}
+          open={open}
+          methods={["passkey"]}
+          onClose={() => setOpen(false)}
+          onSuccess={(token) => {
+            setOpen(false);
+            alert(`Verified! Token: ${token}`);
+          }}
+          onPasskeyVerify={async () => {
+            await new Promise((r) => setTimeout(r, 1500));
+            return "passkey-token-abc123";
+          }}
+        />
+      </div>
+    );
+  },
+};

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.test.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.test.tsx
@@ -1,0 +1,299 @@
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { ReauthDialog } from "./ReauthDialog";
+
+function renderDialog(
+  props: Partial<Parameters<typeof ReauthDialog>[0]> = {},
+) {
+  return render(
+    <ReauthDialog
+      open={true}
+      onClose={() => {}}
+      onSuccess={() => {}}
+      {...props}
+    />,
+  );
+}
+
+function getDialog(container: HTMLElement) {
+  return container.querySelector("[role='dialog']") as HTMLElement;
+}
+
+describe("ReauthDialog", () => {
+  it("renders nothing when closed", () => {
+    const { container } = renderDialog({ open: false });
+    expect(getDialog(container)).not.toBeInTheDocument();
+  });
+
+  it("renders dialog when open", () => {
+    const { container } = renderDialog();
+    expect(getDialog(container)).toBeInTheDocument();
+  });
+
+  it("renders with aria-modal and role dialog", () => {
+    const { container } = renderDialog();
+    const dialog = getDialog(container);
+    expect(dialog.getAttribute("role")).toBe("dialog");
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+  });
+
+  it("renders title and description", () => {
+    const { container } = renderDialog({
+      title: "Custom Title",
+      description: "Custom description text",
+    });
+    expect(container.textContent).toContain("Custom Title");
+    expect(container.textContent).toContain("Custom description text");
+  });
+
+  it("uses default title and description", () => {
+    const { container } = renderDialog();
+    expect(container.textContent).toContain("Verify your identity");
+    expect(container.textContent).toContain("For your security");
+  });
+
+  describe("passkey view", () => {
+    it("shows passkey view by default", () => {
+      const { container } = renderDialog({
+        methods: ["passkey", "password"],
+      });
+      expect(container.textContent).toContain("Verify with passkey");
+    });
+
+    it("shows passkey icon", () => {
+      const { container } = renderDialog({
+        methods: ["passkey", "password"],
+      });
+      const icon = container.querySelector(
+        ".material-symbols-rounded[aria-hidden='true']",
+      );
+      expect(icon?.textContent?.trim()).toBe("passkey");
+    });
+
+    it("shows 'Use password instead' link when both methods available", () => {
+      const { container } = renderDialog({
+        methods: ["passkey", "password"],
+      });
+      expect(container.textContent).toContain("Use password instead");
+    });
+
+    it("does not show password link when passkey-only", () => {
+      const { container } = renderDialog({
+        methods: ["passkey"],
+      });
+      expect(container.textContent).not.toContain("Use password instead");
+    });
+
+    it("calls onPasskeyVerify when button is clicked", () => {
+      const handler = vi.fn().mockResolvedValue("token");
+      const { container } = renderDialog({
+        methods: ["passkey"],
+        onPasskeyVerify: handler,
+      });
+      const buttons = container.querySelectorAll("button");
+      const verifyBtn = Array.from(buttons).find((b) =>
+        b.textContent?.includes("Verify with passkey"),
+      );
+      fireEvent.click(verifyBtn!);
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it("calls onSuccess with token after passkey verify", async () => {
+      const onSuccess = vi.fn();
+      const { container } = renderDialog({
+        methods: ["passkey"],
+        onPasskeyVerify: vi.fn().mockResolvedValue("passkey-token"),
+        onSuccess,
+      });
+      const buttons = container.querySelectorAll("button");
+      const verifyBtn = Array.from(buttons).find((b) =>
+        b.textContent?.includes("Verify with passkey"),
+      );
+      fireEvent.click(verifyBtn!);
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledWith("passkey-token");
+      });
+    });
+  });
+
+  describe("password view", () => {
+    it("shows password view when password-only", () => {
+      const { container } = renderDialog({
+        methods: ["password"],
+      });
+      const input = container.querySelector(
+        "input[type='password']",
+      );
+      expect(input).toBeInTheDocument();
+    });
+
+    it("switches to password view when link is clicked", () => {
+      const { container } = renderDialog({
+        methods: ["passkey", "password"],
+      });
+      const link = Array.from(container.querySelectorAll("button")).find(
+        (b) => b.textContent?.includes("Use password instead"),
+      );
+      fireEvent.click(link!);
+      const input = container.querySelector(
+        "input[type='password']",
+      );
+      expect(input).toBeInTheDocument();
+    });
+
+    it("shows error when submitting empty password", () => {
+      const { container } = renderDialog({
+        methods: ["password"],
+      });
+      const verifyBtn = Array.from(
+        container.querySelectorAll("button"),
+      ).find((b) => b.textContent === "Verify");
+      fireEvent.click(verifyBtn!);
+      expect(container.textContent).toContain("Password is required");
+    });
+
+    it("calls onPasswordVerify with entered password", async () => {
+      const handler = vi.fn().mockResolvedValue("pwd-token");
+      const { container } = renderDialog({
+        methods: ["password"],
+        onPasswordVerify: handler,
+      });
+      const input = container.querySelector(
+        "input[type='password']",
+      ) as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "mypassword" } });
+      const verifyBtn = Array.from(
+        container.querySelectorAll("button"),
+      ).find((b) => b.textContent === "Verify");
+      fireEvent.click(verifyBtn!);
+      expect(handler).toHaveBeenCalledWith("mypassword");
+    });
+
+    it("calls onSuccess after successful password verify", async () => {
+      const onSuccess = vi.fn();
+      const { container } = renderDialog({
+        methods: ["password"],
+        onPasswordVerify: vi.fn().mockResolvedValue("pwd-token"),
+        onSuccess,
+      });
+      const input = container.querySelector(
+        "input[type='password']",
+      ) as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "pass" } });
+      const verifyBtn = Array.from(
+        container.querySelectorAll("button"),
+      ).find((b) => b.textContent === "Verify");
+      fireEvent.click(verifyBtn!);
+      await waitFor(() => {
+        expect(onSuccess).toHaveBeenCalledWith("pwd-token");
+      });
+    });
+
+    it("shows error on password verify failure", async () => {
+      const { container } = renderDialog({
+        methods: ["password"],
+        onPasswordVerify: vi
+          .fn()
+          .mockRejectedValue(new Error("Wrong password")),
+      });
+      const input = container.querySelector(
+        "input[type='password']",
+      ) as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "bad" } });
+      const verifyBtn = Array.from(
+        container.querySelectorAll("button"),
+      ).find((b) => b.textContent === "Verify");
+      fireEvent.click(verifyBtn!);
+      await waitFor(() => {
+        expect(container.textContent).toContain("Wrong password");
+      });
+    });
+
+    it("submits on Enter key", () => {
+      const handler = vi.fn().mockResolvedValue("token");
+      const { container } = renderDialog({
+        methods: ["password"],
+        onPasswordVerify: handler,
+      });
+      const input = container.querySelector(
+        "input[type='password']",
+      ) as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "pass" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(handler).toHaveBeenCalledWith("pass");
+    });
+
+    it("shows 'Use passkey instead' link when both methods", () => {
+      const { container } = renderDialog({
+        methods: ["passkey", "password"],
+      });
+      // Switch to password view first
+      const pwdLink = Array.from(
+        container.querySelectorAll("button"),
+      ).find((b) => b.textContent?.includes("Use password instead"));
+      fireEvent.click(pwdLink!);
+      expect(container.textContent).toContain("Use passkey instead");
+    });
+  });
+
+  describe("close", () => {
+    it("calls onClose when cancel is clicked", () => {
+      const onClose = vi.fn();
+      const { container } = renderDialog({
+        methods: ["password"],
+        onClose,
+      });
+      const cancelBtn = Array.from(
+        container.querySelectorAll("button"),
+      ).find((b) => b.textContent === "Cancel");
+      fireEvent.click(cancelBtn!);
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it("calls onClose when backdrop is clicked", () => {
+      const onClose = vi.fn();
+      const { container } = renderDialog({ onClose });
+      const backdrop = container.querySelector(
+        "[aria-hidden='true']",
+      ) as HTMLElement;
+      fireEvent.click(backdrop);
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("error dismissal", () => {
+    it("dismisses error when close button is clicked", async () => {
+      const { container } = renderDialog({
+        methods: ["password"],
+      });
+      // Trigger error
+      const verifyBtn = Array.from(
+        container.querySelectorAll("button"),
+      ).find((b) => b.textContent === "Verify");
+      fireEvent.click(verifyBtn!);
+
+      await waitFor(() => {
+        expect(container.textContent).toContain("Password is required");
+      });
+
+      const dismissBtn = container.querySelector(
+        "button[aria-label='Dismiss error']",
+      ) as HTMLButtonElement;
+      fireEvent.click(dismissBtn);
+
+      await waitFor(() => {
+        expect(container.textContent).not.toContain(
+          "Password is required",
+        );
+      });
+    });
+  });
+
+  describe("className", () => {
+    it("applies custom className to dialog panel", () => {
+      const { container } = renderDialog({ className: "custom-class" });
+      const panel = getDialog(container).querySelector(".relative");
+      expect(panel?.getAttribute("class")).toContain("custom-class");
+    });
+  });
+});

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -1,0 +1,289 @@
+import { useState, useCallback, useEffect } from "react";
+import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
+import type { ComponentMeta } from "@/types/component-meta";
+import { Button } from "@/components/ui/actions/button/Button";
+
+export const meta: ComponentMeta = {
+  name: "ReauthDialog",
+  description:
+    "Modal dialog prompting re-authentication via passkey or password before sensitive actions",
+};
+
+export type ReauthMethod = "password" | "passkey";
+
+export interface ReauthDialogProps {
+  readonly open: boolean;
+  readonly onClose: () => void;
+  readonly onSuccess: (reauthToken: string) => void;
+  readonly title?: string;
+  readonly description?: string;
+  readonly methods?: readonly ReauthMethod[];
+  readonly onPasswordVerify?: (password: string) => Promise<string>;
+  readonly onPasskeyVerify?: () => Promise<string>;
+  readonly className?: string;
+}
+
+export function ReauthDialog({
+  open,
+  onClose,
+  onSuccess,
+  title = "Verify your identity",
+  description = "For your security, please verify your identity before continuing.",
+  methods = ["passkey", "password"],
+  onPasswordVerify,
+  onPasskeyVerify,
+  className,
+}: ReauthDialogProps) {
+  const hasPasskey = methods.includes("passkey");
+  const hasPassword = methods.includes("password");
+
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [showPasswordFallback, setShowPasswordFallback] = useState(false);
+
+  const showingPassword = !hasPasskey || showPasswordFallback;
+
+  if (isDev) {
+    if (hasPasskey && !onPasskeyVerify) {
+      console.warn(
+        "[ReauthDialog] methods includes 'passkey' but onPasskeyVerify is not provided",
+      );
+    }
+    if (hasPassword && !onPasswordVerify) {
+      console.warn(
+        "[ReauthDialog] methods includes 'password' but onPasswordVerify is not provided",
+      );
+    }
+  }
+
+  const reset = useCallback(() => {
+    setPassword("");
+    setError(null);
+    setIsVerifying(false);
+    setShowPasswordFallback(false);
+  }, []);
+
+  useEffect(() => {
+    if (open) reset();
+  }, [open, reset]);
+
+  const handleClose = () => {
+    if (isVerifying) return;
+    reset();
+    onClose();
+  };
+
+  const handlePasswordVerify = async () => {
+    if (!password) {
+      setError("Password is required");
+      return;
+    }
+
+    setError(null);
+    setIsVerifying(true);
+    try {
+      if (!onPasswordVerify) {
+        throw new Error("Password verification not configured");
+      }
+      const token = await onPasswordVerify(password);
+      reset();
+      onSuccess(token);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Incorrect password",
+      );
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  const handlePasskeyVerify = async () => {
+    setError(null);
+    setIsVerifying(true);
+    try {
+      if (!onPasskeyVerify) {
+        throw new Error("Passkey verification not configured");
+      }
+      const token = await onPasskeyVerify();
+      reset();
+      onSuccess(token);
+    } catch (err) {
+      if (
+        err instanceof DOMException &&
+        err.name === "NotAllowedError"
+      ) {
+        // User cancelled the passkey prompt — not an error
+      } else {
+        setError(
+          err instanceof Error
+            ? err.message
+            : "Passkey verification failed",
+        );
+      }
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      aria-modal="true"
+      role="dialog"
+      aria-label={title}
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-scrim/50"
+        onClick={handleClose}
+        aria-hidden="true"
+      />
+
+      {/* Dialog */}
+      <div
+        className={cn(
+          "relative z-10 w-full max-w-md rounded-2xl bg-surface-container-low p-6 shadow-xl",
+          className,
+        )}
+      >
+        <h2 className="text-lg font-semibold text-on-surface">{title}</h2>
+        <p className="mt-2 text-sm text-on-surface-variant">{description}</p>
+
+        <div className="mt-4">
+          {/* Passkey view */}
+          {!showingPassword && (
+            <div className="flex flex-col items-center gap-3 py-2">
+              <div className="flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
+                <span
+                  className="material-symbols-rounded text-primary"
+                  aria-hidden="true"
+                  style={{ fontSize: 28 }}
+                >
+                  passkey
+                </span>
+              </div>
+              <p className="text-center text-sm text-on-surface-variant">
+                Use your passkey to verify
+              </p>
+              <Button
+                onClick={handlePasskeyVerify}
+                loading={isVerifying}
+                fullWidth
+              >
+                Verify with passkey
+              </Button>
+              {hasPassword && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setError(null);
+                    setShowPasswordFallback(true);
+                  }}
+                  disabled={isVerifying}
+                  className="text-sm text-primary hover:underline disabled:opacity-50 cursor-pointer"
+                >
+                  Use password instead
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* Password view */}
+          {showingPassword && (
+            <div className="flex flex-col gap-3">
+              <div>
+                <label
+                  htmlFor="reauth-password"
+                  className="mb-1 block text-sm font-medium text-on-surface"
+                >
+                  Password
+                </label>
+                <input
+                  type="password"
+                  id="reauth-password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  disabled={isVerifying}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handlePasswordVerify();
+                  }}
+                  autoFocus
+                  className={cn(
+                    "w-full rounded-lg border px-3 py-2 text-sm outline-none transition-colors",
+                    "bg-surface text-on-surface border-outline-variant",
+                    "focus:border-primary focus:ring-1 focus:ring-primary",
+                    "disabled:opacity-50 disabled:cursor-not-allowed",
+                  )}
+                />
+              </div>
+              {hasPasskey && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setError(null);
+                    setShowPasswordFallback(false);
+                  }}
+                  disabled={isVerifying}
+                  className="self-start text-sm text-primary hover:underline disabled:opacity-50 cursor-pointer"
+                >
+                  Use passkey instead
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* Error */}
+          {error && (
+            <div
+              className="mt-4 flex items-center gap-3 rounded-xl border bg-error/10 border-error/30 px-4 py-3 text-error"
+              role="alert"
+            >
+              <span
+                className="material-symbols-rounded shrink-0"
+                aria-hidden="true"
+                style={{ fontSize: 20 }}
+              >
+                error
+              </span>
+              <span className="flex-1 text-sm">{error}</span>
+              <button
+                type="button"
+                onClick={() => setError(null)}
+                aria-label="Dismiss error"
+                className="shrink-0 rounded-full p-1 text-current opacity-70 hover:opacity-100 cursor-pointer"
+              >
+                <span
+                  className="material-symbols-rounded"
+                  aria-hidden="true"
+                  style={{ fontSize: 18 }}
+                >
+                  close
+                </span>
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Actions for password view */}
+        {showingPassword && (
+          <div className="mt-6 flex justify-end gap-2">
+            <Button
+              variant="text"
+              onClick={handleClose}
+              disabled={isVerifying}
+            >
+              Cancel
+            </Button>
+            <Button onClick={handlePasswordVerify} loading={isVerifying}>
+              Verify
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,11 @@ export {
   type SegmentedButtonOption,
 } from "./components/ui/inputs/segmented-button/SegmentedButton";
 export {
+  ReauthDialog,
+  type ReauthDialogProps,
+  type ReauthMethod,
+} from "./components/ui/surfaces/reauth-dialog/ReauthDialog";
+export {
   DevToolbar,
   type DevToolbarProps,
   type DevToolbarItem,


### PR DESCRIPTION
## Summary
- Add `ReauthDialog` modal for re-authentication via passkey or password
- Passkey view shown first with "Use password instead" fallback
- Password view with label, input, Enter-to-submit, Cancel/Verify buttons
- Handles WebAuthn `NotAllowedError` gracefully (user cancellation)
- Prevents closing during verification, resets state on each open
- Inline error display with dismissible `role="alert"` banner
- Dev-only warnings for missing verify callbacks
- Uses existing `Button` component for all actions

Closes #32

## Verification

### Tests (82 pass, 23 new)
```
 ✓ src/components/ui/surfaces/reauth-dialog/ReauthDialog.test.tsx (23 tests) 96ms
 ✓ src/components/ui/inputs/segmented-button/SegmentedButton.test.tsx (10 tests)
 ✓ src/components/ui/feedback/progress/Progress.test.tsx (20 tests)
 ✓ src/components/ui/actions/button/Button.test.tsx (24 tests)
 ✓ src/components/ui/state/dev-toolbar/DevToolbar.test.tsx (5 tests)

 Test Files  5 passed (5)
      Tests  82 passed (82)
```

### Typecheck
```
tsc --noEmit  (clean)
```

### Component validation
```
PASS  src/components/ui/actions/button/Button.tsx
PASS  src/components/ui/feedback/progress/Progress.tsx
PASS  src/components/ui/inputs/segmented-button/SegmentedButton.tsx
PASS  src/components/ui/state/dev-toolbar/DevToolbar.tsx
PASS  src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx

All 5 component(s) have valid metadata.
```

### CONTRIBUTING.md compliance (12/12 PASS)
- Folder: `ui/surfaces/reauth-dialog/` ✓
- Files: `.tsx`, `.stories.tsx`, `.test.tsx` ✓
- `meta` export with `ComponentMeta` ✓
- No `"use client"` ✓
- `@/` path alias ✓
- `cn()` for class merging ✓
- `isDev` from `@/utils/env` ✓
- Dev warnings with `[ReauthDialog]` prefix ✓
- Story title `UI/Surfaces/ReauthDialog` ✓
- Playground story ✓
- Exported from `index.ts` with types ✓
- Props interface exported ✓

## Test plan
- [ ] Verify Storybook renders ReauthDialog with passkey view
- [ ] Test "Use password instead" switches to password view
- [ ] Test password verification with correct/incorrect password
- [ ] Verify Cancel button closes dialog
- [ ] Test backdrop click closes dialog
- [ ] Verify dialog cannot be closed during verification
- [ ] Test error display and dismissal
- [ ] Check PasswordOnly and PasskeyOnly story variants