### PR TITLE
feat: add ActivityList component (#33)

### DIFF
--- a/src/components/ui/data/activity-list/ActivityList.stories.tsx
+++ b/src/components/ui/data/activity-list/ActivityList.stories.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ActivityList, type ActivityItem } from "./ActivityList";
+
+const sampleItems: ActivityItem[] = [
+  { id: "1", icon: "login", label: "Signed in from Chrome on macOS", timestamp: "2 min ago" },
+  { id: "2", icon: "key", label: "Registered a new passkey", timestamp: "1 hour ago" },
+  { id: "3", icon: "edit", label: "Updated profile picture", timestamp: "3 hours ago" },
+  { id: "4", icon: "security", label: "Changed password", timestamp: "Yesterday" },
+  { id: "5", icon: "devices", label: "Revoked session on Firefox", timestamp: "2 days ago" },
+];
+
+const meta: Meta<typeof ActivityList> = {
+  title: "UI/Data/ActivityList",
+  component: ActivityList,
+  args: {
+    items: sampleItems,
+  },
+  argTypes: {
+    loading: { control: "boolean" },
+    hasMore: { control: "boolean" },
+    loadingMore: { control: "boolean" },
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-lg">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ActivityList>;
+
+export const Playground: Story = {};
+
+export const Loading: Story = {
+  args: { items: [], loading: true },
+};
+
+export const Empty: Story = {
+  args: { items: [] },
+};
+
+export const WithLoadMore: Story = {
+  render: () => {
+    const [items, setItems] = useState(sampleItems.slice(0, 3));
+    const [loadingMore, setLoadingMore] = useState(false);
+
+    const handleLoadMore = () => {
+      setLoadingMore(true);
+      setTimeout(() => {
+        setItems(sampleItems);
+        setLoadingMore(false);
+      }, 1000);
+    };
+
+    return (
+      <ActivityList
+        items={items}
+        hasMore={items.length < sampleItems.length}
+        loadingMore={loadingMore}
+        onLoadMore={handleLoadMore}
+      />
+    );
+  },
+};

--- a/src/components/ui/data/activity-list/ActivityList.test.tsx
+++ b/src/components/ui/data/activity-list/ActivityList.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { ActivityList } from "./ActivityList";
+
+afterEach(cleanup);
+
+const items = [
+  { id: "1", icon: "login", label: "Signed in", timestamp: "2 min ago" },
+  { id: "2", icon: "key", label: "Added passkey", timestamp: "1 hour ago" },
+];
+
+describe("ActivityList", () => {
+  it("renders items", () => {
+    render(<ActivityList items={items} />);
+    expect(screen.getByText("Signed in")).toBeInTheDocument();
+    expect(screen.getByText("Added passkey")).toBeInTheDocument();
+    expect(screen.getByText("2 min ago")).toBeInTheDocument();
+  });
+
+  it("shows loading spinner", () => {
+    const { container } = render(<ActivityList items={[]} loading />);
+    expect(container.querySelector("[role='progressbar']")).toBeInTheDocument();
+  });
+
+  it("shows empty message when no items", () => {
+    render(<ActivityList items={[]} />);
+    expect(screen.getByText("No activity recorded yet.")).toBeInTheDocument();
+  });
+
+  it("shows custom empty message", () => {
+    render(<ActivityList items={[]} emptyMessage="Nothing here" />);
+    expect(screen.getByText("Nothing here")).toBeInTheDocument();
+  });
+
+  it("shows load more button when hasMore and onLoadMore", () => {
+    const onLoadMore = vi.fn();
+    render(<ActivityList items={items} hasMore onLoadMore={onLoadMore} />);
+    const btn = screen.getByRole("button", { name: "Load more" });
+    fireEvent.click(btn);
+    expect(onLoadMore).toHaveBeenCalledOnce();
+  });
+
+  it("hides load more when hasMore is false", () => {
+    render(<ActivityList items={items} onLoadMore={() => {}} />);
+    expect(screen.queryByRole("button", { name: "Load more" })).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ui/data/activity-list/ActivityList.tsx
+++ b/src/components/ui/data/activity-list/ActivityList.tsx
@@ -39,7 +39,7 @@ export function ActivityList({
   if (loading) {
     return (
       <div className={cn("py-8 text-center", className)}>
-        <Progress type="circular" size="sm" />
+        <Progress type="circular" size="md" />
       </div>
     );
   }

--- a/src/components/ui/data/activity-list/ActivityList.tsx
+++ b/src/components/ui/data/activity-list/ActivityList.tsx
@@ -1,0 +1,90 @@
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { Button } from "@/components/ui/actions/button/Button";
+import { Icon } from "@/components/ui/media/icon/Icon";
+import { Progress } from "@/components/ui/feedback/progress/Progress";
+
+export const meta: ComponentMeta = {
+  name: "ActivityList",
+  description:
+    "Vertical list of activity/event items with loading, empty, and load-more states",
+};
+
+export interface ActivityItem {
+  id: string;
+  icon: string;
+  label: string;
+  timestamp: string;
+}
+
+export interface ActivityListProps {
+  items: ActivityItem[];
+  loading?: boolean;
+  hasMore?: boolean;
+  loadingMore?: boolean;
+  onLoadMore?: () => void;
+  emptyMessage?: string;
+  className?: string;
+}
+
+export function ActivityList({
+  items,
+  loading = false,
+  hasMore = false,
+  loadingMore = false,
+  onLoadMore,
+  emptyMessage = "No activity recorded yet.",
+  className,
+}: ActivityListProps) {
+  if (loading) {
+    return (
+      <div className={cn("py-8 text-center", className)}>
+        <Progress type="circular" size="lg" />
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <p
+        className={cn(
+          "text-sm text-on-surface-variant text-center py-8",
+          className,
+        )}
+      >
+        {emptyMessage}
+      </p>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-1", className)}>
+      {items.map((item) => (
+          <div
+            key={item.id}
+            className="flex items-center gap-3 px-3 py-2 rounded-lg bg-surface-container"
+          >
+            <Icon
+              name={item.icon}
+              size={20}
+              className="text-on-surface-variant shrink-0"
+            />
+            <span className="text-sm font-medium text-on-surface">
+              {item.label}
+            </span>
+            <span className="text-xs text-on-surface-variant ml-auto shrink-0">
+              {item.timestamp}
+            </span>
+          </div>
+      ))}
+
+      {hasMore && onLoadMore && (
+        <div className="mt-3 text-center">
+          <Button variant="text" onClick={onLoadMore} loading={loadingMore}>
+            Load more
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/data/activity-list/ActivityList.tsx
+++ b/src/components/ui/data/activity-list/ActivityList.tsx
@@ -39,7 +39,7 @@ export function ActivityList({
   if (loading) {
     return (
       <div className={cn("py-8 text-center", className)}>
-        <Progress type="circular" size="lg" />
+        <Progress type="circular" size="sm" />
       </div>
     );
   }
@@ -80,7 +80,7 @@ export function ActivityList({
 
       {hasMore && onLoadMore && (
         <div className="mt-3 text-center">
-          <Button variant="text" onClick={onLoadMore} loading={loadingMore}>
+          <Button variant="text" size="sm" onClick={onLoadMore} loading={loadingMore}>
             Load more
           </Button>
         </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,3 +96,8 @@ export {
   ReadOnlyField,
   type ReadOnlyFieldProps,
 } from "./components/ui/data/read-only-field/ReadOnlyField";
+export {
+  ActivityList,
+  type ActivityListProps,
+  type ActivityItem,
+} from "./components/ui/data/activity-list/ActivityList";


### PR DESCRIPTION
## Summary
- Renders activity items with icon, label, and timestamp
- Loading state with circular Progress spinner
- Empty state with configurable message
- "Load more" button when `hasMore` and `onLoadMore` provided
- Uses `<Icon>`, `<Button>`, `<Progress>` from the kit
- Stories: Playground, Loading, Empty, WithLoadMore (interactive)

Closes #33

## Test plan
- [x] `pnpm components validate` — 22 components pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 6 tests pass
- [ ] Visual review in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)