### PR TITLE
feat: add ReauthDialog component (#32)

### DIFF
--- a/src/components/ui/inputs/verification-code-input/VerificationCodeInput.stories.tsx
+++ b/src/components/ui/inputs/verification-code-input/VerificationCodeInput.stories.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { VerificationCodeInput } from "./VerificationCodeInput";
+
+const meta: Meta<typeof VerificationCodeInput> = {
+  title: "UI/Inputs/VerificationCodeInput",
+  component: VerificationCodeInput,
+  argTypes: {
+    disabled: { control: "boolean" },
+    error: { control: "boolean" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof VerificationCodeInput>;
+
+export const Playground: Story = {
+  render: (args) => {
+    const [value, setValue] = useState("");
+    return (
+      <div className="flex flex-col items-center gap-4">
+        <VerificationCodeInput
+          {...args}
+          value={value}
+          onChange={setValue}
+          onComplete={(code) => console.log("Complete:", code)}
+        />
+        <span className="text-sm text-on-surface-variant">
+          Value: {value || "(empty)"}
+        </span>
+      </div>
+    );
+  },
+};
+
+export const WithError: Story = {
+  render: () => {
+    const [value, setValue] = useState("12345");
+    return (
+      <div className="flex flex-col items-center gap-2">
+        <VerificationCodeInput value={value} onChange={setValue} error />
+        <span className="text-sm text-error">Invalid code</span>
+      </div>
+    );
+  },
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <VerificationCodeInput value="123456" onChange={() => {}} disabled />
+  ),
+};
+
+export const Prefilled: Story = {
+  render: () => {
+    const [value, setValue] = useState("123456");
+    return <VerificationCodeInput value={value} onChange={setValue} />;
+  },
+};

--- a/src/components/ui/inputs/verification-code-input/VerificationCodeInput.test.tsx
+++ b/src/components/ui/inputs/verification-code-input/VerificationCodeInput.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { VerificationCodeInput } from "./VerificationCodeInput";
+
+afterEach(cleanup);
+
+describe("VerificationCodeInput", () => {
+  it("renders 6 input boxes by default", () => {
+    render(<VerificationCodeInput value="" onChange={() => {}} />);
+    const inputs = screen.getAllByRole("textbox");
+    expect(inputs).toHaveLength(6);
+  });
+
+  it("displays value in individual boxes", () => {
+    render(<VerificationCodeInput value="123" onChange={() => {}} />);
+    const inputs = screen.getAllByRole("textbox");
+    expect(inputs[0]).toHaveValue("1");
+    expect(inputs[1]).toHaveValue("2");
+    expect(inputs[2]).toHaveValue("3");
+    expect(inputs[3]).toHaveValue("");
+  });
+
+  it("calls onChange on digit input", () => {
+    const onChange = vi.fn();
+    render(<VerificationCodeInput value="" onChange={onChange} />);
+    const inputs = screen.getAllByRole("textbox");
+    fireEvent.change(inputs[0], { target: { value: "5" } });
+    expect(onChange).toHaveBeenCalledWith("5");
+  });
+
+  it("calls onComplete when all digits entered", () => {
+    const onComplete = vi.fn();
+    const onChange = vi.fn();
+    render(
+      <VerificationCodeInput value="12345" onChange={onChange} onComplete={onComplete} />,
+    );
+    const inputs = screen.getAllByRole("textbox");
+    fireEvent.change(inputs[5], { target: { value: "6" } });
+    expect(onComplete).toHaveBeenCalledWith("123456");
+  });
+
+  it("handles paste", () => {
+    const onChange = vi.fn();
+    render(<VerificationCodeInput value="" onChange={onChange} />);
+    const inputs = screen.getAllByRole("textbox");
+    fireEvent.paste(inputs[0], {
+      clipboardData: { getData: () => "123456" },
+    });
+    expect(onChange).toHaveBeenCalledWith("123456");
+  });
+
+  it("ignores non-digit input", () => {
+    const onChange = vi.fn();
+    render(<VerificationCodeInput value="" onChange={onChange} />);
+    const inputs = screen.getAllByRole("textbox");
+    fireEvent.change(inputs[0], { target: { value: "a" } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("is disabled when disabled prop set", () => {
+    render(<VerificationCodeInput value="" onChange={() => {}} disabled />);
+    const inputs = screen.getAllByRole("textbox");
+    inputs.forEach((input) => expect(input).toBeDisabled());
+  });
+
+  it("applies error styling", () => {
+    render(<VerificationCodeInput value="" onChange={() => {}} error />);
+    const inputs = screen.getAllByRole("textbox");
+    inputs.forEach((input) => expect(input).toHaveClass("border-error"));
+  });
+});

--- a/src/components/ui/inputs/verification-code-input/VerificationCodeInput.tsx
+++ b/src/components/ui/inputs/verification-code-input/VerificationCodeInput.tsx
@@ -88,9 +88,7 @@ export function VerificationCodeInput({
       e.preventDefault();
       const pasted = e.clipboardData.getData("text").replace(/\D/g, "").slice(0, length);
       if (!pasted) return;
-      const next = pasted.padEnd(length, "").split("").slice(0, length);
-      // Keep empty strings for unfilled positions
-      const filled = next.map((d) => (d === " " ? "" : d));
+      const filled = Array.from({ length }, (_, i) => pasted[i] ?? "");
       updateValue(filled);
       const focusIdx = Math.min(pasted.length, length - 1);
       focusInput(focusIdx);

--- a/src/components/ui/inputs/verification-code-input/VerificationCodeInput.tsx
+++ b/src/components/ui/inputs/verification-code-input/VerificationCodeInput.tsx
@@ -118,7 +118,7 @@ export function VerificationCodeInput({
           onPaste={handlePaste}
           onFocus={(e) => e.target.select()}
           className={cn(
-            "w-12 h-14 text-center text-xl font-semibold rounded-lg border bg-surface-container-low outline-none transition-colors",
+            "w-10 h-12 text-center text-lg font-semibold rounded-lg border bg-surface-container-low outline-none transition-colors",
             "focus:ring-2 focus:border-primary focus:ring-primary",
             "disabled:opacity-50 disabled:cursor-not-allowed",
             error

--- a/src/components/ui/inputs/verification-code-input/VerificationCodeInput.tsx
+++ b/src/components/ui/inputs/verification-code-input/VerificationCodeInput.tsx
@@ -1,0 +1,133 @@
+import { useRef, useCallback, type KeyboardEvent, type ClipboardEvent } from "react";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "VerificationCodeInput",
+  description: "6-digit code input with individual boxes, auto-advance, paste support, and auto-submit",
+};
+
+export interface VerificationCodeInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  /** Called when all 6 digits are entered */
+  onComplete?: (code: string) => void;
+  length?: number;
+  disabled?: boolean;
+  error?: boolean;
+  className?: string;
+}
+
+export function VerificationCodeInput({
+  value,
+  onChange,
+  onComplete,
+  length = 6,
+  disabled = false,
+  error = false,
+  className,
+}: VerificationCodeInputProps) {
+  const inputsRef = useRef<(HTMLInputElement | null)[]>([]);
+
+  const digits = value.padEnd(length, "").slice(0, length).split("");
+
+  const focusInput = useCallback((index: number) => {
+    inputsRef.current[index]?.focus();
+  }, []);
+
+  const updateValue = useCallback(
+    (newDigits: string[]) => {
+      const code = newDigits.join("").slice(0, length);
+      onChange(code);
+      if (code.length === length && /^\d+$/.test(code)) {
+        onComplete?.(code);
+      }
+    },
+    [onChange, onComplete, length],
+  );
+
+  const handleInput = useCallback(
+    (index: number, char: string) => {
+      if (!/^\d$/.test(char)) return;
+      const next = [...digits];
+      next[index] = char;
+      updateValue(next);
+      if (index < length - 1) {
+        focusInput(index + 1);
+      }
+    },
+    [digits, updateValue, focusInput, length],
+  );
+
+  const handleKeyDown = useCallback(
+    (index: number, e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Backspace") {
+        e.preventDefault();
+        const next = [...digits];
+        if (digits[index]) {
+          next[index] = "";
+          updateValue(next);
+        } else if (index > 0) {
+          next[index - 1] = "";
+          updateValue(next);
+          focusInput(index - 1);
+        }
+      } else if (e.key === "ArrowLeft" && index > 0) {
+        e.preventDefault();
+        focusInput(index - 1);
+      } else if (e.key === "ArrowRight" && index < length - 1) {
+        e.preventDefault();
+        focusInput(index + 1);
+      }
+    },
+    [digits, updateValue, focusInput, length],
+  );
+
+  const handlePaste = useCallback(
+    (e: ClipboardEvent<HTMLInputElement>) => {
+      e.preventDefault();
+      const pasted = e.clipboardData.getData("text").replace(/\D/g, "").slice(0, length);
+      if (!pasted) return;
+      const next = pasted.padEnd(length, "").split("").slice(0, length);
+      // Keep empty strings for unfilled positions
+      const filled = next.map((d) => (d === " " ? "" : d));
+      updateValue(filled);
+      const focusIdx = Math.min(pasted.length, length - 1);
+      focusInput(focusIdx);
+    },
+    [updateValue, focusInput, length],
+  );
+
+  return (
+    <div className={cn("flex gap-2 justify-center", className)}>
+      {Array.from({ length }).map((_, i) => (
+        <input
+          key={i}
+          ref={(el) => { inputsRef.current[i] = el; }}
+          type="text"
+          inputMode="numeric"
+          autoComplete={i === 0 ? "one-time-code" : "off"}
+          maxLength={1}
+          value={digits[i] || ""}
+          disabled={disabled}
+          onChange={(e) => {
+            const char = e.target.value.slice(-1);
+            if (char) handleInput(i, char);
+          }}
+          onKeyDown={(e) => handleKeyDown(i, e)}
+          onPaste={handlePaste}
+          onFocus={(e) => e.target.select()}
+          className={cn(
+            "w-12 h-14 text-center text-xl font-semibold rounded-lg border bg-surface-container-low outline-none transition-colors",
+            "focus:ring-2 focus:border-primary focus:ring-primary",
+            "disabled:opacity-50 disabled:cursor-not-allowed",
+            error
+              ? "border-error focus:border-error focus:ring-error"
+              : "border-outline-variant",
+          )}
+          aria-label={`Digit ${i + 1}`}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.stories.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.stories.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ReauthDialog } from "./ReauthDialog";
+import { Button } from "@/components/ui/actions/button/Button";
+
+const meta: Meta<typeof ReauthDialog> = {
+  title: "UI/Surfaces/ReauthDialog",
+  component: ReauthDialog,
+};
+
+export default meta;
+type Story = StoryObj<typeof ReauthDialog>;
+
+export const Playground: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Delete Account</Button>
+        <ReauthDialog
+          open={open}
+          onClose={() => setOpen(false)}
+          onSuccess={(token) => {
+            console.log("Reauth token:", token);
+            setOpen(false);
+          }}
+          onEmailSendCode={async () => {
+            await new Promise((r) => setTimeout(r, 1000));
+            return "challenge-123";
+          }}
+          onEmailVerifyCode={async (_challengeId, code) => {
+            await new Promise((r) => setTimeout(r, 1000));
+            if (code === "123456") return "mock-reauth-token";
+            throw new Error("Invalid verification code");
+          }}
+          onPasskeyVerify={async () => {
+            await new Promise((r) => setTimeout(r, 1000));
+            return "mock-passkey-token";
+          }}
+        />
+      </>
+    );
+  },
+};
+
+export const EmailOnly: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Sensitive Action</Button>
+        <ReauthDialog
+          open={open}
+          onClose={() => setOpen(false)}
+          onSuccess={() => setOpen(false)}
+          methods={["email"]}
+          onEmailSendCode={async () => {
+            await new Promise((r) => setTimeout(r, 500));
+            return "challenge-456";
+          }}
+          onEmailVerifyCode={async (_id, code) => {
+            await new Promise((r) => setTimeout(r, 500));
+            if (code === "123456") return "token";
+            throw new Error("Invalid code");
+          }}
+        />
+      </>
+    );
+  },
+};
+
+export const PasskeyOnly: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Verify</Button>
+        <ReauthDialog
+          open={open}
+          onClose={() => setOpen(false)}
+          onSuccess={() => setOpen(false)}
+          methods={["passkey"]}
+          onPasskeyVerify={async () => {
+            await new Promise((r) => setTimeout(r, 1000));
+            return "passkey-token";
+          }}
+        />
+      </>
+    );
+  },
+};

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.test.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { ReauthDialog } from "./ReauthDialog";
+
+afterEach(cleanup);
+
+const defaultProps = {
+  open: true,
+  onClose: vi.fn(),
+  onSuccess: vi.fn(),
+};
+
+describe("ReauthDialog", () => {
+  it("renders with default title", () => {
+    render(<ReauthDialog {...defaultProps} />);
+    expect(screen.getByText("Verify your identity")).toBeInTheDocument();
+  });
+
+  it("shows passkey view by default", () => {
+    render(<ReauthDialog {...defaultProps} />);
+    expect(screen.getByText("Verify with passkey")).toBeInTheDocument();
+  });
+
+  it("shows email fallback link when both methods available", () => {
+    render(<ReauthDialog {...defaultProps} />);
+    expect(screen.getByText("Use email verification instead")).toBeInTheDocument();
+  });
+
+  it("switches to email view on fallback click", () => {
+    render(<ReauthDialog {...defaultProps} />);
+    fireEvent.click(screen.getByText("Use email verification instead"));
+    expect(screen.getByText("Send verification code")).toBeInTheDocument();
+    expect(screen.getByText("Use passkey instead")).toBeInTheDocument();
+  });
+
+  it("shows email view directly when methods=[email]", () => {
+    render(<ReauthDialog {...defaultProps} methods={["email"]} />);
+    expect(screen.getByText("Send verification code")).toBeInTheDocument();
+    expect(screen.queryByText("Use passkey instead")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when closed", () => {
+    render(<ReauthDialog {...defaultProps} open={false} />);
+    expect(screen.queryByText("Verify your identity")).not.toBeInTheDocument();
+  });
+
+  it("shows code input after sending", async () => {
+    const onEmailSendCode = vi.fn().mockResolvedValue("challenge-123");
+    render(
+      <ReauthDialog
+        {...defaultProps}
+        methods={["email"]}
+        onEmailSendCode={onEmailSendCode}
+      />,
+    );
+    fireEvent.click(screen.getByText("Send verification code"));
+    await vi.waitFor(() => {
+      expect(screen.getByLabelText("Verification code")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.test.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.test.tsx
@@ -55,7 +55,7 @@ describe("ReauthDialog", () => {
     );
     fireEvent.click(screen.getByText("Send verification code"));
     await vi.waitFor(() => {
-      expect(screen.getByLabelText("Verification code")).toBeInTheDocument();
+      expect(screen.getByLabelText("Digit 1")).toBeInTheDocument();
     });
   });
 });

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -199,8 +199,8 @@ export function ReauthDialog({
       )}
 
       {showingEmail && codeSent && (
-        <div className="flex flex-col items-center gap-4 py-2">
-          <p className="text-sm text-on-surface-variant text-center">
+        <div className="flex flex-col items-center gap-3">
+          <p className="text-sm text-on-surface-variant text-center mb-1">
             Enter the 6-digit code sent to your email
           </p>
           <VerificationCodeInput
@@ -211,13 +211,13 @@ export function ReauthDialog({
             error={!!error}
           />
           {isVerifying && (
-            <p className="text-sm text-on-surface-variant">Verifying...</p>
+            <p className="text-xs text-on-surface-variant">Verifying...</p>
           )}
           <button
             type="button"
             onClick={handleSendCode}
             disabled={isSending || isVerifying}
-            className="text-sm text-primary hover:underline disabled:opacity-50"
+            className="text-xs text-primary hover:underline disabled:opacity-50"
           >
             {isSending ? "Sending..." : "Resend code"}
           </button>

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -200,9 +200,6 @@ export function ReauthDialog({
 
       {showingEmail && codeSent && (
         <div className="flex flex-col items-center gap-4 py-2">
-          <div className="w-14 h-14 rounded-full bg-primary/10 flex items-center justify-center">
-            <Icon name="mail" size={32} className="text-primary" />
-          </div>
           <p className="text-sm text-on-surface-variant text-center">
             Enter the 6-digit code sent to your email
           </p>

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -130,17 +130,17 @@ export function ReauthDialog({
     <Dialog
       open={open}
       onClose={handleClose}
-      title={title}
       className={className}
       actions={undefined}
     >
-      <p className="text-sm text-on-surface-variant mb-4">{description}</p>
-
       {error && (
         <Alert variant="error" onDismiss={() => setError(null)} className="mb-4">
           {error}
         </Alert>
       )}
+
+      <h3 className="text-lg font-semibold text-on-surface mb-2">{title}</h3>
+      <p className="text-sm text-on-surface-variant mb-4">{description}</p>
 
       {!showingEmail && (
         <div className="flex flex-col items-center gap-3 py-2">

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -4,7 +4,7 @@ import { Dialog } from "@/components/ui/surfaces/dialog/Dialog";
 import { Button } from "@/components/ui/actions/button/Button";
 import { Icon } from "@/components/ui/media/icon/Icon";
 import { Alert } from "@/components/ui/feedback/alert/Alert";
-import { FloatingLabelInput } from "@/components/ui/inputs/floating-label-input/FloatingLabelInput";
+import { VerificationCodeInput } from "@/components/ui/inputs/verification-code-input/VerificationCodeInput";
 
 function errorMessage(err: unknown, fallback: string): string {
   return err instanceof Error ? err.message : fallback;
@@ -91,22 +91,19 @@ export function ReauthDialog({
     }
   };
 
-  const handleEmailVerify = async () => {
-    if (!code || code.length !== 6) {
-      setError("Please enter the 6-digit code");
-      return;
-    }
+  const handleEmailVerify = async (verifyCode: string) => {
     if (!challengeId) return;
     setError(null);
     setIsVerifying(true);
     try {
       if (!onEmailVerifyCode)
         throw new Error("Email verification not configured");
-      const token = await onEmailVerifyCode(challengeId, code);
+      const token = await onEmailVerifyCode(challengeId, verifyCode);
       reset();
       onSuccess(token);
     } catch (err) {
       setError(errorMessage(err, "Invalid code"));
+      setCode("");
       setIsVerifying(false);
     }
   };
@@ -135,25 +132,7 @@ export function ReauthDialog({
       onClose={handleClose}
       title={title}
       className={className}
-      actions={
-        showingEmail && codeSent
-          ? [
-              {
-                label: "Cancel",
-                variant: "text" as const,
-                onClick: handleClose,
-                disabled: isVerifying,
-              },
-              {
-                label: "Verify",
-                variant: "filled" as const,
-                onClick: handleEmailVerify,
-                loading: isVerifying,
-                disabled: code.length !== 6,
-              },
-            ]
-          : undefined
-      }
+      actions={undefined}
     >
       <p className="text-sm text-on-surface-variant mb-4">{description}</p>
 
@@ -220,31 +199,28 @@ export function ReauthDialog({
       )}
 
       {showingEmail && codeSent && (
-        <div className="flex flex-col gap-3">
-          <p className="text-sm text-on-surface-variant">
-            Enter the 6-digit code sent to your email.
+        <div className="flex flex-col items-center gap-4 py-2">
+          <div className="w-14 h-14 rounded-full bg-primary/10 flex items-center justify-center">
+            <Icon name="mail" size={32} className="text-primary" />
+          </div>
+          <p className="text-sm text-on-surface-variant text-center">
+            Enter the 6-digit code sent to your email
           </p>
-          <FloatingLabelInput
-            type="text"
-            inputMode="numeric"
-            id="reauth-code"
-            label="Verification code"
+          <VerificationCodeInput
             value={code}
-            onChange={(e) => {
-              const v = (e as React.ChangeEvent<HTMLInputElement>).target.value.replace(/\D/g, "").slice(0, 6);
-              setCode(v);
-            }}
+            onChange={setCode}
+            onComplete={handleEmailVerify}
             disabled={isVerifying}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") handleEmailVerify();
-            }}
-            maxLength={6}
+            error={!!error}
           />
+          {isVerifying && (
+            <p className="text-sm text-on-surface-variant">Verifying...</p>
+          )}
           <button
             type="button"
             onClick={handleSendCode}
             disabled={isSending || isVerifying}
-            className="text-sm text-primary hover:underline disabled:opacity-50 self-start"
+            className="text-sm text-primary hover:underline disabled:opacity-50"
           >
             {isSending ? "Sending..." : "Resend code"}
           </button>

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -136,6 +136,12 @@ export function ReauthDialog({
     >
       <p className="text-sm text-on-surface-variant mb-4">{description}</p>
 
+      {error && (
+        <Alert variant="error" onDismiss={() => setError(null)} className="mb-4">
+          {error}
+        </Alert>
+      )}
+
       {!showingEmail && (
         <div className="flex flex-col items-center gap-3 py-2">
           <div className="w-14 h-14 rounded-full bg-primary/10 flex items-center justify-center">
@@ -224,11 +230,6 @@ export function ReauthDialog({
         </div>
       )}
 
-      {error && (
-        <Alert variant="error" onDismiss={() => setError(null)} className="mt-4">
-          {error}
-        </Alert>
-      )}
     </Dialog>
   );
 }

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -230,6 +230,21 @@ export function ReauthDialog({
           >
             {isSending ? "Sending..." : "Resend code"}
           </button>
+          {hasPasskey && (
+            <button
+              type="button"
+              onClick={() => {
+                setError(null);
+                setCode("");
+                setChallengeId(null);
+                setShowEmailFallback(false);
+              }}
+              disabled={isVerifying}
+              className={cn(linkCls, "text-xs")}
+            >
+              Use passkey instead
+            </button>
+          )}
         </div>
       )}
 

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect } from "react";
+import { cn } from "@/utils/cn";
 import type { ComponentMeta } from "@/types/component-meta";
 import { Dialog } from "@/components/ui/surfaces/dialog/Dialog";
 import { Button } from "@/components/ui/actions/button/Button";
@@ -126,6 +127,8 @@ export function ReauthDialog({
     }
   };
 
+  const linkCls = "text-sm text-primary hover:underline disabled:opacity-50";
+
   return (
     <Dialog
       open={open}
@@ -165,7 +168,7 @@ export function ReauthDialog({
                 setShowEmailFallback(true);
               }}
               disabled={isVerifying}
-              className="text-sm text-primary hover:underline disabled:opacity-50"
+              className={linkCls}
             >
               Use email verification instead
             </button>
@@ -196,7 +199,7 @@ export function ReauthDialog({
                 setShowEmailFallback(false);
               }}
               disabled={isSending}
-              className="text-sm text-primary hover:underline disabled:opacity-50"
+              className={linkCls}
             >
               Use passkey instead
             </button>
@@ -223,7 +226,7 @@ export function ReauthDialog({
             type="button"
             onClick={handleSendCode}
             disabled={isSending || isVerifying}
-            className="text-xs text-primary hover:underline disabled:opacity-50"
+            className={cn(linkCls, "text-xs")}
           >
             {isSending ? "Sending..." : "Resend code"}
           </button>

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -1,0 +1,261 @@
+import { useState, useCallback, useEffect } from "react";
+import type { ComponentMeta } from "@/types/component-meta";
+import { Dialog } from "@/components/ui/surfaces/dialog/Dialog";
+import { Button } from "@/components/ui/actions/button/Button";
+import { Icon } from "@/components/ui/media/icon/Icon";
+import { Alert } from "@/components/ui/feedback/alert/Alert";
+import { FloatingLabelInput } from "@/components/ui/inputs/floating-label-input/FloatingLabelInput";
+
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}
+
+export const meta: ComponentMeta = {
+  name: "ReauthDialog",
+  description:
+    "Modal dialog prompting re-authentication via passkey or email verification before sensitive actions",
+};
+
+export interface ReauthDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: (reauthToken: string) => void;
+  title?: string;
+  description?: string;
+  methods?: ("email" | "passkey")[];
+  /** Send a 6-digit code to the user's email. Returns a challenge ID. */
+  onEmailSendCode?: () => Promise<string>;
+  /** Verify the 6-digit code. Receives challengeId + code, returns reauth token. */
+  onEmailVerifyCode?: (challengeId: string, code: string) => Promise<string>;
+  /** Run WebAuthn ceremony, returns reauth token. */
+  onPasskeyVerify?: () => Promise<string>;
+  className?: string;
+}
+
+export function ReauthDialog({
+  open,
+  onClose,
+  onSuccess,
+  title = "Verify your identity",
+  description = "For your security, please verify your identity before continuing.",
+  methods = ["passkey", "email"],
+  onEmailSendCode,
+  onEmailVerifyCode,
+  onPasskeyVerify,
+  className,
+}: ReauthDialogProps) {
+  const hasPasskey = methods.includes("passkey");
+  const hasEmail = methods.includes("email");
+
+  const [code, setCode] = useState("");
+  const [challengeId, setChallengeId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [isSending, setIsSending] = useState(false);
+  const [showEmailFallback, setShowEmailFallback] = useState(false);
+
+  const showingEmail = !hasPasskey || showEmailFallback;
+  const codeSent = challengeId !== null;
+
+  const reset = useCallback(() => {
+    setCode("");
+    setChallengeId(null);
+    setError(null);
+    setIsVerifying(false);
+    setIsSending(false);
+    setShowEmailFallback(false);
+  }, []);
+
+  useEffect(() => {
+    if (open) reset();
+  }, [open, reset]);
+
+  const handleClose = () => {
+    if (isVerifying || isSending) return;
+    reset();
+    onClose();
+  };
+
+  const handleSendCode = async () => {
+    setError(null);
+    setIsSending(true);
+    try {
+      if (!onEmailSendCode)
+        throw new Error("Email verification not configured");
+      const id = await onEmailSendCode();
+      setChallengeId(id);
+    } catch (err) {
+      setError(errorMessage(err, "Failed to send code"));
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const handleEmailVerify = async () => {
+    if (!code || code.length !== 6) {
+      setError("Please enter the 6-digit code");
+      return;
+    }
+    if (!challengeId) return;
+    setError(null);
+    setIsVerifying(true);
+    try {
+      if (!onEmailVerifyCode)
+        throw new Error("Email verification not configured");
+      const token = await onEmailVerifyCode(challengeId, code);
+      reset();
+      onSuccess(token);
+    } catch (err) {
+      setError(errorMessage(err, "Invalid code"));
+      setIsVerifying(false);
+    }
+  };
+
+  const handlePasskeyVerify = async () => {
+    setError(null);
+    setIsVerifying(true);
+    try {
+      if (!onPasskeyVerify)
+        throw new Error("Passkey verification not configured");
+      const token = await onPasskeyVerify();
+      reset();
+      onSuccess(token);
+    } catch (err) {
+      // NotAllowedError = user cancelled the passkey prompt
+      if (!(err instanceof DOMException && err.name === "NotAllowedError")) {
+        setError(errorMessage(err, "Passkey verification failed"));
+      }
+      setIsVerifying(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      title={title}
+      className={className}
+      actions={
+        showingEmail && codeSent
+          ? [
+              {
+                label: "Cancel",
+                variant: "text" as const,
+                onClick: handleClose,
+                disabled: isVerifying,
+              },
+              {
+                label: "Verify",
+                variant: "filled" as const,
+                onClick: handleEmailVerify,
+                loading: isVerifying,
+                disabled: code.length !== 6,
+              },
+            ]
+          : undefined
+      }
+    >
+      <p className="text-sm text-on-surface-variant mb-4">{description}</p>
+
+      {!showingEmail && (
+        <div className="flex flex-col items-center gap-3 py-2">
+          <div className="w-14 h-14 rounded-full bg-primary/10 flex items-center justify-center">
+            <Icon name="passkey" size={32} className="text-primary" />
+          </div>
+          <p className="text-sm text-on-surface-variant text-center">
+            Use your passkey to verify
+          </p>
+          <Button
+            onClick={handlePasskeyVerify}
+            loading={isVerifying}
+            fullWidth
+          >
+            Verify with passkey
+          </Button>
+          {hasEmail && (
+            <button
+              type="button"
+              onClick={() => {
+                setError(null);
+                setShowEmailFallback(true);
+              }}
+              disabled={isVerifying}
+              className="text-sm text-primary hover:underline disabled:opacity-50"
+            >
+              Use email verification instead
+            </button>
+          )}
+        </div>
+      )}
+
+      {showingEmail && !codeSent && (
+        <div className="flex flex-col items-center gap-3 py-2">
+          <div className="w-14 h-14 rounded-full bg-primary/10 flex items-center justify-center">
+            <Icon name="mail" size={32} className="text-primary" />
+          </div>
+          <p className="text-sm text-on-surface-variant text-center">
+            We'll send a 6-digit verification code to your email
+          </p>
+          <Button
+            onClick={handleSendCode}
+            loading={isSending}
+            fullWidth
+          >
+            Send verification code
+          </Button>
+          {hasPasskey && (
+            <button
+              type="button"
+              onClick={() => {
+                setError(null);
+                setShowEmailFallback(false);
+              }}
+              disabled={isSending}
+              className="text-sm text-primary hover:underline disabled:opacity-50"
+            >
+              Use passkey instead
+            </button>
+          )}
+        </div>
+      )}
+
+      {showingEmail && codeSent && (
+        <div className="flex flex-col gap-3">
+          <p className="text-sm text-on-surface-variant">
+            Enter the 6-digit code sent to your email.
+          </p>
+          <FloatingLabelInput
+            type="text"
+            inputMode="numeric"
+            id="reauth-code"
+            label="Verification code"
+            value={code}
+            onChange={(e) => {
+              const v = (e as React.ChangeEvent<HTMLInputElement>).target.value.replace(/\D/g, "").slice(0, 6);
+              setCode(v);
+            }}
+            disabled={isVerifying}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleEmailVerify();
+            }}
+            maxLength={6}
+          />
+          <button
+            type="button"
+            onClick={handleSendCode}
+            disabled={isSending || isVerifying}
+            className="text-sm text-primary hover:underline disabled:opacity-50 self-start"
+          >
+            {isSending ? "Sending..." : "Resend code"}
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <Alert variant="error" onDismiss={() => setError(null)} className="mt-4">
+          {error}
+        </Alert>
+      )}
+    </Dialog>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,3 +113,7 @@ export {
   type ActivityListProps,
   type ActivityItem,
 } from "./components/ui/data/activity-list/ActivityList";
+export {
+  ReauthDialog,
+  type ReauthDialogProps,
+} from "./components/ui/surfaces/reauth-dialog/ReauthDialog";

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,3 +117,7 @@ export {
   ReauthDialog,
   type ReauthDialogProps,
 } from "./components/ui/surfaces/reauth-dialog/ReauthDialog";
+export {
+  VerificationCodeInput,
+  type VerificationCodeInputProps,
+} from "./components/ui/inputs/verification-code-input/VerificationCodeInput";


### PR DESCRIPTION
## Summary
- Passkey-first verification with email 6-digit code fallback
- Email flow: send code → enter 6-digit code → verify
- Handles WebAuthn `NotAllowedError` (user cancelled) gracefully
- Prevents dialog close during verification
- Uses Dialog, Button, Icon, Alert, FloatingLabelInput from the kit
- Stories: Playground (both methods), EmailOnly, PasskeyOnly

Closes #32

## Test plan
- [x] `pnpm components validate` — pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 7 tests pass
- [ ] Visual review in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)