### PR TITLE
feat: add ReauthDialog component (#32)

### DIFF
--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.stories.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.stories.tsx
@@ -24,10 +24,14 @@ export const Playground: Story = {
             console.log("Reauth token:", token);
             setOpen(false);
           }}
-          onPasswordVerify={async (pw) => {
+          onEmailSendCode={async () => {
             await new Promise((r) => setTimeout(r, 1000));
-            if (pw === "password") return "mock-reauth-token";
-            throw new Error("Incorrect password");
+            return "challenge-123";
+          }}
+          onEmailVerifyCode={async (_challengeId, code) => {
+            await new Promise((r) => setTimeout(r, 1000));
+            if (code === "123456") return "mock-reauth-token";
+            throw new Error("Invalid verification code");
           }}
           onPasskeyVerify={async () => {
             await new Promise((r) => setTimeout(r, 1000));
@@ -39,7 +43,7 @@ export const Playground: Story = {
   },
 };
 
-export const PasswordOnly: Story = {
+export const EmailOnly: Story = {
   render: () => {
     const [open, setOpen] = useState(false);
     return (
@@ -49,11 +53,15 @@ export const PasswordOnly: Story = {
           open={open}
           onClose={() => setOpen(false)}
           onSuccess={() => setOpen(false)}
-          methods={["password"]}
-          onPasswordVerify={async (pw) => {
+          methods={["email"]}
+          onEmailSendCode={async () => {
             await new Promise((r) => setTimeout(r, 500));
-            if (pw === "password") return "token";
-            throw new Error("Incorrect password");
+            return "challenge-456";
+          }}
+          onEmailVerifyCode={async (_id, code) => {
+            await new Promise((r) => setTimeout(r, 500));
+            if (code === "123456") return "token";
+            throw new Error("Invalid code");
           }}
         />
       </>

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.stories.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.stories.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ReauthDialog } from "./ReauthDialog";
+import { Button } from "@/components/ui/actions/button/Button";
+
+const meta: Meta<typeof ReauthDialog> = {
+  title: "UI/Surfaces/ReauthDialog",
+  component: ReauthDialog,
+};
+
+export default meta;
+type Story = StoryObj<typeof ReauthDialog>;
+
+export const Playground: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Delete Account</Button>
+        <ReauthDialog
+          open={open}
+          onClose={() => setOpen(false)}
+          onSuccess={(token) => {
+            console.log("Reauth token:", token);
+            setOpen(false);
+          }}
+          onPasswordVerify={async (pw) => {
+            await new Promise((r) => setTimeout(r, 1000));
+            if (pw === "password") return "mock-reauth-token";
+            throw new Error("Incorrect password");
+          }}
+          onPasskeyVerify={async () => {
+            await new Promise((r) => setTimeout(r, 1000));
+            return "mock-passkey-token";
+          }}
+        />
+      </>
+    );
+  },
+};
+
+export const PasswordOnly: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Sensitive Action</Button>
+        <ReauthDialog
+          open={open}
+          onClose={() => setOpen(false)}
+          onSuccess={() => setOpen(false)}
+          methods={["password"]}
+          onPasswordVerify={async (pw) => {
+            await new Promise((r) => setTimeout(r, 500));
+            if (pw === "password") return "token";
+            throw new Error("Incorrect password");
+          }}
+        />
+      </>
+    );
+  },
+};
+
+export const PasskeyOnly: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Verify</Button>
+        <ReauthDialog
+          open={open}
+          onClose={() => setOpen(false)}
+          onSuccess={() => setOpen(false)}
+          methods={["passkey"]}
+          onPasskeyVerify={async () => {
+            await new Promise((r) => setTimeout(r, 1000));
+            return "passkey-token";
+          }}
+        />
+      </>
+    );
+  },
+};

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.test.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.test.tsx
@@ -21,34 +21,41 @@ describe("ReauthDialog", () => {
     expect(screen.getByText("Verify with passkey")).toBeInTheDocument();
   });
 
