### PR TITLE
feat: add AgentSidebar components (#10)

### DIFF
--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebar.stories.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebar.stories.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { AgentSidebarHeader } from "./AgentSidebarHeader";
+import { AgentSidebarInput } from "./AgentSidebarInput";
+
+const meta: Meta = {
+  title: "UI/Surfaces/AgentSidebar",
+  decorators: [
+    (Story) => (
+      <div className="h-[500px] w-[400px] border border-outline-variant rounded-2xl overflow-hidden flex flex-col">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+export const Header: StoryObj = {
+  render: () => {
+    const [width, setWidth] = useState(400);
+    return (
+      <div className="bg-surface-container">
+        <AgentSidebarHeader
+          sidebarWidth={width}
+          onToggleCollapse={() => setWidth(width <= 350 ? 600 : 350)}
+          onClose={() => console.log("close")}
+        />
+      </div>
+    );
+  },
+};
+
+export const Input: StoryObj = {
+  render: () => (
+    <div className="mt-auto bg-on-background rounded-b-2xl">
+      <AgentSidebarInput
+        onSend={(msg) => console.log("Send:", msg)}
+        onAttachFile={() => console.log("attach")}
+        onMic={() => console.log("mic")}
+      />
+    </div>
+  ),
+};
+
+export const Playground: StoryObj = {
+  render: () => (
+    <>
+      <AgentSidebarHeader
+        sidebarWidth={400}
+        onToggleCollapse={() => {}}
+        onClose={() => {}}
+      />
+      <div className="flex-1 bg-on-background rounded-2xl flex flex-col">
+        <div className="flex-1 p-4 text-inverse-on-surface text-sm">
+          Chat messages would appear here...
+        </div>
+        <AgentSidebarInput
+          onSend={(msg) => console.log("Send:", msg)}
+          onAttachFile={() => console.log("attach")}
+          onMic={() => console.log("mic")}
+        />
+      </div>
+    </>
+  ),
+};

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebar.test.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebar.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { AgentSidebarHeader } from "./AgentSidebarHeader";
+import { AgentSidebarInput } from "./AgentSidebarInput";
+
+afterEach(cleanup);
+
+describe("AgentSidebarHeader", () => {
+  it("renders with default tab", () => {
+    render(
+      <AgentSidebarHeader sidebarWidth={400} onToggleCollapse={() => {}} onClose={() => {}} />,
+    );
+    expect(screen.getByText("Chat 1")).toBeInTheDocument();
+  });
+
+  it("adds a new tab", () => {
+    render(
+      <AgentSidebarHeader sidebarWidth={400} onToggleCollapse={() => {}} onClose={() => {}} />,
+    );
+    fireEvent.click(screen.getByLabelText("New chat"));
+    expect(screen.getByText("Chat 2")).toBeInTheDocument();
+  });
+
+  it("calls onClose", () => {
+    const onClose = vi.fn();
+    render(
+      <AgentSidebarHeader sidebarWidth={400} onToggleCollapse={() => {}} onClose={onClose} />,
+    );
+    fireEvent.click(screen.getByLabelText("Close sidebar"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});
+
+describe("AgentSidebarInput", () => {
+  it("renders textarea", () => {
+    render(<AgentSidebarInput />);
+    expect(screen.getByLabelText("Message to agent")).toBeInTheDocument();
+  });
+
+  it("calls onSend on Enter", () => {
+    const onSend = vi.fn();
+    render(<AgentSidebarInput onSend={onSend} />);
+    const textarea = screen.getByLabelText("Message to agent");
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSend).toHaveBeenCalledWith("hello");
+  });
+
+  it("does not send on Shift+Enter", () => {
+    const onSend = vi.fn();
+    render(<AgentSidebarInput onSend={onSend} />);
+    const textarea = screen.getByLabelText("Message to agent");
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("does not send empty message", () => {
+    const onSend = vi.fn();
+    render(<AgentSidebarInput onSend={onSend} />);
+    fireEvent.click(screen.getByLabelText("Send message"));
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebar.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebar.tsx
@@ -1,0 +1,10 @@
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "AgentSidebar",
+  description:
+    "Agent chat sidebar with tab bar header and auto-expanding message input",
+};
+
+export { AgentSidebarHeader, type AgentSidebarHeaderProps } from "./AgentSidebarHeader";
+export { AgentSidebarInput, type AgentSidebarInputProps } from "./AgentSidebarInput";

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -1,0 +1,123 @@
+import { useState, useRef } from "react";
+import { cn } from "@/utils/cn";
+import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+import { Icon } from "@/components/ui/media/icon/Icon";
+
+interface ChatTab {
+  id: string;
+  title: string;
+}
+
+export interface AgentSidebarHeaderProps {
+  sidebarWidth: number;
+  onToggleCollapse: () => void;
+  onClose: () => void;
+}
+
+export function AgentSidebarHeader({
+  sidebarWidth,
+  onToggleCollapse,
+  onClose,
+}: AgentSidebarHeaderProps) {
+  const isCollapsed = sidebarWidth <= 350;
+
+  const [tabs, setTabs] = useState<ChatTab[]>([{ id: "1", title: "Chat 1" }]);
+  const [activeTabId, setActiveTabId] = useState("1");
+  const nextIdRef = useRef(2);
+  const tabsContainerRef = useRef<HTMLDivElement>(null);
+
+  const handleAddTab = () => {
+    const id = String(nextIdRef.current++);
+    const newTab: ChatTab = { id, title: `Chat ${id}` };
+    setTabs((prev) => [...prev, newTab]);
+    setActiveTabId(id);
+  };
+
+  const handleCloseTab = (tabId: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (tabs.length === 1) return;
+    const idx = tabs.findIndex((t) => t.id === tabId);
+    const newTabs = tabs.filter((t) => t.id !== tabId);
+    setTabs(newTabs);
+    if (tabId === activeTabId) {
+      const next = newTabs[Math.min(idx, newTabs.length - 1)];
+      if (next) setActiveTabId(next.id);
+    }
+  };
+
+  return (
+    <div className="relative flex items-center h-10 shrink-0">
+      <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-2 gap-1.5">
+        <div role="tablist" aria-label="Chat sessions" className="flex h-full gap-1.5">
+          {tabs.map((tab) => {
+            const isActive = tab.id === activeTabId;
+            return (
+              <div
+                key={tab.id}
+                role="tab"
+                aria-selected={isActive}
+                tabIndex={isActive ? 0 : -1}
+                onClick={() => setActiveTabId(tab.id)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setActiveTabId(tab.id);
+                  }
+                }}
+                className={cn(
+                  "flex items-center gap-2 px-3 h-full cursor-pointer select-none text-sm",
+                  isActive
+                    ? "rounded-t-xl bg-on-background text-inverse-on-surface"
+                    : "h-7 m-auto rounded-lg bg-secondary-container text-on-surface/80 hover:bg-on-secondary-container/50",
+                )}
+              >
+                <Icon name="auto_awesome" size={14} />
+                <span className="truncate max-w-[100px]">{tab.title}</span>
+                {tabs.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={(e) => handleCloseTab(tab.id, e)}
+                    className="ml-1 opacity-60 hover:opacity-100"
+                    aria-label={`Close ${tab.title}`}
+                  >
+                    <Icon name="close" size={14} />
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="z-10 h-10 flex justify-center">
+          <IconButton
+            icon="add"
+            variant="text"
+            size="sm"
+            className="m-auto text-on-surface"
+            onClick={handleAddTab}
+            aria-label="New chat"
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-0.5 pr-1 shrink-0">
+        <IconButton
+          icon={isCollapsed ? "unfold_more" : "unfold_less"}
+          variant="text"
+          size="sm"
+          className="rotate-90 text-on-surface"
+          onClick={onToggleCollapse}
+          aria-label={isCollapsed ? "Expand" : "Collapse"}
+        />
+        <IconButton
+          icon="close"
+          variant="text"
+          size="sm"
+          className="text-on-surface"
+          onClick={onClose}
+          aria-label="Close sidebar"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -24,7 +24,6 @@ export function AgentSidebarHeader({
   const [tabs, setTabs] = useState<ChatTab[]>([{ id: "1", title: "Chat 1" }]);
   const [activeTabId, setActiveTabId] = useState("1");
   const nextIdRef = useRef(2);
-  const tabsContainerRef = useRef<HTMLDivElement>(null);
 
   const handleAddTab = () => {
     const id = String(nextIdRef.current++);
@@ -47,47 +46,98 @@ export function AgentSidebarHeader({
 
   return (
     <div className="relative flex items-center h-10 shrink-0">
-      <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-2 gap-1.5">
+      {/* History */}
+      <div className="absolute left-0 top-0 z-10 w-10 h-10 flex justify-center">
+        <IconButton
+          icon="stat_minus_1"
+          variant="text"
+          size="sm"
+          className="m-auto text-on-surface"
+          aria-label="Chat history"
+        />
+      </div>
+
+      {/* Tabs */}
+      <div className="flex-1 flex h-full overflow-hidden pl-10 gap-1.5">
         <div role="tablist" aria-label="Chat sessions" className="flex h-full gap-1.5">
           {tabs.map((tab) => {
             const isActive = tab.id === activeTabId;
             return (
-              <div
-                key={tab.id}
-                role="tab"
-                aria-selected={isActive}
-                tabIndex={isActive ? 0 : -1}
-                onClick={() => setActiveTabId(tab.id)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    setActiveTabId(tab.id);
-                  }
-                }}
-                className={cn(
-                  "flex items-center gap-2 px-3 h-full cursor-pointer select-none text-sm",
-                  isActive
-                    ? "rounded-t-xl bg-on-background text-inverse-on-surface"
-                    : "h-7 m-auto rounded-lg bg-secondary-container text-on-surface/80 hover:bg-on-secondary-container/50",
-                )}
-              >
-                <Icon name="auto_awesome" size={14} />
-                <span className="truncate max-w-[100px]">{tab.title}</span>
+              <div key={tab.id} className="group relative h-full flex">
+                <div
+                  role="tab"
+                  aria-selected={isActive}
+                  tabIndex={isActive ? 0 : -1}
+                  onClick={() => setActiveTabId(tab.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setActiveTabId(tab.id);
+                    }
+                  }}
+                  className="relative h-full flex"
+                >
+                  <div
+                    className={cn(
+                      "relative flex items-center gap-2 px-3 h-full max-w-[200px] cursor-pointer select-none min-w-[100px]",
+                      isActive
+                        ? "rounded-t-xl bg-on-background text-inverse-on-surface z-10"
+                        : "h-7 m-auto rounded-lg bg-secondary-container text-on-surface/80 hover:bg-on-secondary-container/50",
+                    )}
+                  >
+                    {/* Inverse corners for active tab (Chrome-tab style) */}
+                    {isActive && (
+                      <>
+                        <div
+                          className="absolute left-0 w-3 h-3 pointer-events-none"
+                          style={{
+                            bottom: 0,
+                            transform: "translateX(-100%)",
+                            backgroundColor: "var(--color-on-background)",
+                            maskImage: "radial-gradient(circle 12px at 0 0, transparent 12px, black 12px)",
+                            WebkitMaskImage: "radial-gradient(circle 12px at 0 0, transparent 12px, black 12px)",
+                          }}
+                        />
+                        <div
+                          className="absolute right-0 w-3 h-3 pointer-events-none"
+                          style={{
+                            bottom: 0,
+                            transform: "translateX(100%)",
+                            backgroundColor: "var(--color-on-background)",
+                            maskImage: "radial-gradient(circle 12px at 12px 0, transparent 12px, black 12px)",
+                            WebkitMaskImage: "radial-gradient(circle 12px at 12px 0, transparent 12px, black 12px)",
+                          }}
+                        />
+                      </>
+                    )}
+
+                    <Icon name="auto_awesome" size={14} className="shrink-0" />
+                    <span className="text-[13px] font-normal truncate flex-1">{tab.title}</span>
+                    {tabs.length > 1 && <span className="w-5 h-5 shrink-0" />}
+                  </div>
+                </div>
+
+                {/* Close button — visible on hover, always visible when active */}
                 {tabs.length > 1 && (
-                  <button
-                    type="button"
+                  <div
+                    className={cn(
+                      "absolute right-1 top-1/2 -translate-y-1/2 z-20 w-5 h-5 flex items-center justify-center rounded-full hover:bg-inverse-on-surface/15 transition-opacity cursor-pointer",
+                      isActive
+                        ? "opacity-70 hover:opacity-100"
+                        : "opacity-0 group-hover:opacity-70 group-hover:hover:opacity-100",
+                    )}
                     onClick={(e) => handleCloseTab(tab.id, e)}
-                    className="ml-1 opacity-60 hover:opacity-100"
                     aria-label={`Close ${tab.title}`}
                   >
                     <Icon name="close" size={14} />
-                  </button>
+                  </div>
                 )}
               </div>
             );
           })}
         </div>
 
+        {/* Add tab */}
         <div className="z-10 h-10 flex justify-center">
           <IconButton
             icon="add"
@@ -100,6 +150,7 @@ export function AgentSidebarHeader({
         </div>
       </div>
 
+      {/* Actions */}
       <div className="flex items-center gap-0.5 pr-1 shrink-0">
         <IconButton
           icon={isCollapsed ? "unfold_more" : "unfold_less"}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarInput.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarInput.tsx
@@ -55,65 +55,103 @@ export function AgentSidebarInput({
   const iconBtnCls = "text-inverse-on-surface hover:bg-primary-container hover:text-primary";
 
   return (
-    <div className="p-3 pt-2 shrink-0">
-      <div className="flex flex-col border-3 border-inverse-primary rounded-xl">
+    <div className="p-3 pt-2 shrink-0 flex flex-col">
+      <div className="w-full p-1">
+        <span className="text-background/80 text-sm">
+          Tip — ctrl + c to interrupt
+        </span>
+      </div>
+      <div className="flex flex-col w-full border-3 border-inverse-primary rounded-xl">
         <div
           className={cn(
-            "w-full p-0.5 flex gap-0.5",
-            isMultiline ? "flex-col" : "items-center",
+            "justify-between w-full p-0.5 flex gap-0.5",
+            isMultiline ? "flex-col" : "flex-row items-center",
           )}
         >
-          {!isMultiline && (
-            <IconButton
-              icon="attach_file_add"
-              variant="text"
-              size="sm"
-              className={cn("shrink-0", iconBtnCls)}
-              onClick={onAttachFile}
-              aria-label="Attach file"
-            />
-          )}
-          <textarea
-            ref={textareaRef}
-            value={text}
-            onChange={handleChange}
-            onKeyDown={handleKeyDown}
-            onCompositionStart={() => setIsComposing(true)}
-            onCompositionEnd={() => setIsComposing(false)}
-            className="w-full text-on-secondary rounded-lg px-2 py-1 resize-none focus:outline-none bg-transparent"
-            placeholder={placeholder}
-            aria-label="Message to agent"
-            rows={1}
-          />
-          <div className={cn("flex gap-0.5", isMultiline && "items-center")}>
-            {isMultiline && (
+          {isMultiline ? (
+            <>
+              <textarea
+                ref={textareaRef}
+                value={text}
+                onChange={handleChange}
+                onKeyDown={handleKeyDown}
+                onCompositionStart={() => setIsComposing(true)}
+                onCompositionEnd={() => setIsComposing(false)}
+                className="w-full text-on-secondary rounded-lg px-2 py-1 resize-none focus:outline-none bg-transparent"
+                placeholder={placeholder}
+                aria-label="Message to agent"
+                rows={1}
+              />
+              <div className="flex w-full gap-0.5 items-center">
+                <IconButton
+                  icon="attach_file_add"
+                  variant="text"
+                  size="sm"
+                  className={iconBtnCls}
+                  onClick={onAttachFile}
+                  aria-label="Attach file"
+                />
+                <IconButton
+                  icon="mic"
+                  variant="text"
+                  size="sm"
+                  className={iconBtnCls}
+                  onClick={onMic}
+                  aria-label="Voice input"
+                />
+                <div className="flex-1" />
+                <IconButton
+                  icon="send"
+                  variant="filled"
+                  size="sm"
+                  className="bg-tertiary-container hover:bg-tertiary-container-dim"
+                  onClick={send}
+                  aria-label="Send message"
+                />
+              </div>
+            </>
+          ) : (
+            <>
               <IconButton
                 icon="attach_file_add"
                 variant="text"
                 size="sm"
-                className={iconBtnCls}
+                className={cn("shrink-0", iconBtnCls)}
                 onClick={onAttachFile}
                 aria-label="Attach file"
               />
-            )}
-            <IconButton
-              icon="mic"
-              variant="text"
-              size="sm"
-              className={iconBtnCls}
-              onClick={onMic}
-              aria-label="Voice input"
-            />
-            {isMultiline && <div className="flex-1" />}
-            <IconButton
-              icon="send"
-              variant="filled"
-              size="sm"
-              className="bg-tertiary-container hover:bg-tertiary-container-dim"
-              onClick={send}
-              aria-label="Send message"
-            />
-          </div>
+              <textarea
+                ref={textareaRef}
+                value={text}
+                onChange={handleChange}
+                onKeyDown={handleKeyDown}
+                onCompositionStart={() => setIsComposing(true)}
+                onCompositionEnd={() => setIsComposing(false)}
+                className="w-full text-on-secondary rounded-lg px-2 py-1 resize-none focus:outline-none bg-transparent"
+                placeholder={placeholder}
+                aria-label="Message to agent"
+                rows={1}
+              />
+              <div className="flex gap-0.5">
+                <IconButton
+                  icon="mic"
+                  variant="text"
+                  size="sm"
+                  className={iconBtnCls}
+                  onClick={onMic}
+                  aria-label="Voice input"
+                />
+                <IconButton
+                  icon="send"
+                  variant="filled"
+                  size="sm"
+                  className="bg-tertiary-container hover:bg-tertiary-container-dim"
+                  onClick={send}
+                  aria-label="Send message"
+                />
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarInput.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarInput.tsx
@@ -1,0 +1,121 @@
+import {
+  useState,
+  useRef,
+  useEffect,
+  type KeyboardEvent,
+  type ChangeEvent,
+} from "react";
+import { cn } from "@/utils/cn";
+import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+
+export interface AgentSidebarInputProps {
+  onSend?: (message: string) => void;
+  onAttachFile?: () => void;
+  onMic?: () => void;
+  placeholder?: string;
+}
+
+export function AgentSidebarInput({
+  onSend,
+  onAttachFile,
+  onMic,
+  placeholder = "Type a message...",
+}: AgentSidebarInputProps) {
+  const [text, setText] = useState("");
+  const [isComposing, setIsComposing] = useState(false);
+  const [isMultiline, setIsMultiline] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
+    setIsMultiline(text.includes("\n") || el.scrollHeight > el.clientHeight + 2);
+  }, [text]);
+
+  const send = () => {
+    if (!text.trim()) return;
+    onSend?.(text);
+    setText("");
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (isComposing || e.nativeEvent.isComposing) return;
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  };
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setText(e.target.value);
+  };
+
+  const iconBtnCls = "text-inverse-on-surface hover:bg-primary-container hover:text-primary";
+
+  return (
+    <div className="p-3 pt-2 shrink-0">
+      <div className="flex flex-col border-3 border-inverse-primary rounded-xl">
+        <div
+          className={cn(
+            "w-full p-0.5 flex gap-0.5",
+            isMultiline ? "flex-col" : "items-center",
+          )}
+        >
+          {!isMultiline && (
+            <IconButton
+              icon="attach_file_add"
+              variant="text"
+              size="sm"
+              className={cn("shrink-0", iconBtnCls)}
+              onClick={onAttachFile}
+              aria-label="Attach file"
+            />
+          )}
+          <textarea
+            ref={textareaRef}
+            value={text}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            onCompositionStart={() => setIsComposing(true)}
+            onCompositionEnd={() => setIsComposing(false)}
+            className="w-full text-on-secondary rounded-lg px-2 py-1 resize-none focus:outline-none bg-transparent"
+            placeholder={placeholder}
+            aria-label="Message to agent"
+            rows={1}
+          />
+          <div className={cn("flex gap-0.5", isMultiline && "items-center")}>
+            {isMultiline && (
+              <IconButton
+                icon="attach_file_add"
+                variant="text"
+                size="sm"
+                className={iconBtnCls}
+                onClick={onAttachFile}
+                aria-label="Attach file"
+              />
+            )}
+            <IconButton
+              icon="mic"
+              variant="text"
+              size="sm"
+              className={iconBtnCls}
+              onClick={onMic}
+              aria-label="Voice input"
+            />
+            {isMultiline && <div className="flex-1" />}
+            <IconButton
+              icon="send"
+              variant="filled"
+              size="sm"
+              className="bg-tertiary-container hover:bg-tertiary-container-dim"
+              onClick={send}
+              aria-label="Send message"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,3 +132,9 @@ export {
   type NavDrawerItem,
   type NavDrawerSection,
 } from "./components/ui/navigation/nav-drawer/NavDrawer";
+export {
+  AgentSidebarHeader,
+  type AgentSidebarHeaderProps,
+  AgentSidebarInput,
+  type AgentSidebarInputProps,
+} from "./components/ui/surfaces/agent-sidebar/AgentSidebar";


### PR DESCRIPTION
## Summary
- **AgentSidebarHeader**: tab bar with add/close/switch, collapse/expand, close sidebar
- **AgentSidebarInput**: auto-expanding textarea (single-line → multiline), attach file, mic, send buttons, IME composition handling, Enter to send / Shift+Enter for newline
- Stories: Header, Input, Playground (combined)

Closes #10

## Test plan
- [x] `pnpm components validate` — 27 components pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 7 tests pass
- [ ] Visual review in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)