### PR TITLE
feat: add Surface component (#28)

### DIFF
--- a/src/components/ui/surfaces/surface/Surface.stories.tsx
+++ b/src/components/ui/surfaces/surface/Surface.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Surface } from "./Surface";
+import { Button } from "@/components/ui/actions/button/Button";
+
+const meta: Meta<typeof Surface> = {
+  title: "UI/Surfaces/Surface",
+  component: Surface,
+  args: {
+    className: "p-6",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Surface>;
+
+export const Playground: Story = {
+  args: {
+    children: "Surface container with default styling",
+  },
+};
+
+export const CardExample: Story = {
+  render: () => (
+    <Surface className="p-0 max-w-sm overflow-hidden">
+      <div className="aspect-video bg-surface-container" />
+      <div className="p-4">
+        <h3 className="text-base font-semibold text-on-surface">Card Title</h3>
+        <p className="text-sm text-on-surface-variant mt-1">
+          A brief description of the card content.
+        </p>
+        <div className="flex justify-end gap-2 mt-4">
+          <Button variant="text" size="sm">
+            Cancel
+          </Button>
+          <Button variant="filled" size="sm">
+            Action
+          </Button>
+        </div>
+      </div>
+    </Surface>
+  ),
+};
+
+export const Nested: Story = {
+  render: () => (
+    <Surface className="p-6">
+      <h3 className="text-base font-semibold text-on-surface mb-3">
+        Outer Surface
+      </h3>
+      <Surface className="p-4 bg-surface-container">
+        <p className="text-sm text-on-surface-variant">
+          Nested surface with higher elevation background
+        </p>
+      </Surface>
+    </Surface>
+  ),
+};

--- a/src/components/ui/surfaces/surface/Surface.tsx
+++ b/src/components/ui/surfaces/surface/Surface.tsx
@@ -1,0 +1,27 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "Surface",
+  description:
+    "Container with rounded corners, low-elevation background, and outline border",
+};
+
+export interface SurfaceProps extends HTMLAttributes<HTMLDivElement> {
+  children: ReactNode;
+}
+
+export function Surface({ children, className, ...props }: SurfaceProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-2xl bg-surface-container-low border border-outline-variant",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,3 +44,7 @@ export {
   type DevToolbarProps,
   type DevToolbarItem,
 } from "./components/ui/state/dev-toolbar/DevToolbar";
+export {
+  Surface,
+  type SurfaceProps,
+} from "./components/ui/surfaces/surface/Surface";


### PR DESCRIPTION
## Summary
- Container div with `rounded-2xl`, `bg-surface-container-low`, `border-outline-variant`
- Extends native `HTMLDivElement` attributes
- Stories: Playground, CardExample, Nested surfaces

Closes #28

## Test plan
- [x] `pnpm components validate` — pass
- [x] `pnpm typecheck` — clean
- [ ] Visual review in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)