### PR TITLE
feat: add ReadOnlyField component + fix Storybook cache

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -1,0 +1,3 @@
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+<meta http-equiv="Pragma" content="no-cache" />
+<meta http-equiv="Expires" content="0" />

--- a/src/components/ui/data/read-only-field/ReadOnlyField.stories.tsx
+++ b/src/components/ui/data/read-only-field/ReadOnlyField.stories.tsx
@@ -16,6 +16,13 @@ const meta: Meta<typeof ReadOnlyField> = {
     label: { control: "text" },
     value: { control: "text" },
   },
+};
+
+export default meta;
+type Story = StoryObj<typeof ReadOnlyField>;
+
+/** Interactive playground — all controls work here */
+export const Playground: Story = {
   decorators: [
     (Story) => (
       <div className="max-w-md rounded-xl bg-surface-container p-5">
@@ -24,12 +31,6 @@ const meta: Meta<typeof ReadOnlyField> = {
     ),
   ],
 };
-
-export default meta;
-type Story = StoryObj<typeof ReadOnlyField>;
-
-/** Interactive playground — all controls work here */
-export const Playground: Story = {};
 
 /** Account details card with multiple fields */
 export const AccountDetails: Story = {

--- a/src/components/ui/data/read-only-field/ReadOnlyField.stories.tsx
+++ b/src/components/ui/data/read-only-field/ReadOnlyField.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ReadOnlyField } from "./ReadOnlyField";
+
+const meta: Meta<typeof ReadOnlyField> = {
+  title: "UI/Data/ReadOnlyField",
+  component: ReadOnlyField,
+  args: {
+    label: "API Key",
+    value: "sk-proj-abc123def456ghi789",
+    mono: false,
+    copyable: false,
+  },
+  argTypes: {
+    mono: { control: "boolean" },
+    copyable: { control: "boolean" },
+    label: { control: "text" },
+    value: { control: "text" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ReadOnlyField>;
+
+/** Interactive playground — all controls work here */
+export const Playground: Story = {};
+
+/** Monospace value with copy button */
+export const MonoCopyable: Story = {
+  args: {
+    label: "API Key",
+    value: "sk-proj-abc123def456ghi789jkl012mno345",
+    mono: true,
+    copyable: true,
+  },
+};
+
+/** Multiple fields stacked */
+export const FieldGroup: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-4 max-w-sm">
+      <ReadOnlyField
+        {...args}
+        label="Name"
+        value="Jane Doe"
+      />
+      <ReadOnlyField
+        {...args}
+        label="Email"
+        value="jane@example.com"
+        copyable
+      />
+      <ReadOnlyField
+        {...args}
+        label="User ID"
+        value="usr_2f8a9c1b3d4e5f6a"
+        mono
+        copyable
+      />
+    </div>
+  ),
+};
+
+/** With suffix slot */
+export const WithSuffix: Story = {
+  args: {
+    label: "Status",
+    value: "Active",
+    suffix: (
+      <span className="rounded-full bg-success/10 px-2 py-0.5 text-xs font-medium text-success">
+        Verified
+      </span>
+    ),
+  },
+};
+
+/** Long value truncated */
+export const Truncated: Story = {
+  render: (args) => (
+    <div className="max-w-xs">
+      <ReadOnlyField
+        {...args}
+        label="Webhook URL"
+        value="https://api.example.com/webhooks/v2/ingest/events/abc123def456ghi789"
+        mono
+        copyable
+      />
+    </div>
+  ),
+};

--- a/src/components/ui/data/read-only-field/ReadOnlyField.stories.tsx
+++ b/src/components/ui/data/read-only-field/ReadOnlyField.stories.tsx
@@ -7,8 +7,8 @@ const meta: Meta<typeof ReadOnlyField> = {
   args: {
     label: "API Key",
     value: "sk-proj-abc123def456ghi789",
-    mono: false,
-    copyable: false,
+    mono: true,
+    copyable: true,
   },
   argTypes: {
     mono: { control: "boolean" },
@@ -24,66 +24,70 @@ type Story = StoryObj<typeof ReadOnlyField>;
 /** Interactive playground — all controls work here */
 export const Playground: Story = {};
 
-/** Monospace value with copy button */
-export const MonoCopyable: Story = {
-  args: {
-    label: "API Key",
-    value: "sk-proj-abc123def456ghi789jkl012mno345",
-    mono: true,
-    copyable: true,
-  },
-};
-
-/** Multiple fields stacked */
-export const FieldGroup: Story = {
+/** Account details card with multiple fields */
+export const AccountDetails: Story = {
   render: (args) => (
-    <div className="flex flex-col gap-4 max-w-sm">
-      <ReadOnlyField
-        {...args}
-        label="Name"
-        value="Jane Doe"
-      />
-      <ReadOnlyField
-        {...args}
-        label="Email"
-        value="jane@example.com"
-        copyable
-      />
-      <ReadOnlyField
-        {...args}
-        label="User ID"
-        value="usr_2f8a9c1b3d4e5f6a"
-        mono
-        copyable
-      />
+    <div className="max-w-md rounded-xl bg-surface-container p-5">
+      <p className="mb-4 text-sm font-semibold text-on-surface">
+        Account Details
+      </p>
+      <div className="flex flex-col gap-4">
+        <ReadOnlyField {...args} label="Name" value="Jane Doe" mono={false} copyable={false} />
+        <ReadOnlyField {...args} label="Email" value="jane@example.com" mono={false} copyable />
+        <ReadOnlyField
+          {...args}
+          label="User ID"
+          value="usr_2f8a9c1b3d4e5f6a"
+          mono
+          copyable
+        />
+        <ReadOnlyField
+          {...args}
+          label="API Key"
+          value="sk-proj-abc123def456ghi789jkl012mno345"
+          mono
+          copyable
+        />
+        <ReadOnlyField
+          {...args}
+          label="Status"
+          value="Active"
+          mono={false}
+          copyable={false}
+          suffix={
+            <span className="rounded-full bg-success/10 px-2 py-0.5 text-xs font-medium text-success">
+              Verified
+            </span>
+          }
+        />
+      </div>
     </div>
   ),
 };
 
-/** With suffix slot */
-export const WithSuffix: Story = {
-  args: {
-    label: "Status",
-    value: "Active",
-    suffix: (
-      <span className="rounded-full bg-success/10 px-2 py-0.5 text-xs font-medium text-success">
-        Verified
-      </span>
-    ),
-  },
-};
-
-/** Long value truncated */
+/** Long values truncated inside a narrow container */
 export const Truncated: Story = {
   render: (args) => (
-    <div className="max-w-xs">
-      <ReadOnlyField
-        {...args}
-        label="Webhook URL"
-        value="https://api.example.com/webhooks/v2/ingest/events/abc123def456ghi789"
-        mono
-        copyable
-      />
+    <div className="max-w-xs rounded-xl bg-surface-container p-5">
+      <p className="mb-4 text-sm font-semibold text-on-surface">
+        Webhook Config
+      </p>
+      <div className="flex flex-col gap-4">
+        <ReadOnlyField
+          {...args}
+          label="Endpoint URL"
+          value="https://api.example.com/webhooks/v2/ingest/events/abc123def456"
+          mono
+          copyable
+        />
+        <ReadOnlyField
+          {...args}
+          label="Secret"
+          value="whsec_MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQ"
+          mono
+          copyable
+        />
+      </div>
     </div>
   ),
 };

--- a/src/components/ui/data/read-only-field/ReadOnlyField.stories.tsx
+++ b/src/components/ui/data/read-only-field/ReadOnlyField.stories.tsx
@@ -16,6 +16,13 @@ const meta: Meta<typeof ReadOnlyField> = {
     label: { control: "text" },
     value: { control: "text" },
   },
+  decorators: [
+    (Story) => (
+      <div className="max-w-md rounded-xl bg-surface-container p-5">
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export default meta;

--- a/src/components/ui/data/read-only-field/ReadOnlyField.test.tsx
+++ b/src/components/ui/data/read-only-field/ReadOnlyField.test.tsx
@@ -1,0 +1,130 @@
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ReadOnlyField } from "./ReadOnlyField";
+
+function renderField(
+  props: Partial<Parameters<typeof ReadOnlyField>[0]> = {},
+) {
+  return render(
+    <ReadOnlyField label="Test Label" value="Test Value" {...props} />,
+  );
+}
+
+describe("ReadOnlyField", () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  it("renders label and value", () => {
+    const { container } = renderField();
+    expect(container.textContent).toContain("Test Label");
+    expect(container.textContent).toContain("Test Value");
+  });
+
+  it("renders label as a label element", () => {
+    const { container } = renderField();
+    const label = container.querySelector("label");
+    expect(label).toBeInTheDocument();
+    expect(label?.textContent).toBe("Test Label");
+  });
+
+  describe("mono", () => {
+    it("applies monospace font when mono is true", () => {
+      const { container } = renderField({ mono: true });
+      const valueSpan = container.querySelector(".truncate");
+      expect(valueSpan?.getAttribute("class")).toContain("font-mono");
+    });
+
+    it("does not apply monospace font by default", () => {
+      const { container } = renderField();
+      const valueSpan = container.querySelector(".truncate");
+      expect(valueSpan?.getAttribute("class")).not.toContain("font-mono");
+    });
+  });
+
+  describe("copyable", () => {
+    it("shows copy button when copyable is true", () => {
+      const { container } = renderField({ copyable: true });
+      const btn = container.querySelector(
+        "button[aria-label='Copy Test Label']",
+      );
+      expect(btn).toBeInTheDocument();
+    });
+
+    it("does not show copy button by default", () => {
+      const { container } = renderField();
+      const btn = container.querySelector("button");
+      expect(btn).not.toBeInTheDocument();
+    });
+
+    it("copies value to clipboard on click", async () => {
+      const { container } = renderField({ copyable: true });
+      const btn = container.querySelector("button") as HTMLButtonElement;
+      fireEvent.click(btn);
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        "Test Value",
+      );
+    });
+
+    it("calls onCopy after successful copy", async () => {
+      const handler = vi.fn();
+      const { container } = renderField({
+        copyable: true,
+        onCopy: handler,
+      });
+      const btn = container.querySelector("button") as HTMLButtonElement;
+      fireEvent.click(btn);
+      await waitFor(() => {
+        expect(handler).toHaveBeenCalledOnce();
+      });
+    });
+
+    it("shows check icon after copy", async () => {
+      const { container } = renderField({ copyable: true });
+      const btn = container.querySelector("button") as HTMLButtonElement;
+
+      // Before copy: shows content_copy
+      const iconBefore = btn.querySelector(".material-symbols-rounded");
+      expect(iconBefore?.textContent?.trim()).toBe("content_copy");
+
+      fireEvent.click(btn);
+
+      await waitFor(() => {
+        const iconAfter = btn.querySelector(".material-symbols-rounded");
+        expect(iconAfter?.textContent?.trim()).toBe("check");
+      });
+    });
+  });
+
+  describe("suffix", () => {
+    it("renders suffix content", () => {
+      const { container } = renderField({
+        suffix: <span data-testid="suffix">Badge</span>,
+      });
+      const suffix = container.querySelector("[data-testid='suffix']");
+      expect(suffix).toBeInTheDocument();
+      expect(suffix?.textContent).toBe("Badge");
+    });
+  });
+
+  describe("truncation", () => {
+    it("applies truncate class to value", () => {
+      const { container } = renderField();
+      const valueSpan = container.querySelector(".truncate");
+      expect(valueSpan).toBeInTheDocument();
+    });
+  });
+
+  describe("className", () => {
+    it("applies custom className to container", () => {
+      const { container } = renderField({ className: "custom-class" });
+      expect(
+        container.firstElementChild?.getAttribute("class"),
+      ).toContain("custom-class");
+    });
+  });
+});

--- a/src/components/ui/data/read-only-field/ReadOnlyField.tsx
+++ b/src/components/ui/data/read-only-field/ReadOnlyField.tsx
@@ -1,0 +1,91 @@
+import { type ReactNode, useState } from "react";
+import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "ReadOnlyField",
+  description:
+    "Label/value pair display with optional copy-to-clipboard button and suffix slot",
+};
+
+export interface ReadOnlyFieldProps {
+  readonly label: string;
+  readonly value: string;
+  readonly mono?: boolean;
+  readonly copyable?: boolean;
+  readonly onCopy?: () => void;
+  readonly suffix?: ReactNode;
+  readonly className?: string;
+}
+
+export function ReadOnlyField({
+  label,
+  value,
+  mono = false,
+  copyable = false,
+  onCopy,
+  suffix,
+  className,
+}: ReadOnlyFieldProps) {
+  const [copied, setCopied] = useState(false);
+
+  if (isDev) {
+    if (!label) {
+      console.warn("[ReadOnlyField] label should not be empty");
+    }
+    if (copyable && !value) {
+      console.warn(
+        "[ReadOnlyField] copyable is true but value is empty — nothing to copy",
+      );
+    }
+  }
+
+  const handleCopy = () => {
+    navigator.clipboard
+      .writeText(value)
+      .then(() => {
+        setCopied(true);
+        onCopy?.();
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => {});
+  };
+
+  return (
+    <div className={className}>
+      <label className="mb-1 block text-sm font-medium text-on-surface">
+        {label}
+      </label>
+      <div className="flex min-h-8 items-center gap-2">
+        <span
+          className={cn(
+            "truncate text-sm",
+            mono
+              ? "font-mono text-on-surface-variant"
+              : "text-on-surface",
+          )}
+        >
+          {value}
+        </span>
+        {copyable && (
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="shrink-0 cursor-pointer p-1 text-on-surface-variant transition-colors hover:text-primary"
+            aria-label={`Copy ${label}`}
+          >
+            <span
+              className="material-symbols-rounded"
+              aria-hidden="true"
+              style={{ fontSize: 16 }}
+            >
+              {copied ? "check" : "content_copy"}
+            </span>
+          </button>
+        )}
+        {suffix}
+      </div>
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,10 @@ export {
   type SegmentedButtonOption,
 } from "./components/ui/inputs/segmented-button/SegmentedButton";
 export {
+  ReadOnlyField,
+  type ReadOnlyFieldProps,
+} from "./components/ui/data/read-only-field/ReadOnlyField";
+export {
   DevToolbar,
   type DevToolbarProps,
   type DevToolbarItem,


### PR DESCRIPTION
## Summary
- Add `ReadOnlyField` component for label/value pair display
- Optional copy-to-clipboard with visual feedback (icon changes to checkmark for 2s)
- Monospace font toggle via `mono` prop, CSS truncation for long values
- Suffix slot for extra content (badges, status indicators)
- Dev-only warnings for empty label and empty copyable value
- Fix Storybook manager cache issue that caused "Couldn't find story" errors on PR preview updates

Closes #30

## Storybook cache fix
Added `.storybook/manager-head.html` with `Cache-Control: no-cache` meta tags. Without this, renaming or removing stories in a PR update causes the browser to serve stale `index.json` from cache, resulting in:
> Couldn't find story matching id 'ui-data-readonlyfield--mono-copyable'

## Verification

### Tests (71 pass, 12 new)
```
 ✓ src/components/ui/data/read-only-field/ReadOnlyField.test.tsx (12 tests) 89ms
 ✓ src/components/ui/inputs/segmented-button/SegmentedButton.test.tsx (10 tests)
 ✓ src/components/ui/feedback/progress/Progress.test.tsx (20 tests)
 ✓ src/components/ui/actions/button/Button.test.tsx (24 tests)
 ✓ src/components/ui/state/dev-toolbar/DevToolbar.test.tsx (5 tests)

 Test Files  5 passed (5)
      Tests  71 passed (71)
```

### Typecheck
```
tsc --noEmit  (clean)
```

### Component validation
```
PASS  src/components/ui/actions/button/Button.tsx
PASS  src/components/ui/data/read-only-field/ReadOnlyField.tsx
PASS  src/components/ui/feedback/progress/Progress.tsx
PASS  src/components/ui/inputs/segmented-button/SegmentedButton.tsx
PASS  src/components/ui/state/dev-toolbar/DevToolbar.tsx

All 5 component(s) have valid metadata.
```

### CONTRIBUTING.md compliance (12/12 PASS)
- Folder: `ui/data/read-only-field/` ✓
- Files: `.tsx`, `.stories.tsx`, `.test.tsx` ✓
- `meta` export with `ComponentMeta` ✓
- No `"use client"` ✓
- `@/` path alias ✓
- `cn()` for class merging ✓
- `isDev` from `@/utils/env` ✓
- Dev warnings with `[ReadOnlyField]` prefix ✓
- Story title `UI/Data/ReadOnlyField` ✓
- Playground story ✓
- Exported from `index.ts` with types ✓
- Props interface exported ✓

## Test plan
- [ ] Verify Storybook renders ReadOnlyField with label and value
- [ ] Test copy button copies value to clipboard
- [ ] Verify checkmark icon appears after copy
- [ ] Test monospace font in Playground (mono=true by default)
- [ ] Verify AccountDetails story shows card layout with multiple fields
- [ ] Check truncation on long values in Truncated story
- [ ] Verify no "Couldn't find story" errors after PR preview rebuild