### PR TITLE
fix: add no-cache headers to Storybook manager

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,0 +1,3 @@
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+<meta http-equiv="Pragma" content="no-cache" />
+<meta http-equiv="Expires" content="0" />


### PR DESCRIPTION
## Summary
- Add `.storybook/manager-head.html` with `Cache-Control: no-cache` meta tags
- Prevents browser from serving stale `index.json` on PR preview updates

## Problem
When stories are renamed or removed in a PR update, the browser caches the old Storybook `index.json` (which contains story IDs). On the next visit, the Storybook sidebar references old story IDs like `mono-copyable` that no longer exist in the updated JS bundles, causing:

> Couldn't find story matching id 'ui-data-readonlyfield--mono-copyable' after importing a CSF file.

## Fix
The `manager-head.html` injects `<meta>` tags into the Storybook manager `<head>`, forcing browsers to always fetch the latest `index.json` instead of using a cached copy.

```html
<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
<meta http-equiv="Pragma" content="no-cache" />
<meta http-equiv="Expires" content="0" />
```

## Verification
```
pnpm build-storybook  (success)
```

## Test plan
- [ ] Merge this PR
- [ ] Update a story in another PR (rename/remove a story export)
- [ ] Visit the PR preview — no "Couldn't find story" error