### PR TITLE
feat: add FloatingLabelInput component (#21)

### DIFF
--- a/src/components/ui/inputs/floating-label-input/FloatingLabelInput.stories.tsx
+++ b/src/components/ui/inputs/floating-label-input/FloatingLabelInput.stories.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { FloatingLabelInput } from "./FloatingLabelInput";
+
+const meta: Meta<typeof FloatingLabelInput> = {
+  title: "UI/Inputs/FloatingLabelInput",
+  component: FloatingLabelInput,
+  args: {
+    label: "Email",
+    id: "email",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof FloatingLabelInput>;
+
+export const Playground: Story = {};
+
+export const WithValue: Story = {
+  render: () => {
+    const [value, setValue] = useState("user@mirrorstack.ai");
+    return (
+      <FloatingLabelInput
+        label="Email"
+        id="email-filled"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
+  },
+};
+
+export const Password: Story = {
+  render: () => {
+    const [value, setValue] = useState("");
+    return (
+      <FloatingLabelInput
+        label="Password"
+        id="password"
+        type="password"
+        showPasswordToggle
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    label: "Email",
+    id: "email-error",
+    error: true,
+    helperText: "Please enter a valid email address",
+    value: "invalid",
+  },
+};
+
+export const Multiline: Story = {
+  render: () => {
+    const [value, setValue] = useState("");
+    return (
+      <FloatingLabelInput
+        label="Bio"
+        id="bio"
+        multiline
+        rows={4}
+        maxLength={160}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+    );
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: "Read only",
+    id: "disabled",
+    disabled: true,
+    value: "Cannot edit this",
+  },
+};
+
+export const WithHelperText: Story = {
+  args: {
+    label: "Username",
+    id: "username",
+    helperText: "3-20 characters, letters and numbers only",
+  },
+};

--- a/src/components/ui/inputs/floating-label-input/FloatingLabelInput.test.tsx
+++ b/src/components/ui/inputs/floating-label-input/FloatingLabelInput.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { FloatingLabelInput } from "./FloatingLabelInput";
+
+describe("FloatingLabelInput", () => {
+  it("renders with label", () => {
+    render(<FloatingLabelInput label="Email" id="email" />);
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+  });
+
+  it("renders as input by default", () => {
+    render(<FloatingLabelInput label="Name" id="name" />);
+    expect(screen.getByLabelText("Name").tagName).toBe("INPUT");
+  });
+
+  it("renders as textarea when multiline", () => {
+    render(<FloatingLabelInput label="Bio" id="bio" multiline />);
+    expect(screen.getByLabelText("Bio").tagName).toBe("TEXTAREA");
+  });
+
+  it("shows helper text", () => {
+    render(
+      <FloatingLabelInput label="Email" id="email" helperText="Required" />,
+    );
+    expect(screen.getByText("Required")).toBeInTheDocument();
+  });
+
+  it("shows error styling with helper text", () => {
+    render(
+      <FloatingLabelInput
+        label="Email"
+        id="email"
+        error
+        helperText="Invalid email"
+      />,
+    );
+    expect(screen.getByText("Invalid email")).toHaveClass("text-error");
+  });
+
+  it("toggles password visibility", async () => {
+    const user = userEvent.setup();
+    render(
+      <FloatingLabelInput
+        label="Password"
+        id="pw"
+        type="password"
+        showPasswordToggle
+        value="secret"
+        onChange={() => {}}
+      />,
+    );
+
+    const input = screen.getByLabelText("Password");
+    expect(input).toHaveAttribute("type", "password");
+
+    await user.click(screen.getByLabelText("Show password"));
+    expect(input).toHaveAttribute("type", "text");
+
+    await user.click(screen.getByLabelText("Hide password"));
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("shows character counter for multiline", () => {
+    render(
+      <FloatingLabelInput
+        label="Bio"
+        id="bio"
+        multiline
+        maxLength={160}
+        value="Hello"
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText("5/160")).toBeInTheDocument();
+  });
+
+  it("disables input when disabled", () => {
+    const { container } = render(
+      <FloatingLabelInput
+        label="Name"
+        id="name"
+        disabled
+        value=""
+        onChange={() => {}}
+      />,
+    );
+    const input = container.querySelector("input");
+    expect(input).toHaveAttribute("disabled");
+  });
+
+  it("calls onChange on user input", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    const { container } = render(
+      <FloatingLabelInput
+        label="Name"
+        id="name"
+        onChange={onChange}
+      />,
+    );
+    const input = container.querySelector("input")!;
+    await user.type(input, "a");
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/inputs/floating-label-input/FloatingLabelInput.tsx
+++ b/src/components/ui/inputs/floating-label-input/FloatingLabelInput.tsx
@@ -1,0 +1,200 @@
+import {
+  useState,
+  type InputHTMLAttributes,
+  type TextareaHTMLAttributes,
+} from "react";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+
+export const meta: ComponentMeta = {
+  name: "FloatingLabelInput",
+  description:
+    "Text input or textarea with floating label animation, password toggle, and character counter.",
+};
+
+type BaseProps = {
+  label: string;
+  containerClassName?: string;
+  error?: boolean;
+  helperText?: string;
+};
+
+type InputModeProps = BaseProps &
+  Omit<InputHTMLAttributes<HTMLInputElement>, "placeholder"> & {
+    multiline?: false;
+    showPasswordToggle?: boolean;
+    rows?: never;
+    maxLength?: number;
+  };
+
+type TextareaModeProps = BaseProps &
+  Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "placeholder"> & {
+    multiline: true;
+    showPasswordToggle?: never;
+    rows?: number;
+    maxLength?: number;
+  };
+
+export type FloatingLabelInputProps = InputModeProps | TextareaModeProps;
+
+export function FloatingLabelInput(props: FloatingLabelInputProps) {
+  const {
+    label,
+    id,
+    containerClassName,
+    className,
+    error = false,
+    helperText,
+    disabled,
+    multiline,
+    maxLength,
+  } = props;
+
+  const [focused, setFocused] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+
+  const showPasswordToggle =
+    !multiline && (props as InputModeProps).showPasswordToggle;
+  const type = !multiline
+    ? ((props as InputModeProps).type ?? "text")
+    : undefined;
+
+  const inputType =
+    showPasswordToggle && type === "password"
+      ? showPassword
+        ? "text"
+        : "password"
+      : type;
+
+  const value = props.value;
+  const charCount = typeof value === "string" ? value.length : 0;
+  const showCounter = multiline && maxLength != null;
+  const counterId = showCounter && id ? `${id}-counter` : undefined;
+
+  const userPlaceholder = (props as { placeholder?: string }).placeholder;
+  const hasValue = typeof value === "string" ? value.length > 0 : !!value;
+  const visiblePlaceholder =
+    focused && !hasValue && userPlaceholder ? userPlaceholder : " ";
+
+  const originalOnFocus = (props as { onFocus?: (e: React.FocusEvent) => void }).onFocus;
+  const originalOnBlur = (props as { onBlur?: (e: React.FocusEvent) => void }).onBlur;
+
+  const handleFocus = (e: React.FocusEvent) => {
+    setFocused(true);
+    originalOnFocus?.(e);
+  };
+  const handleBlur = (e: React.FocusEvent) => {
+    setFocused(false);
+    originalOnBlur?.(e);
+  };
+
+  const fieldClassName = cn(
+    "peer w-full rounded-lg px-4 bg-transparent border-0 outline-none",
+    "text-on-surface transition-colors disabled:cursor-not-allowed",
+    error ? "focus:text-error" : "focus:text-primary",
+    multiline
+      ? showCounter
+        ? "pt-3 pb-6 resize-none"
+        : "pt-3 pb-2 resize-none"
+      : "py-4",
+    !multiline && showPasswordToggle && type === "password" && "pr-12",
+    className,
+  );
+
+  const borderClassName = cn(
+    "relative flex border rounded-lg transition-colors bg-surface-container-low",
+    multiline ? "items-start" : "items-center",
+    error
+      ? "border-error hover:border-error focus-within:ring-2 focus-within:ring-error focus-within:border-error"
+      : "border-outline-variant hover:border-primary focus-within:ring-2 focus-within:ring-primary focus-within:border-primary",
+    disabled && "opacity-50 cursor-not-allowed hover:border-outline-variant",
+  );
+
+  const labelClassName = cn(
+    "absolute text-base z-10 font-normal left-4 top-4 px-1",
+    "bg-surface-container-low rounded-md transition-all duration-200 ease-in-out",
+    "origin-top-left pointer-events-none",
+    "peer-focus:scale-75 peer-focus:top-0 peer-focus:-translate-y-1/2 peer-focus:left-3",
+    "peer-[:not(:placeholder-shown)]:scale-75 peer-[:not(:placeholder-shown)]:top-0",
+    "peer-[:not(:placeholder-shown)]:-translate-y-1/2 peer-[:not(:placeholder-shown)]:left-3",
+    error
+      ? "text-error peer-focus:text-error"
+      : "text-on-surface-variant peer-focus:text-primary",
+  );
+
+  return (
+    <div className={cn("relative", containerClassName)}>
+      <div className={borderClassName}>
+        {multiline ? (
+          <textarea
+            id={id}
+            disabled={disabled}
+            maxLength={maxLength}
+            value={value as string}
+            onChange={(props as TextareaModeProps).onChange}
+            rows={(props as TextareaModeProps).rows}
+            className={fieldClassName}
+            placeholder={visiblePlaceholder}
+            aria-describedby={counterId}
+            onFocus={handleFocus as React.FocusEventHandler<HTMLTextAreaElement>}
+            onBlur={handleBlur as React.FocusEventHandler<HTMLTextAreaElement>}
+          />
+        ) : (
+          <input
+            id={id}
+            disabled={disabled}
+            maxLength={maxLength}
+            value={value as string}
+            onChange={(props as InputModeProps).onChange}
+            type={inputType}
+            className={fieldClassName}
+            placeholder={visiblePlaceholder}
+            onFocus={handleFocus as React.FocusEventHandler<HTMLInputElement>}
+            onBlur={handleBlur as React.FocusEventHandler<HTMLInputElement>}
+          />
+        )}
+        <label htmlFor={id} className={labelClassName}>
+          {label}
+        </label>
+        {showPasswordToggle && type === "password" && (
+          <IconButton
+            icon={showPassword ? "visibility_off" : "visibility"}
+            variant="text"
+            size="sm"
+            className="absolute right-2 text-on-surface-variant hover:text-primary"
+            onClick={() => setShowPassword(!showPassword)}
+            aria-label={showPassword ? "Hide password" : "Show password"}
+            tabIndex={-1}
+            type="button"
+          />
+        )}
+        {showCounter && (
+          <span
+            id={counterId}
+            aria-live="polite"
+            aria-atomic="true"
+            className={cn(
+              "absolute bottom-2 right-3 text-xs pointer-events-none",
+              maxLength && charCount > maxLength * 0.875
+                ? "text-error"
+                : "text-on-surface-variant",
+            )}
+          >
+            {charCount}/{maxLength}
+          </span>
+        )}
+      </div>
+      {helperText && (
+        <p
+          className={cn(
+            "text-xs mt-1 px-4",
+            error ? "text-error" : "text-on-surface-variant",
+          )}
+        >
+          {helperText}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,10 @@ export {
   type SnackbarAction,
 } from "./components/ui/feedback/snackbar/Snackbar";
 export {
+  FloatingLabelInput,
+  type FloatingLabelInputProps,
+} from "./components/ui/inputs/floating-label-input/FloatingLabelInput";
+export {
   SegmentedButton,
   type SegmentedButtonProps,
   type SegmentedButtonOption,


### PR DESCRIPTION
## Summary
Text input/textarea with floating label, password toggle, character counter.

- Input (default) and textarea (`multiline`) modes
- Password visibility toggle via IconButton
- Character counter (red at 87.5% capacity)
- Error state: red border + helper text
- 9 tests, 7 stories (Playground, WithValue, Password, Error, Multiline, Disabled, HelperText)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)