### PR TITLE
feat: add Dialog component (#18)

### DIFF
--- a/src/components/ui/surfaces/dialog/Dialog.stories.tsx
+++ b/src/components/ui/surfaces/dialog/Dialog.stories.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Dialog } from "./Dialog";
+import { Button } from "@/components/ui/actions/button/Button";
+
+const meta: Meta<typeof Dialog> = {
+  title: "UI/Surfaces/Dialog",
+  component: Dialog,
+  args: {
+    open: true,
+    title: "Confirm action",
+    children: "Are you sure you want to proceed? This action cannot be undone.",
+  },
+  argTypes: {
+    open: { control: "boolean" },
+    title: { control: "text" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Dialog>;
+
+export const Playground: Story = {
+  args: {
+    actions: [
+      { label: "Cancel", onClick: () => {} },
+      { label: "Confirm", onClick: () => {}, variant: "filled" },
+    ],
+  },
+};
+
+export const WithActions: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open Dialog</Button>
+        <Dialog
+          open={open}
+          onClose={() => setOpen(false)}
+          title="Delete item?"
+          actions={[
+            { label: "Cancel", onClick: () => setOpen(false) },
+            {
+              label: "Delete",
+              onClick: () => setOpen(false),
+              variant: "filled",
+              color: "error",
+            },
+          ]}
+        >
+          <p className="text-on-surface-variant text-sm">
+            This will permanently delete the item. You cannot undo this action.
+          </p>
+        </Dialog>
+      </>
+    );
+  },
+};
+
+export const LoadingAction: Story = {
+  args: {
+    title: "Saving changes",
+    children: "Please wait while your changes are being saved...",
+    actions: [
+      { label: "Cancel", onClick: () => {}, disabled: true },
+      { label: "Saving...", onClick: () => {}, variant: "filled", loading: true },
+    ],
+  },
+};
+
+export const NoTitle: Story = {
+  args: {
+    title: undefined,
+    children: "A simple message dialog without a title heading.",
+    actions: [{ label: "OK", onClick: () => {}, variant: "filled" }],
+  },
+};

--- a/src/components/ui/surfaces/dialog/Dialog.test.tsx
+++ b/src/components/ui/surfaces/dialog/Dialog.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { Dialog } from "./Dialog";
+
+afterEach(cleanup);
+
+describe("Dialog", () => {
+  it("renders nothing when closed", () => {
+    render(<Dialog open={false} title="Test" />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders when open", () => {
+    render(<Dialog open title="Test Dialog" />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Test Dialog")).toBeInTheDocument();
+  });
+
+  it("calls onClose on backdrop click", () => {
+    const onClose = vi.fn();
+    const { container } = render(<Dialog open onClose={onClose} title="Test" />);
+    const backdrop = container.querySelector('[aria-hidden="true"]');
+    fireEvent.click(backdrop!);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose on Escape key", () => {
+    const onClose = vi.fn();
+    render(<Dialog open onClose={onClose} title="Test" />);
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("renders action buttons", () => {
+    const onClick = vi.fn();
+    render(
+      <Dialog
+        open
+        title="Test"
+        actions={[{ label: "Confirm", onClick }]}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: "Confirm" });
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it("renders children content", () => {
+    render(
+      <Dialog open title="Test">
+        <p>Dialog body</p>
+      </Dialog>,
+    );
+    expect(screen.getByText("Dialog body")).toBeInTheDocument();
+  });
+
+  it("has correct aria attributes", () => {
+    render(<Dialog open title="Accessible Dialog" />);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("aria-labelledby");
+  });
+});

--- a/src/components/ui/surfaces/dialog/Dialog.tsx
+++ b/src/components/ui/surfaces/dialog/Dialog.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useRef, useId, type ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { Button, type ButtonProps } from "@/components/ui/actions/button/Button";
+
+export const meta: ComponentMeta = {
+  name: "Dialog",
+  description:
+    "Modal dialog with backdrop, focus trap, scroll locking, and declarative action buttons",
+};
+
+export interface DialogAction {
+  label: string;
+  onClick: () => void;
+  variant?: ButtonProps["variant"];
+  color?: ButtonProps["color"];
+  loading?: boolean;
+  disabled?: boolean;
+}
+
+export interface DialogProps {
+  open: boolean;
+  onClose?: () => void;
+  title?: string;
+  children?: ReactNode;
+  actions?: DialogAction[];
+  className?: string;
+}
+
+let scrollLockCount = 0;
+
+function lockScroll() {
+  if (typeof document === "undefined") return;
+  scrollLockCount++;
+  if (scrollLockCount === 1) document.body.style.overflow = "hidden";
+}
+
+function unlockScroll() {
+  if (typeof document === "undefined") return;
+  scrollLockCount = Math.max(0, scrollLockCount - 1);
+  if (scrollLockCount === 0) document.body.style.overflow = "";
+}
+
+export function Dialog({
+  open,
+  onClose,
+  title,
+  children,
+  actions,
+  className,
+}: DialogProps) {
+  const titleId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<Element | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      triggerRef.current = document.activeElement;
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    lockScroll();
+    return unlockScroll;
+  }, [open]);
+
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    if (!open) return;
+
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    dialog.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onCloseRef.current?.();
+        return;
+      }
+
+      if (e.key !== "Tab") return;
+
+      const focusable = dialog.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) {
+        e.preventDefault();
+        dialog.focus();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (open) return;
+    if (triggerRef.current instanceof HTMLElement) {
+      triggerRef.current.focus();
+      triggerRef.current = null;
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div
+        aria-hidden="true"
+        className="!m-0 fixed inset-0 z-50 bg-black/50"
+        onClick={() => onClose?.()}
+      />
+      <div className="!m-0 fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
+        <div
+          ref={dialogRef}
+          tabIndex={-1}
+          className={cn(
+            "bg-surface rounded-2xl p-6 max-w-sm w-full mx-4 shadow-xl outline-none pointer-events-auto max-h-[90vh] overflow-y-auto",
+            className,
+          )}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={title ? titleId : undefined}
+        >
+          {title && (
+            <h3
+              id={titleId}
+              className="text-lg font-semibold text-on-surface mb-4"
+            >
+              {title}
+            </h3>
+          )}
+
+          {children}
+
+          {actions && actions.length > 0 && (
+            <div className="flex justify-end gap-3 mt-4">
+              {actions.map((action, i) => (
+                <Button
+                  key={`${i}-${action.label}`}
+                  variant={action.variant ?? "text"}
+                  color={action.color}
+                  onClick={action.onClick}
+                  loading={action.loading}
+                  disabled={action.disabled}
+                >
+                  {action.label}
+                </Button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export {
   type DialogProps,
   type DialogAction,
 } from "./components/ui/surfaces/dialog/Dialog";
+export {
   Surface,
   type SurfaceProps,
 } from "./components/ui/surfaces/surface/Surface";

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,3 +44,8 @@ export {
   type DevToolbarProps,
   type DevToolbarItem,
 } from "./components/ui/state/dev-toolbar/DevToolbar";
+export {
+  Dialog,
+  type DialogProps,
+  type DialogAction,
+} from "./components/ui/surfaces/dialog/Dialog";


### PR DESCRIPTION
## Summary
- Modal with backdrop click + Escape to close
- Ref-counted scroll locking for nested dialogs
- Full focus trap (Tab/Shift+Tab cycle)
- Declarative `actions` array with variant, color, loading, disabled
- Stories: Playground, WithActions (interactive), LoadingAction, NoTitle

Closes #18

## Test plan
- [x] `pnpm components validate` — pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 7 tests pass
- [ ] Visual review in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)