### PR TITLE
feat: add Avatar component (#15)

### DIFF
--- a/src/components/ui/media/avatar/Avatar.stories.tsx
+++ b/src/components/ui/media/avatar/Avatar.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Avatar, type AvatarSize } from "./Avatar";
+import { Progress } from "@/components/ui/feedback/progress/Progress";
+
+const meta: Meta<typeof Avatar> = {
+  title: "UI/Media/Avatar",
+  component: Avatar,
+  args: {
+    fallback: "A",
+    size: "lg",
+  },
+  argTypes: {
+    size: { control: "select", options: ["sm", "md", "lg", "xl"] },
+    fallback: { control: "text" },
+    src: { control: "text" },
+    editable: { control: "boolean" },
+    square: { control: "boolean" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Avatar>;
+
+export const Playground: Story = {};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      {(["sm", "md", "lg", "xl"] as AvatarSize[]).map((size) => (
+        <Avatar key={size} size={size} fallback="M" />
+      ))}
+    </div>
+  ),
+};
+
+export const WithImage: Story = {
+  args: {
+    src: "https://i.pravatar.cc/150?img=12",
+    size: "xl",
+  },
+};
+
+export const Editable: Story = {
+  args: {
+    size: "xl",
+    editable: true,
+    fallback: "J",
+    onFileSelect: (file) => console.log("Selected:", file.name),
+  },
+};
+
+export const Square: Story = {
+  args: {
+    square: true,
+    size: "xl",
+    fallback: "S",
+  },
+};
+
+export const WithOverlay: Story = {
+  args: {
+    size: "xl",
+    editable: true,
+    overlay: <Progress type="circular" variant="wave" size="sm" color="current" className="text-white" />,
+  },
+};

--- a/src/components/ui/media/avatar/Avatar.test.tsx
+++ b/src/components/ui/media/avatar/Avatar.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { Avatar } from "./Avatar";
+
+afterEach(cleanup);
+
+describe("Avatar", () => {
+  it("renders initials fallback when no src", () => {
+    render(<Avatar fallback="John" />);
+    expect(screen.getByText("J")).toBeInTheDocument();
+  });
+
+  it("renders image when src provided", () => {
+    const { container } = render(<Avatar src="https://example.com/photo.jpg" />);
+    const img = container.querySelector("img");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "https://example.com/photo.jpg");
+  });
+
+  it("defaults to U when no fallback", () => {
+    render(<Avatar />);
+    expect(screen.getByText("U")).toBeInTheDocument();
+  });
+
+  it("shows edit badge when editable", () => {
+    render(<Avatar editable />);
+    expect(screen.getByText("edit")).toBeInTheDocument();
+  });
+
+  it("triggers file input on click when editable", () => {
+    const onFileSelect = vi.fn();
+    const { container } = render(<Avatar editable onFileSelect={onFileSelect} />);
+    const button = container.querySelector("button");
+    fireEvent.click(button!);
+    const input = container.querySelector('input[type="file"]');
+    expect(input).toBeInTheDocument();
+  });
+
+  it("applies square shape when square prop set", () => {
+    const { container } = render(<Avatar square fallback="S" />);
+    const inner = container.querySelector(".rounded-2xl");
+    expect(inner).toBeInTheDocument();
+  });
+
+  it("renders overlay when provided", () => {
+    render(<Avatar editable overlay={<span data-testid="spinner" />} />);
+    expect(screen.getByTestId("spinner")).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/media/avatar/Avatar.tsx
+++ b/src/components/ui/media/avatar/Avatar.tsx
@@ -1,0 +1,127 @@
+import { useRef, type ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { Icon } from "@/components/ui/media/icon/Icon";
+
+export const meta: ComponentMeta = {
+  name: "Avatar",
+  description:
+    "User avatar with image, initials fallback, optional edit badge, and file-upload support",
+};
+
+export type AvatarSize = "sm" | "md" | "lg" | "xl";
+
+const sizeMap: Record<
+  AvatarSize,
+  { container: string; text: string; badge: string; badgeIcon: number }
+> = {
+  sm: { container: "w-8 h-8", text: "text-xs", badge: "w-5 h-5", badgeIcon: 12 },
+  md: { container: "w-10 h-10", text: "text-sm", badge: "w-6 h-6", badgeIcon: 12 },
+  lg: { container: "w-16 h-16", text: "text-xl", badge: "w-6 h-6", badgeIcon: 14 },
+  xl: { container: "w-20 h-20", text: "text-2xl", badge: "w-7 h-7", badgeIcon: 14 },
+};
+
+export interface AvatarProps {
+  src?: string | null;
+  fallback?: string;
+  size?: AvatarSize;
+  editable?: boolean;
+  onFileSelect?: (file: File) => void;
+  accept?: string;
+  square?: boolean;
+  overlay?: ReactNode;
+  className?: string;
+}
+
+export function Avatar({
+  src,
+  fallback = "U",
+  size = "md",
+  editable = false,
+  onFileSelect,
+  accept = "image/jpeg,image/png,image/gif,image/webp",
+  square = false,
+  overlay,
+  className,
+}: AvatarProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const s = sizeMap[size];
+  const initial = fallback.charAt(0).toUpperCase();
+  const radius = square ? "rounded-2xl rounded-br-3xl" : "rounded-full";
+
+  const handleClick = () => {
+    if (editable) fileInputRef.current?.click();
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) onFileSelect?.(file);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const avatarContent = src ? (
+    <img
+      src={src}
+      alt=""
+      className={cn(s.container, radius, "object-cover border-2 border-primary")}
+    />
+  ) : (
+    <div
+      className={cn(
+        s.container,
+        radius,
+        "bg-primary/20 flex items-center justify-center border-2 border-primary",
+      )}
+    >
+      <span className={cn("font-bold text-primary", s.text)}>{initial}</span>
+    </div>
+  );
+
+  return (
+    <div className={cn("relative inline-flex shrink-0", className)}>
+      {editable ? (
+        <button
+          type="button"
+          onClick={handleClick}
+          className={cn(
+            "relative cursor-pointer p-1 -m-1 hover:bg-surface-container transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary",
+            radius,
+          )}
+        >
+          {avatarContent}
+          {overlay ? (
+            <div
+              className={cn(
+                "absolute inset-1 bg-black/40 flex items-center justify-center",
+                radius,
+              )}
+            >
+              {overlay}
+            </div>
+          ) : (
+            <div
+              className={cn(
+                s.badge,
+                "absolute bottom-0.5 right-0.5 rounded-full bg-primary flex items-center justify-center shadow-md border-2 border-surface-container-low",
+              )}
+            >
+              <Icon name="edit" size={s.badgeIcon} className="text-on-primary" />
+            </div>
+          )}
+        </button>
+      ) : (
+        avatarContent
+      )}
+
+      {editable && (
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept={accept}
+          onChange={handleChange}
+          className="hidden"
+        />
+      )}
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,3 +44,8 @@ export {
   type DevToolbarProps,
   type DevToolbarItem,
 } from "./components/ui/state/dev-toolbar/DevToolbar";
+export {
+  Avatar,
+  type AvatarProps,
+  type AvatarSize,
+} from "./components/ui/media/avatar/Avatar";


### PR DESCRIPTION
## Summary
- Image avatar with initials fallback (first char of `fallback` prop)
- Sizes: sm (32px), md (40px), lg (64px), xl (80px)
- Editable mode: edit badge, click-to-upload with hidden file input
- Square shape variant, overlay support (e.g. loading spinner)
- Uses `<Icon>` for edit badge
- Stories: Playground, Sizes, WithImage, Editable, Square, WithOverlay

Closes #15

## Test plan
- [x] `pnpm components validate` — pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 7 tests pass
- [ ] Visual review in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)