### PR TITLE
feat: add ThemeProvider and SidebarProvider contexts (#26)

### DIFF
--- a/src/context/sidebar/SidebarProvider.test.tsx
+++ b/src/context/sidebar/SidebarProvider.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, expect, it, afterEach } from "vitest";
+import { SidebarProvider, useSidebarWidth } from "./SidebarProvider";
+
+afterEach(cleanup);
+
+function TestConsumer() {
+  const { sidebarWidth, setSidebarWidth } = useSidebarWidth();
+  return (
+    <div>
+      <span data-testid="width">{sidebarWidth}</span>
+      <button onClick={() => setSidebarWidth(500)}>Resize</button>
+    </div>
+  );
+}
+
+describe("SidebarProvider", () => {
+  it("provides default width", () => {
+    render(
+      <SidebarProvider>
+        <TestConsumer />
+      </SidebarProvider>,
+    );
+    expect(screen.getByTestId("width").textContent).toBe("350");
+  });
+
+  it("accepts custom default width", () => {
+    render(
+      <SidebarProvider defaultWidth={400}>
+        <TestConsumer />
+      </SidebarProvider>,
+    );
+    expect(screen.getByTestId("width").textContent).toBe("400");
+  });
+
+  it("updates width", () => {
+    render(
+      <SidebarProvider>
+        <TestConsumer />
+      </SidebarProvider>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText("Resize"));
+    });
+    expect(screen.getByTestId("width").textContent).toBe("500");
+  });
+
+  it("throws when used outside provider", () => {
+    expect(() => render(<TestConsumer />)).toThrow(
+      "useSidebarWidth must be used within a SidebarProvider",
+    );
+  });
+});

--- a/src/context/sidebar/SidebarProvider.tsx
+++ b/src/context/sidebar/SidebarProvider.tsx
@@ -1,0 +1,34 @@
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+export interface SidebarContextType {
+  sidebarWidth: number;
+  setSidebarWidth: (width: number) => void;
+}
+
+const SidebarContext = createContext<SidebarContextType | undefined>(undefined);
+
+export interface SidebarProviderProps {
+  children: ReactNode;
+  defaultWidth?: number;
+}
+
+export function SidebarProvider({
+  children,
+  defaultWidth = 350,
+}: SidebarProviderProps) {
+  const [sidebarWidth, setSidebarWidth] = useState(defaultWidth);
+
+  return (
+    <SidebarContext.Provider value={{ sidebarWidth, setSidebarWidth }}>
+      {children}
+    </SidebarContext.Provider>
+  );
+}
+
+export function useSidebarWidth() {
+  const context = useContext(SidebarContext);
+  if (context === undefined) {
+    throw new Error("useSidebarWidth must be used within a SidebarProvider");
+  }
+  return context;
+}

--- a/src/context/theme/ThemeProvider.test.tsx
+++ b/src/context/theme/ThemeProvider.test.tsx
@@ -1,0 +1,79 @@
+import { cleanup, render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
+import { ThemeProvider, useTheme } from "./ThemeProvider";
+
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+afterEach(cleanup);
+
+function TestConsumer() {
+  const { theme, resolvedTheme, setTheme } = useTheme();
+  return (
+    <div>
+      <span data-testid="theme">{theme}</span>
+      <span data-testid="resolved">{resolvedTheme}</span>
+      <button onClick={() => setTheme("dark")}>Set Dark</button>
+      <button onClick={() => setTheme("light")}>Set Light</button>
+      <button onClick={() => setTheme("auto")}>Set Auto</button>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.classList.remove("dark");
+});
+
+describe("ThemeProvider", () => {
+  it("defaults to auto theme", () => {
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("theme").textContent).toBe("auto");
+  });
+
+  it("sets theme and persists to localStorage", () => {
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText("Set Dark"));
+    });
+    expect(screen.getByTestId("theme").textContent).toBe("dark");
+    expect(screen.getByTestId("resolved").textContent).toBe("dark");
+    expect(localStorage.getItem("theme")).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("reads from localStorage on mount", () => {
+    localStorage.setItem("theme", "dark");
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("theme").textContent).toBe("dark");
+  });
+
+  it("throws when useTheme used outside provider", () => {
+    expect(() => render(<TestConsumer />)).toThrow(
+      "useTheme must be used within a ThemeProvider",
+    );
+  });
+});

