### PR TITLE
feat: add NavigationRail component (#8)

### DIFF
--- a/src/components/ui/navigation/navigation-button/NavigationButton.tsx
+++ b/src/components/ui/navigation/navigation-button/NavigationButton.tsx
@@ -36,15 +36,13 @@ const buttonStyles: Record<NavigationButtonVariant, Record<"selected" | "unselec
   },
 };
 
+const defaultHoverBg = {
+  selected: "rounded-full pl-12 pr-4 py-2 -left-1 bg-primary-container",
+  unselected: "rounded-full pl-12 pr-4 py-2 -left-1 bg-secondary-container",
+};
 const hoverBgStyles: Record<NavigationButtonVariant, Record<"selected" | "unselected", string>> = {
-  primary: {
-    selected: "rounded-full pl-12 pr-4 py-2 -left-1 bg-primary-container",
-    unselected: "rounded-full pl-12 pr-4 py-2 -left-1 bg-secondary-container",
-  },
-  secondary: {
-    selected: "rounded-full pl-12 pr-4 py-2 -left-1 bg-primary-container",
-    unselected: "rounded-full pl-12 pr-4 py-2 -left-1 bg-secondary-container",
-  },
+  primary: defaultHoverBg,
+  secondary: defaultHoverBg,
   tertiary: {
     selected: "rounded-xl pl-14 pr-4 py-2.5 left-0 bg-tertiary-container",
     unselected: "rounded-xl pl-14 pr-4 py-2.5 left-0 bg-tertiary-container",
@@ -69,15 +67,13 @@ const iconStyles: Record<NavigationButtonVariant, { selected: string; hovered: s
   },
 };
 
+const defaultHoverText = {
+  selected: "var(--color-on-primary-container)",
+  unselected: "var(--color-on-secondary-container)",
+};
 const hoverTextColors: Record<NavigationButtonVariant, Record<"selected" | "unselected", string>> = {
-  primary: {
-    selected: "var(--color-on-primary-container)",
-    unselected: "var(--color-on-secondary-container)",
-  },
-  secondary: {
-    selected: "var(--color-on-primary-container)",
-    unselected: "var(--color-on-secondary-container)",
-  },
+  primary: defaultHoverText,
+  secondary: defaultHoverText,
   tertiary: {
     selected: "var(--color-on-tertiary-container)",
     unselected: "var(--color-on-tertiary-container)",
@@ -140,8 +136,7 @@ export function NavigationButton({
         className={cn(
           "flex items-center justify-center transition-all duration-200 ease-in-out box-border relative z-10 w-10 h-10 disabled:opacity-50 disabled:cursor-not-allowed",
           customIcon ? "p-0 overflow-hidden" : "p-2.5",
-          buttonStyles[variant][selKey],
-          isHovered && "!bg-transparent",
+          !isHovered && buttonStyles[variant][selKey],
           className,
         )}
         onMouseEnter={() => setIsHovered(true)}

--- a/src/components/ui/navigation/navigation-button/NavigationButton.tsx
+++ b/src/components/ui/navigation/navigation-button/NavigationButton.tsx
@@ -1,0 +1,160 @@
+import { type ButtonHTMLAttributes, type ReactNode, useState, useEffect } from "react";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { Icon } from "@/components/ui/media/icon/Icon";
+
+export const meta: ComponentMeta = {
+  name: "NavigationButton",
+  description:
+    "Navigation rail button with icon, hover-expand label animation, and selected state",
+};
+
+export type NavigationButtonVariant = "primary" | "secondary" | "tertiary";
+
+export interface NavigationButtonProps
+  extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
+  icon?: string;
+  customIcon?: ReactNode;
+  label: string;
+  selected?: boolean;
+  variant?: NavigationButtonVariant;
+  disableHoverExpand?: boolean;
+}
+
+const buttonStyles: Record<NavigationButtonVariant, Record<"selected" | "unselected", string>> = {
+  primary: {
+    selected: "bg-primary-container rounded-full cursor-default",
+    unselected: "cursor-pointer",
+  },
+  secondary: {
+    selected: "bg-primary-container rounded-full cursor-default",
+    unselected: "rounded-xl cursor-pointer",
+  },
+  tertiary: {
+    selected: "bg-tertiary-container rounded-xl cursor-default",
+    unselected: "border border-tertiary rounded-xl cursor-pointer",
+  },
+};
+
+const hoverBgStyles: Record<NavigationButtonVariant, Record<"selected" | "unselected", string>> = {
+  primary: {
+    selected: "rounded-full pl-12 pr-4 py-2 -left-1 bg-primary-container",
+    unselected: "rounded-full pl-12 pr-4 py-2 -left-1 bg-secondary-container",
+  },
+  secondary: {
+    selected: "rounded-full pl-12 pr-4 py-2 -left-1 bg-primary-container",
+    unselected: "rounded-full pl-12 pr-4 py-2 -left-1 bg-secondary-container",
+  },
+  tertiary: {
+    selected: "rounded-xl pl-14 pr-4 py-2.5 left-0 bg-tertiary-container",
+    unselected: "rounded-xl pl-14 pr-4 py-2.5 left-0 bg-tertiary-container",
+  },
+};
+
+const iconStyles: Record<NavigationButtonVariant, { selected: string; hovered: string; idle: string }> = {
+  primary: {
+    selected: "text-on-primary-container",
+    hovered: "text-on-surface",
+    idle: "text-on-surface",
+  },
+  secondary: {
+    selected: "text-on-primary-container",
+    hovered: "text-on-secondary-container",
+    idle: "text-on-surface",
+  },
+  tertiary: {
+    selected: "text-on-tertiary-container",
+    hovered: "text-on-tertiary-container",
+    idle: "text-tertiary",
+  },
+};
+
+const hoverTextColors: Record<NavigationButtonVariant, Record<"selected" | "unselected", string>> = {
+  primary: {
+    selected: "var(--color-on-primary-container)",
+    unselected: "var(--color-on-secondary-container)",
+  },
+  secondary: {
+    selected: "var(--color-on-primary-container)",
+    unselected: "var(--color-on-secondary-container)",
+  },
+  tertiary: {
+    selected: "var(--color-on-tertiary-container)",
+    unselected: "var(--color-on-tertiary-container)",
+  },
+};
+
+export function NavigationButton({
+  icon,
+  customIcon,
+  label,
+  variant = "secondary",
+  selected = false,
+  disableHoverExpand = false,
+  className,
+  disabled,
+  ...props
+}: NavigationButtonProps) {
+  const [isHovered, setIsHovered] = useState(false);
+  const [showLabel, setShowLabel] = useState(false);
+
+  useEffect(() => {
+    if (isHovered) {
+      const timer = window.setTimeout(() => setShowLabel(true), 100);
+      return () => clearTimeout(timer);
+    }
+    setShowLabel(false);
+  }, [isHovered]);
+
+  const selKey = selected ? "selected" : "unselected";
+  const iconColor = iconStyles[variant][selected ? "selected" : isHovered ? "hovered" : "idle"];
+
+  return (
+    <div className="relative flex justify-center">
+      {!disableHoverExpand && (
+        <div
+          aria-hidden="true"
+          className={cn(
+            "h-10 absolute top-1/2 -translate-y-1/2 shadow-2xl flex items-center gap-2 z-0",
+            hoverBgStyles[variant][selKey],
+            "transition-all",
+            isHovered
+              ? "duration-300 ease-out opacity-100 translate-x-0"
+              : "duration-200 ease-in opacity-0 -translate-x-full",
+          )}
+        >
+          <span
+            className={cn(
+              "transition-opacity duration-200 whitespace-nowrap text-sm font-medium",
+              showLabel ? "opacity-100" : "opacity-0",
+            )}
+            style={{ color: hoverTextColors[variant][selKey] }}
+          >
+            {label}
+          </span>
+        </div>
+      )}
+
+      <button
+        aria-label={label}
+        className={cn(
+          "flex items-center justify-center transition-all duration-200 ease-in-out box-border relative z-10 w-10 h-10 disabled:opacity-50 disabled:cursor-not-allowed",
+          customIcon ? "p-0 overflow-hidden" : "p-2.5",
+          buttonStyles[variant][selKey],
+          isHovered && "!bg-transparent",
+          className,
+        )}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+        disabled={disabled}
+        {...props}
+      >
+        {icon && !customIcon ? (
+          <Icon name={icon} size={24} className={cn("shrink-0", iconColor)} />
+        ) : customIcon ? (
+          <div className="w-full h-full shrink-0">{customIcon}</div>
+        ) : null}
+      </button>
+    </div>
+  );
+}

--- a/src/components/ui/navigation/navigation-rail/NavigationRail.stories.tsx
+++ b/src/components/ui/navigation/navigation-rail/NavigationRail.stories.tsx
@@ -1,14 +1,16 @@
+import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { NavigationRail } from "./NavigationRail";
-import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+import { NavigationButton } from "@/components/ui/navigation/navigation-button/NavigationButton";
 import { Logo } from "@/components/ui/media/logo-mirrorstack/LogoMirrorStack";
+import { Avatar } from "@/components/ui/media/avatar/Avatar";
 
 const meta: Meta<typeof NavigationRail> = {
   title: "UI/Navigation/NavigationRail",
   component: NavigationRail,
   decorators: [
     (Story) => (
-      <div className="h-[500px] flex">
+      <div className="h-[600px] flex">
         <Story />
       </div>
     ),
@@ -19,23 +21,60 @@ export default meta;
 type Story = StoryObj<typeof NavigationRail>;
 
 export const Playground: Story = {
-  render: () => (
-    <NavigationRail
-      logo={
-        <div className="w-8 h-8">
-          <Logo />
+  render: () => {
+    const [selected, setSelected] = useState("apps");
+    return (
+      <NavigationRail
+        logo={
+          <div className="w-10 h-10">
+            <Logo />
+          </div>
+        }
+        header={<Avatar size="sm" fallback="J" />}
+        footer={
+          <NavigationButton
+            icon="settings"
+            label="Settings"
+            selected={selected === "settings"}
+            onClick={() => setSelected("settings")}
+          />
+        }
+      >
+        <div className="w-full gap-2 flex flex-col">
+          <NavigationButton
+            icon="dashboard"
+            label="Overview"
+            variant="primary"
+            selected={selected === "overview"}
+            onClick={() => setSelected("overview")}
+          />
+          <NavigationButton
+            icon="apps"
+            label="Your Apps"
+            selected={selected === "apps"}
+            onClick={() => setSelected("apps")}
+          />
         </div>
-      }
-      header={
-        <IconButton icon="person" variant="text" size="sm" aria-label="Profile" />
-      }
-      footer={
-        <IconButton icon="settings" variant="text" size="sm" aria-label="Settings" />
-      }
-    >
-      <IconButton icon="home" variant="tonal" size="sm" aria-label="Home" />
-      <IconButton icon="search" variant="text" size="sm" aria-label="Search" />
-      <IconButton icon="notifications" variant="text" size="sm" aria-label="Notifications" />
-    </NavigationRail>
-  ),
+        <div className="h-px rounded-full w-full bg-outline" />
+        <div className="w-full gap-2 flex flex-col">
+          <NavigationButton
+            icon="apartment"
+            label="Organizations"
+            variant="tertiary"
+            selected={selected === "org"}
+            onClick={() => setSelected("org")}
+          />
+        </div>
+        <div className="h-px rounded-full w-full bg-outline" />
+        <div className="w-full gap-2 flex flex-col">
+          <NavigationButton
+            icon="description"
+            label="Documentation"
+            selected={selected === "docs"}
+            onClick={() => setSelected("docs")}
+          />
+        </div>
+      </NavigationRail>
+    );
+  },
 };

--- a/src/components/ui/navigation/navigation-rail/NavigationRail.stories.tsx
+++ b/src/components/ui/navigation/navigation-rail/NavigationRail.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { NavigationRail } from "./NavigationRail";
+import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+import { Logo } from "@/components/ui/media/logo-mirrorstack/LogoMirrorStack";
+
+const meta: Meta<typeof NavigationRail> = {
+  title: "UI/Navigation/NavigationRail",
+  component: NavigationRail,
+  decorators: [
+    (Story) => (
+      <div className="h-[500px] flex">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof NavigationRail>;
+
+export const Playground: Story = {
+  render: () => (
+    <NavigationRail
+      logo={
+        <div className="w-8 h-8">
+          <Logo />
+        </div>
+      }
+      header={
+        <IconButton icon="person" variant="text" size="sm" aria-label="Profile" />
+      }
+      footer={
+        <IconButton icon="settings" variant="text" size="sm" aria-label="Settings" />
+      }
+    >
+      <IconButton icon="home" variant="tonal" size="sm" aria-label="Home" />
+      <IconButton icon="search" variant="text" size="sm" aria-label="Search" />
+      <IconButton icon="notifications" variant="text" size="sm" aria-label="Notifications" />
+    </NavigationRail>
+  ),
+};

--- a/src/components/ui/navigation/navigation-rail/NavigationRail.stories.tsx
+++ b/src/components/ui/navigation/navigation-rail/NavigationRail.stories.tsx
@@ -24,52 +24,45 @@ export const Playground: Story = {
     const [selected, setSelected] = useState("apps");
     return (
       <div className="flex flex-col items-center">
-      <Avatar size="lg" fallback="J" square className="ml-4 mb-2" />
-      <NavigationRail
-        footer={
-          <NavigationButton
-            icon="settings"
-            label="Settings"
-            selected={selected === "settings"}
-            onClick={() => setSelected("settings")}
-          />
-        }
-      >
-        <div className="w-full gap-2 flex flex-col">
-          <NavigationButton
-            icon="dashboard"
-            label="Overview"
-            variant="primary"
-            selected={selected === "overview"}
-            onClick={() => setSelected("overview")}
-          />
-          <NavigationButton
-            icon="apps"
-            label="Your Apps"
-            selected={selected === "apps"}
-            onClick={() => setSelected("apps")}
-          />
-        </div>
-        <div className="h-px rounded-full w-full bg-outline" />
-        <div className="w-full gap-2 flex flex-col">
-          <NavigationButton
-            icon="apartment"
-            label="Organizations"
-            variant="tertiary"
-            selected={selected === "org"}
-            onClick={() => setSelected("org")}
-          />
-        </div>
-        <div className="h-px rounded-full w-full bg-outline" />
-        <div className="w-full gap-2 flex flex-col">
-          <NavigationButton
-            icon="description"
-            label="Documentation"
-            selected={selected === "docs"}
-            onClick={() => setSelected("docs")}
-          />
-        </div>
-      </NavigationRail>
+        <button className="ml-4 w-[4.5rem] h-[4.5rem] rounded-2xl bg-surface-bright shadow-2xl flex items-center justify-center cursor-pointer hover:shadow-none transition-all">
+          <Avatar fallback="J" size="md" />
+        </button>
+        <NavigationRail>
+          <div className="w-full gap-2 flex flex-col">
+            <NavigationButton
+              icon="dashboard"
+              label="Overview"
+              selected={selected === "overview"}
+              onClick={() => setSelected("overview")}
+            />
+            <NavigationButton
+              icon="apps"
+              label="Your Apps"
+              variant="primary"
+              selected={selected === "apps"}
+              onClick={() => setSelected("apps")}
+            />
+          </div>
+          <div className="h-px rounded-full w-full bg-outline" />
+          <div className="w-full gap-2 flex flex-col">
+            <NavigationButton
+              icon="apartment"
+              label="Organizations"
+              variant="tertiary"
+              selected={selected === "org"}
+              onClick={() => setSelected("org")}
+            />
+          </div>
+          <div className="h-px rounded-full w-full bg-outline" />
+          <div className="w-full gap-2 flex flex-col">
+            <NavigationButton
+              icon="description"
+              label="Documentation"
+              selected={selected === "docs"}
+              onClick={() => setSelected("docs")}
+            />
+          </div>
+        </NavigationRail>
       </div>
     );
   },

--- a/src/components/ui/navigation/navigation-rail/NavigationRail.stories.tsx
+++ b/src/components/ui/navigation/navigation-rail/NavigationRail.stories.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { NavigationRail } from "./NavigationRail";
 import { NavigationButton } from "@/components/ui/navigation/navigation-button/NavigationButton";
-import { Avatar } from "@/components/ui/media/avatar/Avatar";
 
 const meta: Meta<typeof NavigationRail> = {
   title: "UI/Navigation/NavigationRail",
@@ -23,47 +22,58 @@ export const Playground: Story = {
   render: () => {
     const [selected, setSelected] = useState("apps");
     return (
-      <div className="flex flex-col items-center">
-        <button className="ml-4 w-[4.5rem] h-[4.5rem] rounded-2xl bg-surface-bright shadow-2xl flex items-center justify-center cursor-pointer hover:shadow-none transition-all">
-          <Avatar fallback="J" size="md" />
-        </button>
-        <NavigationRail>
-          <div className="w-full gap-2 flex flex-col">
-            <NavigationButton
-              icon="dashboard"
-              label="Overview"
-              selected={selected === "overview"}
-              onClick={() => setSelected("overview")}
-            />
-            <NavigationButton
-              icon="apps"
-              label="Your Apps"
-              variant="primary"
-              selected={selected === "apps"}
-              onClick={() => setSelected("apps")}
-            />
-          </div>
-          <div className="h-px rounded-full w-full bg-outline" />
-          <div className="w-full gap-2 flex flex-col">
-            <NavigationButton
-              icon="apartment"
-              label="Organizations"
-              variant="tertiary"
-              selected={selected === "org"}
-              onClick={() => setSelected("org")}
-            />
-          </div>
-          <div className="h-px rounded-full w-full bg-outline" />
-          <div className="w-full gap-2 flex flex-col">
-            <NavigationButton
-              icon="description"
-              label="Documentation"
-              selected={selected === "docs"}
-              onClick={() => setSelected("docs")}
-            />
-          </div>
-        </NavigationRail>
-      </div>
+      <NavigationRail
+        logo={
+          <NavigationButton
+            customIcon={
+              <div className="w-full h-full bg-primary/20 flex items-center justify-center">
+                <span className="text-primary font-semibold text-lg">M</span>
+              </div>
+            }
+            label="My App"
+            variant="secondary"
+            disableHoverExpand
+            className="border border-primary"
+          />
+        }
+      >
+        <div className="w-full gap-2 flex flex-col">
+          <NavigationButton
+            icon="space_dashboard"
+            label="Dashboard"
+            variant="primary"
+            selected={selected === "dashboard"}
+            onClick={() => setSelected("dashboard")}
+          />
+          <NavigationButton
+            icon="apps"
+            label="Your Apps"
+            selected={selected === "apps"}
+            onClick={() => setSelected("apps")}
+          />
+        </div>
+        <div className="h-px rounded-full w-full bg-outline" />
+        <div className="w-full gap-2 flex flex-col">
+          <NavigationButton
+            icon="extension"
+            label="Add-ons"
+            selected={selected === "addons"}
+            onClick={() => setSelected("addons")}
+          />
+          <NavigationButton
+            icon="rocket_launch"
+            label="Deployment"
+            selected={selected === "deployment"}
+            onClick={() => setSelected("deployment")}
+          />
+          <NavigationButton
+            icon="settings"
+            label="Settings"
+            selected={selected === "settings"}
+            onClick={() => setSelected("settings")}
+          />
+        </div>
+      </NavigationRail>
     );
   },
 };

--- a/src/components/ui/navigation/navigation-rail/NavigationRail.stories.tsx
+++ b/src/components/ui/navigation/navigation-rail/NavigationRail.stories.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { NavigationRail } from "./NavigationRail";
 import { NavigationButton } from "@/components/ui/navigation/navigation-button/NavigationButton";
-import { Logo } from "@/components/ui/media/logo-mirrorstack/LogoMirrorStack";
 import { Avatar } from "@/components/ui/media/avatar/Avatar";
 
 const meta: Meta<typeof NavigationRail> = {
@@ -24,13 +23,9 @@ export const Playground: Story = {
   render: () => {
     const [selected, setSelected] = useState("apps");
     return (
+      <div className="flex flex-col items-center">
+      <Avatar size="lg" fallback="J" square className="ml-4 mb-2" />
       <NavigationRail
-        logo={
-          <div className="w-10 h-10">
-            <Logo />
-          </div>
-        }
-        header={<Avatar size="sm" fallback="J" />}
         footer={
           <NavigationButton
             icon="settings"
@@ -75,6 +70,7 @@ export const Playground: Story = {
           />
         </div>
       </NavigationRail>
+      </div>
     );
   },
 };

--- a/src/components/ui/navigation/navigation-rail/NavigationRail.test.tsx
+++ b/src/components/ui/navigation/navigation-rail/NavigationRail.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { describe, expect, it, afterEach } from "vitest";
+import { NavigationRail } from "./NavigationRail";
+
+afterEach(cleanup);
+
+describe("NavigationRail", () => {
+  it("renders children", () => {
+    render(<NavigationRail><span>Nav</span></NavigationRail>);
+    expect(screen.getByText("Nav")).toBeInTheDocument();
+  });
+
+  it("renders logo and header", () => {
+    render(
+      <NavigationRail logo={<span>Logo</span>} header={<span>Header</span>}>
+        <span>Nav</span>
+      </NavigationRail>,
+    );
+    expect(screen.getByText("Logo")).toBeInTheDocument();
+    expect(screen.getByText("Header")).toBeInTheDocument();
+  });
+
+  it("shows divider when logo present", () => {
+    const { container } = render(
+      <NavigationRail logo={<span>Logo</span>}><span>Nav</span></NavigationRail>,
+    );
+    expect(container.querySelector(".bg-outline")).toBeInTheDocument();
+  });
+
+  it("hides divider when no logo or header", () => {
+    const { container } = render(
+      <NavigationRail><span>Nav</span></NavigationRail>,
+    );
+    expect(container.querySelector(".bg-outline")).not.toBeInTheDocument();
+  });
+
+  it("renders footer", () => {
+    render(
+      <NavigationRail footer={<span>Footer</span>}><span>Nav</span></NavigationRail>,
+    );
+    expect(screen.getByText("Footer")).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/navigation/navigation-rail/NavigationRail.tsx
+++ b/src/components/ui/navigation/navigation-rail/NavigationRail.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "NavigationRail",
+  description:
+    "Vertical icon-based navigation rail with logo, header, main content, and footer slots",
+};
+
+export interface NavigationRailProps {
+  logo?: ReactNode;
+  header?: ReactNode;
+  children: ReactNode;
+  footer?: ReactNode;
+  className?: string;
+  containerClassName?: string;
+}
+
+export function NavigationRail({
+  logo,
+  header,
+  children,
+  footer,
+  className,
+  containerClassName,
+}: NavigationRailProps) {
+  return (
+    <div className={cn("pl-2 py-4 overflow-visible", className)}>
+      <div
+        className={cn(
+          "ml-2 px-4 py-6 gap-6 flex flex-col items-center rounded-2xl shadow-2xl bg-surface-bright overflow-visible",
+          containerClassName,
+        )}
+      >
+        {logo}
+        {header}
+        {(logo || header) && (
+          <div className="h-px rounded-full w-full bg-outline" />
+        )}
+        {children}
+        {footer && (
+          <>
+            <div className="flex-1" />
+            {footer}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,3 +132,7 @@ export {
   type NavDrawerItem,
   type NavDrawerSection,
 } from "./components/ui/navigation/nav-drawer/NavDrawer";
+export {
+  NavigationRail,
+  type NavigationRailProps,
+} from "./components/ui/navigation/navigation-rail/NavigationRail";

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,3 +136,8 @@ export {
   NavigationRail,
   type NavigationRailProps,
 } from "./components/ui/navigation/navigation-rail/NavigationRail";
+export {
+  NavigationButton,
+  type NavigationButtonProps,
+  type NavigationButtonVariant,
+} from "./components/ui/navigation/navigation-button/NavigationButton";


### PR DESCRIPTION
## Summary
- Vertical rail with logo, header, children, footer slots
- Divider between logo/header and content (only when logo or header present)
- Footer pushed to bottom via flex spacer
- Inner container with rounded-2xl, shadow, bg-surface-bright
- Stories: Playground with Logo, profile, nav icons, settings footer

Closes #8

## Test plan
- [x] `pnpm components validate` — 27 components pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 5 tests pass
- [ ] Visual review in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)