### PR TITLE
feat: add Icon component (#22)

### DIFF
--- a/src/components/ui/actions/button/Button.tsx
+++ b/src/components/ui/actions/button/Button.tsx
@@ -2,6 +2,7 @@ import { type ButtonHTMLAttributes, type CSSProperties } from "react";
 import { cn } from "@/utils/cn";
 import type { ComponentMeta } from "@/types/component-meta";
 import { Progress } from "@/components/ui/feedback/progress/Progress";
+import { Icon } from "@/components/ui/media/icon/Icon";
 import { isDev } from "@/utils/env";
 import {
   type ButtonVariant,
@@ -44,13 +45,6 @@ const gapStyles: Record<ButtonSize, string> = {
   lg: "gap-3",
 };
 
-function MaterialIcon({ name, size }: { name: string; size: ButtonSize }) {
-  return (
-    <span className="material-symbols-rounded" style={{ fontSize: iconSizes[size] }}>
-      {name}
-    </span>
-  );
-}
 
 export function Button({
   variant = "filled",
@@ -98,9 +92,9 @@ export function Button({
           loading && "opacity-0",
         )}
       >
-        {leftIcon && <MaterialIcon name={leftIcon} size={size} />}
+        {leftIcon && <Icon name={leftIcon} size={iconSizes[size]} />}
         {children}
-        {rightIcon && <MaterialIcon name={rightIcon} size={size} />}
+        {rightIcon && <Icon name={rightIcon} size={iconSizes[size]} />}
       </span>
     </button>
   );

--- a/src/components/ui/actions/icon-button/IconButton.tsx
+++ b/src/components/ui/actions/icon-button/IconButton.tsx
@@ -2,6 +2,7 @@ import { type ButtonHTMLAttributes } from "react";
 import { cn } from "@/utils/cn";
 import type { ComponentMeta } from "@/types/component-meta";
 import { Progress } from "@/components/ui/feedback/progress/Progress";
+import { Icon } from "@/components/ui/media/icon/Icon";
 import { isDev } from "@/utils/env";
 import {
   type ButtonVariant,
@@ -71,12 +72,7 @@ export function IconButton({
           style={{ width: iconSizes[size], height: iconSizes[size] }}
         />
       ) : (
-        <span
-          className="material-symbols-rounded"
-          style={{ fontSize: iconSizes[size] }}
-        >
-          {icon}
-        </span>
+        <Icon name={icon} size={iconSizes[size]} />
       )}
     </button>
   );

--- a/src/components/ui/feedback/snackbar/Snackbar.tsx
+++ b/src/components/ui/feedback/snackbar/Snackbar.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/utils/cn";
 import type { ComponentMeta } from "@/types/component-meta";
 import { Button } from "@/components/ui/actions/button/Button";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+import { Icon } from "@/components/ui/media/icon/Icon";
 
 export const meta: ComponentMeta = {
   name: "Snackbar",
@@ -133,14 +134,11 @@ export function Snackbar({
               <div className="w-2 h-2 rounded-full bg-warning animate-pulse shrink-0" />
             )}
             {icon && (
-              <span
-                className={cn(
-                  "material-symbols-rounded !text-xl shrink-0",
-                  variantTextColor[variant],
-                )}
-              >
-                {icon}
-              </span>
+              <Icon
+                name={icon}
+                size={20}
+                className={variantTextColor[variant]}
+              />
             )}
             <span className={cn("text-sm line-clamp-3 break-all", variantTextColor[variant])}>
               {message}

--- a/src/components/ui/media/icon/Icon.stories.tsx
+++ b/src/components/ui/media/icon/Icon.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Icon } from "./Icon";
+
+const meta: Meta<typeof Icon> = {
+  title: "UI/Media/Icon",
+  component: Icon,
+  args: {
+    name: "edit",
+    size: 24,
+  },
+  argTypes: {
+    name: { control: "text" },
+    size: { control: { type: "range", min: 16, max: 48, step: 4 } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Icon>;
+
+export const Playground: Story = {};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Icon name="home" size={16} />
+      <Icon name="home" size={20} />
+      <Icon name="home" size={24} />
+      <Icon name="home" size={32} />
+      <Icon name="home" size={40} />
+      <Icon name="home" size={48} />
+    </div>
+  ),
+};
+
+export const CommonIcons: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-4">
+      {[
+        "home",
+        "settings",
+        "edit",
+        "delete",
+        "search",
+        "close",
+        "check",
+        "add",
+        "person",
+        "lock",
+        "visibility",
+        "dark_mode",
+        "light_mode",
+        "key",
+        "passkey",
+        "security",
+      ].map((name) => (
+        <div key={name} className="flex flex-col items-center gap-1">
+          <Icon name={name} size={24} />
+          <span className="text-xs text-on-surface-variant">{name}</span>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const WithColor: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Icon name="check_circle" size={24} className="text-success" />
+      <Icon name="error" size={24} className="text-error" />
+      <Icon name="warning" size={24} className="text-warning" />
+      <Icon name="info" size={24} className="text-primary" />
+    </div>
+  ),
+};

--- a/src/components/ui/media/icon/Icon.test.tsx
+++ b/src/components/ui/media/icon/Icon.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Icon } from "./Icon";
+
+describe("Icon", () => {
+  it("renders the icon name as text content", () => {
+    render(<Icon name="edit" />);
+    expect(screen.getByText("edit")).toBeInTheDocument();
+  });
+
+  it("applies material-symbols-rounded class", () => {
+    render(<Icon name="home" />);
+    expect(screen.getByText("home")).toHaveClass("material-symbols-rounded");
+  });
+
+  it("sets font size from size prop", () => {
+    render(<Icon name="settings" size={32} />);
+    expect(screen.getByText("settings")).toHaveStyle({ fontSize: "32px" });
+  });
+
+  it("defaults to size 24", () => {
+    render(<Icon name="check" />);
+    expect(screen.getByText("check")).toHaveStyle({ fontSize: "24px" });
+  });
+
+  it("is aria-hidden by default (decorative)", () => {
+    render(<Icon name="star" />);
+    expect(screen.getByText("star")).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("uses aria-label and role=img when label provided", () => {
+    render(<Icon name="delete" aria-label="Delete item" />);
+    const el = screen.getByLabelText("Delete item");
+    expect(el).toHaveAttribute("role", "img");
+    expect(el).not.toHaveAttribute("aria-hidden");
+  });
+
+  it("merges custom className", () => {
+    render(<Icon name="add" className="text-primary" />);
+    expect(screen.getByText("add")).toHaveClass("text-primary");
+  });
+});

--- a/src/components/ui/media/icon/Icon.tsx
+++ b/src/components/ui/media/icon/Icon.tsx
@@ -1,0 +1,37 @@
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "Icon",
+  description:
+    "Renders a Material Symbols Rounded icon by name at a configurable pixel size.",
+};
+
+export interface IconProps {
+  /** Material Symbols Rounded icon name (e.g. "edit", "delete", "settings") */
+  name: string;
+  /** Icon size in pixels */
+  size?: number;
+  className?: string;
+  /** Accessible label. If omitted, icon is decorative (aria-hidden). */
+  "aria-label"?: string;
+}
+
+export function Icon({
+  name,
+  size = 24,
+  className,
+  "aria-label": ariaLabel,
+}: IconProps) {
+  return (
+    <span
+      className={cn("material-symbols-rounded select-none shrink-0", className)}
+      style={{ fontSize: size }}
+      aria-hidden={ariaLabel ? undefined : true}
+      aria-label={ariaLabel}
+      role={ariaLabel ? "img" : undefined}
+    >
+      {name}
+    </span>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { cn } from "./utils/cn";
+export { Icon, type IconProps } from "./components/ui/media/icon/Icon";
 export { isDev, isProd, isStorybook } from "./utils/env";
 export { Button, type ButtonProps } from "./components/ui/actions/button/Button";
 export {


### PR DESCRIPTION
## Summary
Material Symbols Rounded icon wrapper.

- Configurable `size` (default 24px)
- `aria-hidden` by default (decorative), `aria-label` + `role=img` when label provided
- `shrink-0` to prevent flex squishing
- Playground, Sizes, CommonIcons, WithColor stories
- 7 tests

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)