### PR TITLE
feat: add AppShell layout (#12)

### DIFF
--- a/src/components/layout/app-shell/app-shell/AppShell.stories.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.stories.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { AppShell } from "./AppShell";
+import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+
+const meta: Meta<typeof AppShell> = {
+  title: "Layout/AppShell",
+  component: AppShell,
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AppShell>;
+
+export const Playground: Story = {
+  render: () => {
+    const [agentOpen, setAgentOpen] = useState(false);
+    return (
+      <AppShell
+        navigation={
+          <div className="pl-2 py-4">
+            <div className="ml-2 px-4 py-6 gap-4 flex flex-col items-center rounded-2xl shadow-2xl bg-surface-bright">
+              <IconButton icon="home" variant="tonal" size="sm" aria-label="Home" />
+              <IconButton icon="search" variant="text" size="sm" aria-label="Search" />
+              <IconButton icon="notifications" variant="text" size="sm" aria-label="Notifications" />
+            </div>
+          </div>
+        }
+        agentSidebar={
+          <div className="rounded-2xl bg-on-background h-full flex flex-col">
+            <div className="flex-1 p-4 text-inverse-on-surface text-sm">
+              Agent chat content...
+            </div>
+          </div>
+        }
+        agentSidebarOpen={agentOpen}
+        onAgentSidebarToggle={() => setAgentOpen(!agentOpen)}
+      >
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-2xl font-bold text-on-surface mb-4">Dashboard</h1>
+          <p className="text-on-surface-variant">
+            Main content area. The agent sidebar can be toggled with the floating button.
+          </p>
+        </div>
+      </AppShell>
+    );
+  },
+};

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -1,0 +1,176 @@
+import { useState, useRef, useEffect, type ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+
+export const meta: ComponentMeta = {
+  name: "AppShell",
+  description:
+    "Top-level application layout with navigation, app switcher, resizable agent sidebar, and content area",
+};
+
+const MIN_WIDTH = 350;
+const PADDING = 20;
+
+export interface AppShellProps {
+  children: ReactNode;
+  navigation?: ReactNode;
+  appSwitcher?: ReactNode;
+  className?: string;
+  appSwitcherClassName?: string;
+  contentClassName?: string;
+  agentSidebar?: ReactNode;
+  agentSidebarOpen?: boolean;
+  onAgentSidebarToggle?: () => void;
+}
+
+export function AppShell({
+  children,
+  navigation,
+  appSwitcher,
+  className,
+  appSwitcherClassName = "max-w-7xl",
+  contentClassName,
+  agentSidebar,
+  agentSidebarOpen = false,
+  onAgentSidebarToggle,
+}: AppShellProps) {
+  const [sidebarWidth, setSidebarWidth] = useState(MIN_WIDTH);
+  const [isResizing, setIsResizing] = useState(false);
+  const [windowWidth, setWindowWidth] = useState(0);
+  const startX = useRef(0);
+  const startWidth = useRef(0);
+  const maxWidthRef = useRef(800);
+
+  useEffect(() => {
+    const update = () => {
+      setWindowWidth(window.innerWidth);
+      maxWidthRef.current = window.innerWidth - PADDING;
+    };
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
+
+  const isOverlaying =
+    agentSidebarOpen &&
+    windowWidth > 0 &&
+    windowWidth < sidebarWidth + 800;
+
+  const startResize = (e: React.MouseEvent) => {
+    setIsResizing(true);
+    startX.current = e.clientX;
+    startWidth.current = sidebarWidth;
+    document.body.style.cursor = "ew-resize";
+    document.body.style.userSelect = "none";
+  };
+
+  useEffect(() => {
+    if (!isResizing) return;
+
+    const onMove = (e: MouseEvent) => {
+      const diff = startX.current - e.clientX;
+      const next = startWidth.current + diff;
+      setSidebarWidth(Math.min(Math.max(next, MIN_WIDTH), maxWidthRef.current));
+    };
+
+    const onUp = () => {
+      setIsResizing(false);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+    return () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+  }, [isResizing]);
+
+  return (
+    <div className="h-dvh flex bg-background text-on-background overflow-hidden">
+      <div className="flex-1 min-w-0 h-dvh overflow-hidden">
+        <div className={cn("mx-auto w-full h-full relative", className)}>
+          {appSwitcher && (
+            <div className="hidden lg:block absolute top-2 left-0 right-0 z-20 pointer-events-none">
+              <div className={cn("mx-auto w-full px-4", appSwitcherClassName)}>
+                <div className="pointer-events-auto w-fit">
+                  {appSwitcher}
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div className="h-full flex">
+            {navigation && (
+              <div className="hidden lg:flex h-full shrink-0 items-center">
+                {navigation}
+              </div>
+            )}
+
+            <div className="flex-1 min-w-0 flex flex-col h-full overflow-hidden">
+              <main className="relative flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
+                <div
+                  className={cn(
+                    "mx-auto w-full px-6 pb-8",
+                    appSwitcher ? "pt-20" : "pt-6",
+                    contentClassName,
+                  )}
+                >
+                  {children}
+                </div>
+              </main>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {agentSidebarOpen && agentSidebar && (
+        <div
+          className={cn(
+            "flex justify-end shrink-0",
+            isOverlaying
+              ? "fixed top-0 right-0 h-screen z-30"
+              : "relative z-50",
+            !isResizing && "transition-all duration-300",
+          )}
+          style={isOverlaying ? undefined : { width: `${sidebarWidth + 10}px` }}
+        >
+          {isOverlaying && (
+            <div
+              className="fixed inset-0 bg-black/20 -z-10"
+              onClick={onAgentSidebarToggle}
+            />
+          )}
+
+          <div className="flex">
+            <div
+              className="w-2 flex cursor-ew-resize z-20 rounded-full hover:bg-primary-container transition-colors shrink-0"
+              onMouseDown={startResize}
+            />
+            <div
+              className="overflow-hidden relative my-2 mr-2 flex flex-col"
+              style={{ width: `${sidebarWidth}px`, height: "calc(100vh - 1rem)" }}
+            >
+              {agentSidebar}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {!agentSidebarOpen && agentSidebar && (
+        <IconButton
+          icon="smart_toy"
+          variant="tonal"
+          size="md"
+          className="fixed top-2 right-2 z-50"
+          onClick={onAgentSidebarToggle}
+          aria-label="Open agent"
+        />
+      )}
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,3 +132,7 @@ export {
   type NavDrawerItem,
   type NavDrawerSection,
 } from "./components/ui/navigation/nav-drawer/NavDrawer";
+export {
+  AppShell,
+  type AppShellProps,
+} from "./components/layout/app-shell/app-shell/AppShell";


### PR DESCRIPTION
## Summary
- Top-level `h-dvh` flex layout with navigation and content slots
- App switcher floats top-left with independent max-width
- Agent sidebar: resizable via mouse drag (min 350px), overlay with backdrop on narrow viewports
- Floating "smart_toy" button opens sidebar when closed
- Navigation hidden on mobile (`hidden lg:flex`)
- Stories: Playground with inline nav rail + agent sidebar

Closes #12

## Test plan
- [x] `pnpm components validate` — 27 components pass
- [x] `pnpm typecheck` — clean
- [ ] Visual review in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)