### PR TITLE
feat: add Alert component (#14)

### DIFF
--- a/src/components/ui/feedback/alert/Alert.stories.tsx
+++ b/src/components/ui/feedback/alert/Alert.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Alert, type AlertVariant } from "./Alert";
+
+const meta: Meta<typeof Alert> = {
+  title: "UI/Feedback/Alert",
+  component: Alert,
+  args: {
+    variant: "info",
+    children: "This is an informational alert message.",
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["error", "success", "warning", "info"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Alert>;
+
+export const Playground: Story = {};
+
+export const Variants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      {(["info", "success", "warning", "error"] as AlertVariant[]).map((v) => (
+        <Alert key={v} variant={v}>
+          This is a {v} alert message.
+        </Alert>
+      ))}
+    </div>
+  ),
+};
+
+export const WithTitle: Story = {
+  args: {
+    variant: "error",
+    title: "Something went wrong",
+    children: "Please try again or contact support if the issue persists.",
+  },
+};
+
+export const Dismissible: Story = {
+  args: {
+    variant: "warning",
+    title: "Connection unstable",
+    children: "Some features may not work correctly.",
+    onDismiss: () => {},
+  },
+};

--- a/src/components/ui/feedback/alert/Alert.test.tsx
+++ b/src/components/ui/feedback/alert/Alert.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { Alert } from "./Alert";
+
+afterEach(cleanup);
+
+describe("Alert", () => {
+  it("renders with role=alert", () => {
+    render(<Alert variant="info">Test message</Alert>);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("Test message")).toBeInTheDocument();
+  });
+
+  it("renders the correct variant icon", () => {
+    render(<Alert variant="error">Error</Alert>);
+    expect(screen.getByText("error")).toBeInTheDocument();
+  });
+
+  it("renders title when provided", () => {
+    render(
+      <Alert variant="success" title="Success!">
+        Done
+      </Alert>,
+    );
+    expect(screen.getByText("Success!")).toBeInTheDocument();
+  });
+
+  it("shows dismiss button when onDismiss provided", () => {
+    const onDismiss = vi.fn();
+    render(
+      <Alert variant="warning" onDismiss={onDismiss}>
+        Warning
+      </Alert>,
+    );
+    const btn = screen.getByLabelText("Dismiss");
+    fireEvent.click(btn);
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("does not show dismiss button without onDismiss", () => {
+    render(<Alert variant="info">Info</Alert>);
+    expect(screen.queryByLabelText("Dismiss")).not.toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    render(
+      <Alert variant="info" className="mt-4">
+        Test
+      </Alert>,
+    );
+    expect(screen.getByRole("alert")).toHaveClass("mt-4");
+  });
+});

--- a/src/components/ui/feedback/alert/Alert.tsx
+++ b/src/components/ui/feedback/alert/Alert.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { Icon } from "@/components/ui/media/icon/Icon";
+import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+
+export const meta: ComponentMeta = {
+  name: "Alert",
+  description:
+    "Dismissible inline alert banner with error/success/warning/info variants",
+};
+
+export type AlertVariant = "error" | "success" | "warning" | "info";
+
+export interface AlertProps {
+  variant: AlertVariant;
+  title?: string;
+  children: ReactNode;
+  className?: string;
+  onDismiss?: () => void;
+}
+
+const variantStyles: Record<AlertVariant, string> = {
+  error: "bg-error/10 border-error/30 text-error",
+  success: "bg-success/10 border-success/30 text-success",
+  warning: "bg-warning/10 border-warning/30 text-warning",
+  info: "bg-info/10 border-info/30 text-info",
+};
+
+const variantIcons: Record<AlertVariant, string> = {
+  error: "error",
+  success: "check_circle",
+  warning: "warning",
+  info: "info",
+};
+
+export function Alert({
+  variant,
+  title,
+  children,
+  className,
+  onDismiss,
+}: AlertProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border px-4 py-3",
+        variantStyles[variant],
+        className,
+      )}
+      role="alert"
+    >
+      <div className="flex items-center">
+        <Icon
+          name={variantIcons[variant]}
+          size={20}
+          className="shrink-0"
+        />
+        <div className="ml-3 flex-1">
+          {title && <h3 className="text-sm font-medium">{title}</h3>}
+          <div className={cn("text-sm", title && "mt-1")}>{children}</div>
+        </div>
+        {onDismiss && (
+          <IconButton
+            icon="close"
+            variant="text"
+            size="sm"
+            className="-my-1 ml-auto text-current"
+            onClick={onDismiss}
+            aria-label="Dismiss"
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,3 +44,8 @@ export {
   type DevToolbarProps,
   type DevToolbarItem,
 } from "./components/ui/state/dev-toolbar/DevToolbar";
+export {
+  Alert,
+  type AlertProps,
+  type AlertVariant,
+} from "./components/ui/feedback/alert/Alert";


### PR DESCRIPTION
## Summary
- Inline alert banner with `error`/`success`/`warning`/`info` variants
- Uses `<Icon>` for variant icons, `<IconButton>` for dismiss
- Optional title heading, `role="alert"` for screen readers
- Stories: Playground, Variants, WithTitle, Dismissible

Closes #14

## Test plan
- [x] `pnpm components validate` — pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 6 tests pass
- [ ] Visual review in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)