-  it("shows password fallback link when both methods available", () => {
+  it("shows email fallback link when both methods available", () => {
     render(<ReauthDialog {...defaultProps} />);
-    expect(screen.getByText("Use password instead")).toBeInTheDocument();
+    expect(screen.getByText("Use email verification instead")).toBeInTheDocument();
   });
 
-  it("switches to password view on fallback click", () => {
+  it("switches to email view on fallback click", () => {
     render(<ReauthDialog {...defaultProps} />);
-    fireEvent.click(screen.getByText("Use password instead"));
-    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Use email verification instead"));
+    expect(screen.getByText("Send verification code")).toBeInTheDocument();
     expect(screen.getByText("Use passkey instead")).toBeInTheDocument();
   });
 
-  it("shows password view directly when methods=[password]", () => {
-    render(<ReauthDialog {...defaultProps} methods={["password"]} />);
-    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+  it("shows email view directly when methods=[email]", () => {
+    render(<ReauthDialog {...defaultProps} methods={["email"]} />);
+    expect(screen.getByText("Send verification code")).toBeInTheDocument();
     expect(screen.queryByText("Use passkey instead")).not.toBeInTheDocument();
-  });
-
-  it("prevents closing while verifying", () => {
-    const onClose = vi.fn();
-    render(<ReauthDialog {...defaultProps} onClose={onClose} />);
-    // Dialog onClose is passed handleClose which checks isVerifying
-    // When not verifying, close should work via backdrop
-    expect(screen.getByText("Verify your identity")).toBeInTheDocument();
   });
 
   it("renders nothing when closed", () => {
     render(<ReauthDialog {...defaultProps} open={false} />);
     expect(screen.queryByText("Verify your identity")).not.toBeInTheDocument();
+  });
+
+  it("shows code input after sending", async () => {
+    const onEmailSendCode = vi.fn().mockResolvedValue("challenge-123");
+    render(
+      <ReauthDialog
+        {...defaultProps}
+        methods={["email"]}
+        onEmailSendCode={onEmailSendCode}
+      />,
+    );
+    fireEvent.click(screen.getByText("Send verification code"));
+    await vi.waitFor(() => {
+      expect(screen.getByLabelText("Verification code")).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.test.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { ReauthDialog } from "./ReauthDialog";
+
+afterEach(cleanup);
+
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  onSuccess: vi.fn(),
+};
+
+describe("ReauthDialog", () => {
+  it("renders with default title", () => {
+    render(<ReauthDialog {...defaultProps} />);
+    expect(screen.getByText("Verify your identity")).toBeInTheDocument();
+  });
+
+  it("shows passkey view by default", () => {
+    render(<ReauthDialog {...defaultProps} />);
+    expect(screen.getByText("Verify with passkey")).toBeInTheDocument();
+  });
+
+  it("shows password fallback link when both methods available", () => {
+    render(<ReauthDialog {...defaultProps} />);
+    expect(screen.getByText("Use password instead")).toBeInTheDocument();
+  });
+
+  it("switches to password view on fallback click", () => {
+    render(<ReauthDialog {...defaultProps} />);
+    fireEvent.click(screen.getByText("Use password instead"));
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(screen.getByText("Use passkey instead")).toBeInTheDocument();
+  });
+
+  it("shows password view directly when methods=[password]", () => {
+    render(<ReauthDialog {...defaultProps} methods={["password"]} />);
+    expect(screen.getByLabelText("Password")).toBeInTheDocument();
+    expect(screen.queryByText("Use passkey instead")).not.toBeInTheDocument();
+  });
+
+  it("prevents closing while verifying", () => {
+    const onClose = vi.fn();
+    render(<ReauthDialog {...defaultProps} onClose={onClose} />);
+    // Dialog onClose is passed handleClose which checks isVerifying
+    // When not verifying, close should work via backdrop
+    expect(screen.getByText("Verify your identity")).toBeInTheDocument();
+  });
+
+  it("renders nothing when closed", () => {
+    render(<ReauthDialog {...defaultProps} open={false} />);
+    expect(screen.queryByText("Verify your identity")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -1,0 +1,202 @@
+import { useState, useCallback, useEffect } from "react";
+import type { ComponentMeta } from "@/types/component-meta";
+import { Dialog } from "@/components/ui/surfaces/dialog/Dialog";
+import { Button } from "@/components/ui/actions/button/Button";
+import { Icon } from "@/components/ui/media/icon/Icon";
+import { Alert } from "@/components/ui/feedback/alert/Alert";
+import { FloatingLabelInput } from "@/components/ui/inputs/floating-label-input/FloatingLabelInput";
+
+export const meta: ComponentMeta = {
+  name: "ReauthDialog",
+  description:
+    "Modal dialog prompting re-authentication via passkey or password before sensitive actions",
+};
+
+export interface ReauthDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: (reauthToken: string) => void;
+  title?: string;
+  description?: string;
+  methods?: ("password" | "passkey")[];
+  onPasswordVerify?: (password: string) => Promise<string>;
+  onPasskeyVerify?: () => Promise<string>;
+  className?: string;
+}
+
+export function ReauthDialog({
+  open,
+  onClose,
+  onSuccess,
+  title = "Verify your identity",
+  description = "For your security, please verify your identity before continuing.",
+  methods = ["passkey", "password"],
+  onPasswordVerify,
+  onPasskeyVerify,
+  className,
+}: ReauthDialogProps) {
+  const hasPasskey = methods.includes("passkey");
+  const hasPassword = methods.includes("password");
+
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [showPasswordFallback, setShowPasswordFallback] = useState(false);
+
+  const showingPassword = !hasPasskey || showPasswordFallback;
+
+  const reset = useCallback(() => {
+    setPassword("");
+    setError(null);
+    setIsVerifying(false);
+    setShowPasswordFallback(false);
+  }, []);
+
+  useEffect(() => {
+    if (open) reset();
+  }, [open, reset]);
+
+  const handleClose = () => {
+    if (isVerifying) return;
+    reset();
+    onClose();
+  };
+
+  const handlePasswordVerify = async () => {
+    if (!password) {
+      setError("Password is required");
+      return;
+    }
+    setError(null);
+    setIsVerifying(true);
+    try {
+      if (!onPasswordVerify)
+        throw new Error("Password verification not configured");
+      const token = await onPasswordVerify(password);
+      reset();
+      onSuccess(token);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Incorrect password");
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  const handlePasskeyVerify = async () => {
+    setError(null);
+    setIsVerifying(true);
+    try {
+      if (!onPasskeyVerify)
+        throw new Error("Passkey verification not configured");
+      const token = await onPasskeyVerify();
+      reset();
+      onSuccess(token);
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "NotAllowedError") {
+        // User cancelled the passkey prompt
+      } else {
+        setError(
+          err instanceof Error ? err.message : "Passkey verification failed",
+        );
+      }
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      title={title}
+      className={className}
+      actions={
+        showingPassword
+          ? [
+              {
+                label: "Cancel",
+                variant: "text" as const,
+                onClick: handleClose,
+                disabled: isVerifying,
+              },
+              {
+                label: "Verify",
+                variant: "filled" as const,
+                onClick: handlePasswordVerify,
+                loading: isVerifying,
+              },
+            ]
+          : undefined
+      }
+    >
+      <p className="text-sm text-on-surface-variant mb-4">{description}</p>
+
+      {!showingPassword && (
+        <div className="flex flex-col items-center gap-3 py-2">
+          <div className="w-14 h-14 rounded-full bg-primary/10 flex items-center justify-center">
+            <Icon name="passkey" size={32} className="text-primary" />
+          </div>
+          <p className="text-sm text-on-surface-variant text-center">
+            Use your passkey to verify
+          </p>
+          <Button
+            onClick={handlePasskeyVerify}
+            loading={isVerifying}
+            fullWidth
+          >
+            Verify with passkey
+          </Button>
+          {hasPassword && (
+            <button
+              type="button"
+              onClick={() => {
+                setError(null);
+                setShowPasswordFallback(true);
+              }}
+              disabled={isVerifying}
+              className="text-sm text-primary hover:underline disabled:opacity-50"
+            >
+              Use password instead
+            </button>
+          )}
+        </div>
+      )}
+
+      {showingPassword && (
+        <div className="flex flex-col gap-3">
+          <FloatingLabelInput
+            type="password"
+            id="reauth-password"
+            label="Password"
+            value={password}
+            onChange={(e) => setPassword((e as React.ChangeEvent<HTMLInputElement>).target.value)}
+            disabled={isVerifying}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handlePasswordVerify();
+            }}
+            showPasswordToggle
+          />
+          {hasPasskey && (
+            <button
+              type="button"
+              onClick={() => {
+                setError(null);
+                setShowPasswordFallback(false);
+              }}
+              disabled={isVerifying}
+              className="text-sm text-primary hover:underline disabled:opacity-50 self-start"
+            >
+              Use passkey instead
+            </button>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <Alert variant="error" onDismiss={() => setError(null)} className="mt-4">
+          {error}
+        </Alert>
+      )}
+    </Dialog>
+  );
+}

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -9,7 +9,7 @@ import { FloatingLabelInput } from "@/components/ui/inputs/floating-label-input/
 export const meta: ComponentMeta = {
   name: "ReauthDialog",
   description:
-    "Modal dialog prompting re-authentication via passkey or password before sensitive actions",
+    "Modal dialog prompting re-authentication via passkey or email verification before sensitive actions",
 };
 
 export interface ReauthDialogProps {
@@ -18,8 +18,12 @@ export interface ReauthDialogProps {
   onSuccess: (reauthToken: string) => void;
   title?: string;
   description?: string;
-  methods?: ("password" | "passkey")[];
-  onPasswordVerify?: (password: string) => Promise<string>;
+  methods?: ("email" | "passkey")[];
+  /** Send a 6-digit code to the user's email. Returns a challenge ID. */
+  onEmailSendCode?: () => Promise<string>;
+  /** Verify the 6-digit code. Receives challengeId + code, returns reauth token. */
+  onEmailVerifyCode?: (challengeId: string, code: string) => Promise<string>;
+  /** Run WebAuthn ceremony, returns reauth token. */
   onPasskeyVerify?: () => Promise<string>;
   className?: string;
 }
@@ -30,26 +34,32 @@ export function ReauthDialog({
   onSuccess,
   title = "Verify your identity",
   description = "For your security, please verify your identity before continuing.",
-  methods = ["passkey", "password"],
-  onPasswordVerify,
+  methods = ["passkey", "email"],
+  onEmailSendCode,
+  onEmailVerifyCode,
   onPasskeyVerify,
   className,
 }: ReauthDialogProps) {
   const hasPasskey = methods.includes("passkey");
-  const hasPassword = methods.includes("password");
+  const hasEmail = methods.includes("email");
 
-  const [password, setPassword] = useState("");
+  const [code, setCode] = useState("");
+  const [challengeId, setChallengeId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isVerifying, setIsVerifying] = useState(false);
-  const [showPasswordFallback, setShowPasswordFallback] = useState(false);
+  const [isSending, setIsSending] = useState(false);
+  const [showEmailFallback, setShowEmailFallback] = useState(false);
 
-  const showingPassword = !hasPasskey || showPasswordFallback;
+  const showingEmail = !hasPasskey || showEmailFallback;
+  const codeSent = challengeId !== null;
 
   const reset = useCallback(() => {
-    setPassword("");
+    setCode("");
+    setChallengeId(null);
     setError(null);
     setIsVerifying(false);
-    setShowPasswordFallback(false);
+    setIsSending(false);
+    setShowEmailFallback(false);
   }, []);
 
   useEffect(() => {
@@ -57,26 +67,42 @@ export function ReauthDialog({
   }, [open, reset]);
 
   const handleClose = () => {
-    if (isVerifying) return;
+    if (isVerifying || isSending) return;
     reset();
     onClose();
   };
 
-  const handlePasswordVerify = async () => {
-    if (!password) {
-      setError("Password is required");
+  const handleSendCode = async () => {
+    setError(null);
+    setIsSending(true);
+    try {
+      if (!onEmailSendCode)
+        throw new Error("Email verification not configured");
+      const id = await onEmailSendCode();
+      setChallengeId(id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to send code");
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const handleEmailVerify = async () => {
+    if (!code || code.length !== 6) {
+      setError("Please enter the 6-digit code");
       return;
     }
+    if (!challengeId) return;
     setError(null);
     setIsVerifying(true);
     try {
-      if (!onPasswordVerify)
-        throw new Error("Password verification not configured");
-      const token = await onPasswordVerify(password);
+      if (!onEmailVerifyCode)
+        throw new Error("Email verification not configured");
+      const token = await onEmailVerifyCode(challengeId, code);
       reset();
       onSuccess(token);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Incorrect password");
+      setError(err instanceof Error ? err.message : "Invalid code");
     } finally {
       setIsVerifying(false);
     }
@@ -111,7 +137,7 @@ export function ReauthDialog({
       title={title}
       className={className}
       actions={
-        showingPassword
+        showingEmail && codeSent
           ? [
               {
                 label: "Cancel",
@@ -122,8 +148,9 @@ export function ReauthDialog({
               {
                 label: "Verify",
                 variant: "filled" as const,
-                onClick: handlePasswordVerify,
+                onClick: handleEmailVerify,
                 loading: isVerifying,
+                disabled: code.length !== 6,
               },
             ]
           : undefined
@@ -131,7 +158,7 @@ export function ReauthDialog({
     >
       <p className="text-sm text-on-surface-variant mb-4">{description}</p>
 
-      {!showingPassword && (
+      {!showingEmail && (
         <div className="flex flex-col items-center gap-3 py-2">
           <div className="w-14 h-14 rounded-full bg-primary/10 flex items-center justify-center">
             <Icon name="passkey" size={32} className="text-primary" />
@@ -146,49 +173,82 @@ export function ReauthDialog({
           >
             Verify with passkey
           </Button>
-          {hasPassword && (
+          {hasEmail && (
             <button
               type="button"
               onClick={() => {
                 setError(null);
-                setShowPasswordFallback(true);
+                setShowEmailFallback(true);
               }}
               disabled={isVerifying}
               className="text-sm text-primary hover:underline disabled:opacity-50"
             >
-              Use password instead
+              Use email verification instead
             </button>
           )}
         </div>
       )}
 
-      {showingPassword && (
-        <div className="flex flex-col gap-3">
-          <FloatingLabelInput
-            type="password"
-            id="reauth-password"
-            label="Password"
-            value={password}
-            onChange={(e) => setPassword((e as React.ChangeEvent<HTMLInputElement>).target.value)}
-            disabled={isVerifying}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") handlePasswordVerify();
-            }}
-            showPasswordToggle
-          />
+      {showingEmail && !codeSent && (
+        <div className="flex flex-col items-center gap-3 py-2">
+          <div className="w-14 h-14 rounded-full bg-primary/10 flex items-center justify-center">
+            <Icon name="mail" size={32} className="text-primary" />
+          </div>
+          <p className="text-sm text-on-surface-variant text-center">
+            We'll send a 6-digit verification code to your email
+          </p>
+          <Button
+            onClick={handleSendCode}
+            loading={isSending}
+            fullWidth
+          >
+            Send verification code
+          </Button>
           {hasPasskey && (
             <button
               type="button"
               onClick={() => {
                 setError(null);
-                setShowPasswordFallback(false);
+                setShowEmailFallback(false);
               }}
-              disabled={isVerifying}
-              className="text-sm text-primary hover:underline disabled:opacity-50 self-start"
+              disabled={isSending}
+              className="text-sm text-primary hover:underline disabled:opacity-50"
             >
               Use passkey instead
             </button>
           )}
+        </div>
+      )}
+
+      {showingEmail && codeSent && (
+        <div className="flex flex-col gap-3">
+          <p className="text-sm text-on-surface-variant">
+            Enter the 6-digit code sent to your email.
+          </p>
+          <FloatingLabelInput
+            type="text"
+            inputMode="numeric"
+            id="reauth-code"
+            label="Verification code"
+            value={code}
+            onChange={(e) => {
+              const v = (e as React.ChangeEvent<HTMLInputElement>).target.value.replace(/\D/g, "").slice(0, 6);
+              setCode(v);
+            }}
+            disabled={isVerifying}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleEmailVerify();
+            }}
+            maxLength={6}
+          />
+          <button
+            type="button"
+            onClick={handleSendCode}
+            disabled={isSending || isVerifying}
+            className="text-sm text-primary hover:underline disabled:opacity-50 self-start"
+          >
+            {isSending ? "Sending..." : "Resend code"}
+          </button>
         </div>
       )}
 

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -6,6 +6,10 @@ import { Icon } from "@/components/ui/media/icon/Icon";
 import { Alert } from "@/components/ui/feedback/alert/Alert";
 import { FloatingLabelInput } from "@/components/ui/inputs/floating-label-input/FloatingLabelInput";
 
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}
+
 export const meta: ComponentMeta = {
   name: "ReauthDialog",
   description:
@@ -81,7 +85,7 @@ export function ReauthDialog({
       const id = await onEmailSendCode();
       setChallengeId(id);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to send code");
+      setError(errorMessage(err, "Failed to send code"));
     } finally {
       setIsSending(false);
     }
@@ -102,8 +106,7 @@ export function ReauthDialog({
       reset();
       onSuccess(token);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Invalid code");
-    } finally {
+      setError(errorMessage(err, "Invalid code"));
       setIsVerifying(false);
     }
   };
@@ -118,14 +121,10 @@ export function ReauthDialog({
       reset();
       onSuccess(token);
     } catch (err) {
-      if (err instanceof DOMException && err.name === "NotAllowedError") {
-        // User cancelled the passkey prompt
-      } else {
-        setError(
-          err instanceof Error ? err.message : "Passkey verification failed",
-        );
+      // NotAllowedError = user cancelled the passkey prompt
+      if (!(err instanceof DOMException && err.name === "NotAllowedError")) {
+        setError(errorMessage(err, "Passkey verification failed"));
       }
-    } finally {
       setIsVerifying(false);
     }
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -96,3 +96,7 @@ export {
   ReadOnlyField,
   type ReadOnlyFieldProps,
 } from "./components/ui/data/read-only-field/ReadOnlyField";
+export {
+  ReauthDialog,
+  type ReauthDialogProps,
+} from "./components/ui/surfaces/reauth-dialog/ReauthDialog";


### PR DESCRIPTION
## Summary
- Passkey-first verification with password fallback
- Handles `NotAllowedError` (user cancelled WebAuthn) gracefully
- Prevents dialog close during verification
- Resets state on each open
- Uses Dialog, Button, Icon, Alert, FloatingLabelInput from the kit
- Stories: Playground (both methods), PasswordOnly, PasskeyOnly

Closes #32

## Test plan
- [x] `pnpm components validate` — 22 components pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 7 tests pass
- [ ] Visual review in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)