--- a/src/context/theme/ThemeProvider.tsx
+++ b/src/context/theme/ThemeProvider.tsx
@@ -1,0 +1,115 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+export type Theme = "auto" | "light" | "dark";
+
+export interface ThemeContextType {
+  theme: Theme;
+  resolvedTheme: "light" | "dark";
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+const STORAGE_KEY = "theme";
+
+function getMediaDark() {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+function applyClass(resolved: "light" | "dark") {
+  document.documentElement.classList.toggle("dark", resolved === "dark");
+}
+
+function resolve(theme: Theme): "light" | "dark" {
+  if (theme === "auto") return getMediaDark() ? "dark" : "light";
+  return theme;
+}
+
+function normalize(raw: string | null | undefined): Theme {
+  if (raw === "system") return "auto";
+  if (raw === "light" || raw === "dark" || raw === "auto") return raw;
+  return "auto";
+}
+
+export interface ThemeProviderProps {
+  children: ReactNode;
+  /** API base URL for fetching user theme preference. If omitted, no API sync. */
+  apiBaseUrl?: string;
+}
+
+export function ThemeProvider({ children, apiBaseUrl }: ThemeProviderProps) {
+  const [theme, setThemeState] = useState<Theme>("auto");
+  const [resolvedTheme, setResolvedTheme] = useState<"light" | "dark">("light");
+
+  const setTheme = useCallback((next: Theme) => {
+    setThemeState(next);
+    localStorage.setItem(STORAGE_KEY, next);
+    const resolved = resolve(next);
+    setResolvedTheme(resolved);
+    applyClass(resolved);
+  }, []);
+
+  useEffect(() => {
+    const stored = normalize(localStorage.getItem(STORAGE_KEY));
+    setThemeState(stored);
+    const resolved = resolve(stored);
+    setResolvedTheme(resolved);
+    applyClass(resolved);
+
+    if (!apiBaseUrl) return;
+
+    fetch(`${apiBaseUrl}/v1/auth/me/preferences`, { credentials: "include" })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!data?.theme) return;
+        const apiTheme = normalize(data.theme);
+        const localTheme = normalize(localStorage.getItem(STORAGE_KEY));
+        if (apiTheme !== localTheme) {
+          localStorage.setItem(STORAGE_KEY, apiTheme);
+          setThemeState(apiTheme);
+          const r = resolve(apiTheme);
+          setResolvedTheme(r);
+          applyClass(r);
+        }
+      })
+      .catch(() => {});
+  }, [apiBaseUrl]);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => {
+      if (normalize(localStorage.getItem(STORAGE_KEY)) === "auto") {
+        const resolved = mq.matches ? "dark" : "light";
+        setResolvedTheme(resolved);
+        applyClass(resolved);
+      }
+    };
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  const value = useMemo(
+    () => ({ theme, resolvedTheme, setTheme }),
+    [theme, resolvedTheme, setTheme],
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,3 +96,15 @@ export {
   ReadOnlyField,
   type ReadOnlyFieldProps,
 } from "./components/ui/data/read-only-field/ReadOnlyField";
+export {
+  ThemeProvider,
+  useTheme,
+  type ThemeProviderProps,
+  type ThemeContextType,
+} from "./context/theme/ThemeProvider";
+export {
+  SidebarProvider,
+  useSidebarWidth,
+  type SidebarProviderProps,
+  type SidebarContextType,
+} from "./context/sidebar/SidebarProvider";


### PR DESCRIPTION
## Summary
- **ThemeProvider**: manages `auto`/`light`/`dark` with `.dark` class on `<html>`, localStorage persistence, optional API sync (`/v1/auth/me/preferences`), OS `prefers-color-scheme` listener
- **SidebarProvider**: manages sidebar width state with configurable default
- Both export context hooks: `useTheme()`, `useSidebarWidth()`

Closes #26

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 8 tests pass (4 ThemeProvider + 4 SidebarProvider)

🤖 Generated with [Claude Code](https://claude.com/claude-code)