### PR TITLE
feat: add AgentSidebar components (#10)

### DIFF
--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebar.stories.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebar.stories.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { AgentSidebarHeader } from "./AgentSidebarHeader";
+import { AgentSidebarInput } from "./AgentSidebarInput";
+
+const meta: Meta = {
+  title: "UI/Surfaces/AgentSidebar",
+  decorators: [
+    (Story) => (
+      <div className="h-[500px] w-[400px] border border-outline-variant rounded-2xl overflow-hidden flex flex-col">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+export const Header: StoryObj = {
+  render: () => {
+    const [width, setWidth] = useState(400);
+    return (
+      <div className="bg-surface-container">
+        <AgentSidebarHeader
+          sidebarWidth={width}
+          onToggleCollapse={() => setWidth(width <= 350 ? 600 : 350)}
+          onClose={() => console.log("close")}
+        />
+      </div>
+    );
+  },
+};
+
+export const Input: StoryObj = {
+  render: () => (
+    <div className="mt-auto bg-on-background rounded-b-2xl">
+      <AgentSidebarInput
+        onSend={(msg) => console.log("Send:", msg)}
+        onAttachFile={() => console.log("attach")}
+        onMic={() => console.log("mic")}
+      />
+    </div>
+  ),
+};
+
+export const Playground: StoryObj = {
+  render: () => (
+    <>
+      <AgentSidebarHeader
+        sidebarWidth={400}
+        onToggleCollapse={() => {}}
+        onClose={() => {}}
+      />
+      <div className="flex-1 bg-on-background rounded-2xl flex flex-col">
+        <div className="flex-1 p-4 text-inverse-on-surface text-sm">
+          Chat messages would appear here...
+        </div>
+        <AgentSidebarInput
+          onSend={(msg) => console.log("Send:", msg)}
+          onAttachFile={() => console.log("attach")}
+          onMic={() => console.log("mic")}
+        />
+      </div>
+    </>
+  ),
+};

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebar.stories.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebar.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta = {
   title: "UI/Surfaces/AgentSidebar",
   decorators: [
     (Story) => (
-      <div className="h-[500px] w-[400px] border border-outline-variant rounded-2xl overflow-hidden flex flex-col">
+      <div className="h-[500px] w-[400px] rounded-2xl overflow-hidden flex flex-col">
         <Story />
       </div>
     ),

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebar.test.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebar.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { AgentSidebarHeader } from "./AgentSidebarHeader";
+import { AgentSidebarInput } from "./AgentSidebarInput";
+
+afterEach(cleanup);
+
+describe("AgentSidebarHeader", () => {
+  it("renders with default tab", () => {
+    render(
+      <AgentSidebarHeader sidebarWidth={400} onToggleCollapse={() => {}} onClose={() => {}} />,
+    );
+    expect(screen.getByText("Chat 1")).toBeInTheDocument();
+  });
+
+  it("adds a new tab", () => {
+    render(
+      <AgentSidebarHeader sidebarWidth={400} onToggleCollapse={() => {}} onClose={() => {}} />,
+    );
+    fireEvent.click(screen.getByLabelText("New chat"));
+    expect(screen.getByText("Chat 2")).toBeInTheDocument();
+  });
+
+  it("calls onClose", () => {
+    const onClose = vi.fn();
+    render(
+      <AgentSidebarHeader sidebarWidth={400} onToggleCollapse={() => {}} onClose={onClose} />,
+    );
+    fireEvent.click(screen.getByLabelText("Close sidebar"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});
+
+describe("AgentSidebarInput", () => {
+  it("renders textarea", () => {
+    render(<AgentSidebarInput />);
+    expect(screen.getByLabelText("Message to agent")).toBeInTheDocument();
+  });
+
+  it("calls onSend on Enter", () => {
+    const onSend = vi.fn();
+    render(<AgentSidebarInput onSend={onSend} />);
+    const textarea = screen.getByLabelText("Message to agent");
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSend).toHaveBeenCalledWith("hello");
+  });
+
+  it("does not send on Shift+Enter", () => {
+    const onSend = vi.fn();
+    render(<AgentSidebarInput onSend={onSend} />);
+    const textarea = screen.getByLabelText("Message to agent");
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("does not send empty message", () => {
+    const onSend = vi.fn();
+    render(<AgentSidebarInput onSend={onSend} />);
+    fireEvent.click(screen.getByLabelText("Send message"));
+    expect(onSend).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebar.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebar.tsx
@@ -1,0 +1,10 @@
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "AgentSidebar",
+  description:
+    "Agent chat sidebar with tab bar header and auto-expanding message input",
+};
+
+export { AgentSidebarHeader, type AgentSidebarHeaderProps } from "./AgentSidebarHeader";
+export { AgentSidebarInput, type AgentSidebarInputProps } from "./AgentSidebarInput";

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -246,7 +246,7 @@ export function AgentSidebarHeader({
               <div
                 key={tab.id}
                 className={cn(
-                  "group/item flex items-center gap-0.5 px-1.5 py-0.5 rounded cursor-pointer transition-colors",
+                  "group/item flex items-center gap-1 px-2 py-1 rounded-md cursor-pointer transition-colors",
                   tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
                 )}
                 onClick={() => { setActiveTabId(tab.id); setShowHistory(false); }}
@@ -358,7 +358,7 @@ export function AgentSidebarHeader({
               <button
                 key={tab.id}
                 className={cn(
-                  "w-full px-1.5 py-0.5 text-left text-sm rounded transition-colors flex items-center gap-0.5",
+                  "w-full px-2 py-1 text-left text-sm rounded-md transition-colors flex items-center gap-1",
                   tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
                 )}
                 onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
@@ -368,7 +368,7 @@ export function AgentSidebarHeader({
             ))}
             <div className="h-px bg-outline-variant mx-1 my-0.5" />
             <button
-              className="w-full px-1.5 py-0.5 text-left text-sm rounded transition-colors flex items-center gap-0.5 text-primary hover:bg-on-surface/10"
+              className="w-full px-2 py-1 text-left text-sm rounded-md transition-colors flex items-center gap-1 text-primary hover:bg-on-surface/10"
               onClick={() => { handleAddTab(); setShowOverflow(false); }}
             >
               <Icon name="add" size={12} />

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -239,7 +239,7 @@ export function AgentSidebarHeader({
           )}
           <div
             ref={histContentRef}
-            className="relative z-10 pt-2 pb-1.5 px-1.5"
+            className="relative z-10 pt-2 pb-1.5 px-1.5 flex flex-col gap-0.5"
             style={{ marginTop: HIST_NOTCH_H, width: HIST_W }}
           >
             {tabs.map((tab) => (
@@ -351,7 +351,7 @@ export function AgentSidebarHeader({
           )}
           <div
             ref={ddContentRef}
-            className="relative z-10 pt-2 pb-1.5 px-1.5"
+            className="relative z-10 pt-2 pb-1.5 px-1.5 flex flex-col gap-0.5"
             style={{ marginTop: DD_NOTCH_H, width: DD_W }}
           >
             {overflowTabs.map((tab) => (

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -24,8 +24,9 @@ const TAB_R = 12;
 const TAB_IR = 12;
 const HEADER_H = 40;
 
-// History dropdown width
+// History dropdown
 const HIST_W = 148;
+const HIST_NOTCH_H = 20;
 
 // Overflow dropdown notch dimensions
 const DD_W = 176;
@@ -219,14 +220,14 @@ export function AgentSidebarHeader({
         <div
           ref={historyDropdownRef}
           className="absolute z-50 overflow-visible"
-          style={{ left: 4, top: `calc(100% - ${DD_NOTCH_H + 4}px)`, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
+          style={{ left: 4, top: HIST_NOTCH_H, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
         >
           {histContentH > 0 && (
             <Notch
               width={HIST_W}
               height={histContentH}
               notchWidth={DD_NOTCH_W}
-              notchHeight={DD_NOTCH_H}
+              notchHeight={HIST_NOTCH_H}
               notchSide="bottom"
               notchOffset={0}
               radius={DD_R}
@@ -238,8 +239,8 @@ export function AgentSidebarHeader({
           )}
           <div
             ref={histContentRef}
-            className="relative z-10 py-1 px-1"
-            style={{ marginTop: DD_NOTCH_H, width: HIST_W }}
+            className="relative z-10 pt-2 pb-1 px-1"
+            style={{ marginTop: HIST_NOTCH_H, width: HIST_W }}
           >
             {tabs.map((tab) => (
               <div

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -23,8 +23,8 @@ const ADD_BTN = 40;
 const DD_W = 176;
 const DD_NOTCH_W = 32; // matches IconButton sm
 const DD_NOTCH_H = 32; // full IconButton sm height (h-8)
-const DD_R = 10;
-const DD_IR = 6;
+const DD_R = 8;
+const DD_IR = 5;
 
 export function AgentSidebarHeader({
   sidebarWidth,
@@ -215,7 +215,7 @@ export function AgentSidebarHeader({
               radius={DD_R}
               inverseRadius={DD_IR}
               stroke="var(--color-primary)"
-              strokeWidth={1}
+              strokeWidth={1.5}
               className="absolute top-0 left-0"
             />
           )}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -1,7 +1,8 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useLayoutEffect } from "react";
 import { cn } from "@/utils/cn";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 import { Icon } from "@/components/ui/media/icon/Icon";
+import { Notch } from "@/components/ui/surfaces/notch/Notch";
 
 interface ChatTab {
   id: string;
@@ -18,6 +19,13 @@ const TAB_WIDTH = 100;
 const GAP = 6;
 const ADD_BTN = 40;
 
+// Overflow dropdown notch dimensions
+const DD_W = 176;
+const DD_NOTCH_W = 32; // matches IconButton sm
+const DD_NOTCH_H = 20; // must be >= DD_R + DD_IR for valid arcs
+const DD_R = 10;
+const DD_IR = 6;
+
 export function AgentSidebarHeader({
   sidebarWidth,
   onToggleCollapse,
@@ -32,7 +40,11 @@ export function AgentSidebarHeader({
   const nextIdRef = useRef(2);
   const tabsContainerRef = useRef<HTMLDivElement>(null);
   const overflowRef = useRef<HTMLDivElement>(null);
+  const triggerBtnRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const ddContentRef = useRef<HTMLDivElement>(null);
+  const [ddContentH, setDdContentH] = useState(0);
+  const [ddNotchX, setDdNotchX] = useState(0);
 
   const calculateVisible = useCallback(() => {
     if (!tabsContainerRef.current) return;
@@ -82,6 +94,18 @@ export function AgentSidebarHeader({
     document.addEventListener("mousedown", handleClick);
     return () => { document.removeEventListener("keydown", handleKey); document.removeEventListener("mousedown", handleClick); };
   }, [showOverflow]);
+
+  useLayoutEffect(() => {
+    if (!showOverflow || !ddContentRef.current) return;
+    setDdContentH(ddContentRef.current.offsetHeight);
+    const triggerBtn = triggerBtnRef.current;
+    const dd = dropdownRef.current;
+    if (triggerBtn && dd) {
+      const btnRect = triggerBtn.getBoundingClientRect();
+      const ddRect = dd.getBoundingClientRect();
+      setDdNotchX(btnRect.left - ddRect.left);
+    }
+  }, [showOverflow, overflowTabs.length]);
 
   const handleAddTab = () => {
     const id = String(nextIdRef.current++);
@@ -163,7 +187,9 @@ export function AgentSidebarHeader({
       {/* Actions */}
       <div ref={overflowRef} className="flex items-center gap-0.5 pr-1 shrink-0">
         {overflowTabs.length > 0 ? (
-          <IconButton icon="more_horiz" variant="text" size="sm" className="text-on-surface" onClick={() => setShowOverflow(!showOverflow)} aria-label={`${overflowTabs.length} more tabs`} />
+          <div ref={triggerBtnRef}>
+            <IconButton icon="more_horiz" variant="text" size="sm" className="text-on-surface" onClick={() => setShowOverflow(!showOverflow)} aria-label={`${overflowTabs.length} more tabs`} />
+          </div>
         ) : (
           <IconButton icon="add" variant="text" size="sm" className="text-on-surface" onClick={handleAddTab} aria-label="New chat" />
         )}
@@ -171,30 +197,54 @@ export function AgentSidebarHeader({
         <IconButton icon="close" variant="text" size="sm" className="text-on-surface" onClick={onClose} aria-label="Close sidebar" />
       </div>
 
-      {/* Overflow dropdown — simple bordered card until NotchedOutline (#112) is built */}
+      {/* Overflow dropdown with notch tab connecting to the ... button */}
       {showOverflow && overflowTabs.length > 0 && (
-        <div ref={dropdownRef} className="absolute top-full right-0 mt-0.5 w-44 bg-surface-container-low border border-primary rounded-lg shadow-lg z-50 py-1.5 px-1.5">
-          {overflowTabs.map((tab) => (
-            <button
-              key={tab.id}
-              className={cn(
-                "w-full px-2.5 py-1.5 text-left text-xs rounded-md transition-colors flex items-center gap-1.5",
-                tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
-              )}
-              onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
-            >
-              <Icon name="auto_awesome" size={12} />
-              <span className="truncate">{tab.title}</span>
-            </button>
-          ))}
-          <div className="h-px bg-outline-variant mx-1 my-1" />
-          <button
-            className="w-full px-2.5 py-1.5 text-left text-xs rounded-md transition-colors flex items-center gap-1.5 text-primary hover:bg-on-surface/10"
-            onClick={() => { handleAddTab(); setShowOverflow(false); }}
+        <div
+          ref={dropdownRef}
+          className="absolute z-50"
+          style={{ right: 0, top: `calc(100% - ${DD_NOTCH_H}px)`, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
+        >
+          {ddContentH > 0 && (
+            <Notch
+              width={DD_W}
+              height={ddContentH}
+              notchWidth={DD_NOTCH_W}
+              notchHeight={DD_NOTCH_H}
+              notchSide="bottom"
+              notchOffset={ddNotchX}
+              radius={DD_R}
+              inverseRadius={DD_IR}
+              stroke="var(--color-outline-variant)"
+              className="absolute top-0 left-0"
+            />
+          )}
+          <div
+            ref={ddContentRef}
+            className="relative z-10 py-1.5 px-1.5"
+            style={{ marginTop: DD_NOTCH_H, width: DD_W }}
           >
-            <Icon name="add" size={12} />
-            <span>New chat</span>
-          </button>
+            {overflowTabs.map((tab) => (
+              <button
+                key={tab.id}
+                className={cn(
+                  "w-full px-2.5 py-1.5 text-left text-xs rounded-md transition-colors flex items-center gap-1.5",
+                  tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
+                )}
+                onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
+              >
+                <Icon name="auto_awesome" size={12} />
+                <span className="truncate">{tab.title}</span>
+              </button>
+            ))}
+            <div className="h-px bg-outline-variant mx-1 my-1" />
+            <button
+              className="w-full px-2.5 py-1.5 text-left text-xs rounded-md transition-colors flex items-center gap-1.5 text-primary hover:bg-on-surface/10"
+              onClick={() => { handleAddTab(); setShowOverflow(false); }}
+            >
+              <Icon name="add" size={12} />
+              <span>New chat</span>
+            </button>
+          </div>
         </div>
       )}
     </div>

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { cn } from "@/utils/cn";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 import { Icon } from "@/components/ui/media/icon/Icon";
@@ -14,6 +14,10 @@ export interface AgentSidebarHeaderProps {
   onClose: () => void;
 }
 
+const TAB_WIDTH = 110;
+const GAP = 6;
+const RESERVED = 90;
+
 export function AgentSidebarHeader({
   sidebarWidth,
   onToggleCollapse,
@@ -23,12 +27,56 @@ export function AgentSidebarHeader({
 
   const [tabs, setTabs] = useState<ChatTab[]>([{ id: "1", title: "Chat 1" }]);
   const [activeTabId, setActiveTabId] = useState("1");
+  const [visibleCount, setVisibleCount] = useState(tabs.length);
+  const [showOverflow, setShowOverflow] = useState(false);
   const nextIdRef = useRef(2);
+  const tabsContainerRef = useRef<HTMLDivElement>(null);
+  const overflowRef = useRef<HTMLDivElement>(null);
+
+  const calculateVisible = useCallback(() => {
+    if (!tabsContainerRef.current) return;
+    const available = tabsContainerRef.current.clientWidth - RESERVED;
+    const overflow = available - 40;
+    const count = Math.floor((overflow + GAP) / (TAB_WIDTH + GAP));
+    setVisibleCount(Math.max(1, Math.min(count, tabs.length)));
+  }, [tabs.length]);
+
+  useEffect(() => {
+    calculateVisible();
+    const el = tabsContainerRef.current;
+    if (!el) return;
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(calculateVisible);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [calculateVisible]);
+
+  // Ensure active tab is always visible by swapping it into visible range
+  let visibleTabs = tabs.slice(0, visibleCount);
+  let overflowTabs = tabs.slice(visibleCount);
+  const activeIdx = tabs.findIndex((t) => t.id === activeTabId);
+  if (activeIdx >= visibleCount && visibleCount > 0) {
+    const swapped = [...tabs];
+    [swapped[activeIdx], swapped[visibleCount - 1]] = [swapped[visibleCount - 1], swapped[activeIdx]];
+    visibleTabs = swapped.slice(0, visibleCount);
+    overflowTabs = swapped.slice(visibleCount);
+  }
+
+  // Close overflow on outside click / Escape
+  useEffect(() => {
+    if (!showOverflow) return;
+    const handleKey = (e: KeyboardEvent) => { if (e.key === "Escape") setShowOverflow(false); };
+    const handleClick = (e: MouseEvent) => {
+      if (overflowRef.current && !overflowRef.current.contains(e.target as Node)) setShowOverflow(false);
+    };
+    document.addEventListener("keydown", handleKey);
+    document.addEventListener("mousedown", handleClick);
+    return () => { document.removeEventListener("keydown", handleKey); document.removeEventListener("mousedown", handleClick); };
+  }, [showOverflow]);
 
   const handleAddTab = () => {
     const id = String(nextIdRef.current++);
-    const newTab: ChatTab = { id, title: `Chat ${id}` };
-    setTabs((prev) => [...prev, newTab]);
+    setTabs((prev) => [...prev, { id, title: `Chat ${id}` }]);
     setActiveTabId(id);
   };
 
@@ -48,19 +96,13 @@ export function AgentSidebarHeader({
     <div className="relative flex items-center h-10 shrink-0">
       {/* History */}
       <div className="absolute left-0 top-0 z-10 w-10 h-10 flex justify-center">
-        <IconButton
-          icon="stat_minus_1"
-          variant="text"
-          size="sm"
-          className="m-auto text-on-surface"
-          aria-label="Chat history"
-        />
+        <IconButton icon="stat_minus_1" variant="text" size="sm" className="m-auto text-on-surface" aria-label="Chat history" />
       </div>
 
-      {/* Tabs */}
-      <div className="flex-1 flex h-full overflow-hidden pl-10 gap-1.5">
+      {/* Tabs + add */}
+      <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-10 gap-1.5">
         <div role="tablist" aria-label="Chat sessions" className="flex h-full gap-1.5">
-          {tabs.map((tab) => {
+          {visibleTabs.map((tab) => {
             const isActive = tab.id === activeTabId;
             return (
               <div key={tab.id} className="group relative h-full flex">
@@ -69,62 +111,33 @@ export function AgentSidebarHeader({
                   aria-selected={isActive}
                   tabIndex={isActive ? 0 : -1}
                   onClick={() => setActiveTabId(tab.id)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      setActiveTabId(tab.id);
-                    }
-                  }}
+                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setActiveTabId(tab.id); } }}
                   className="relative h-full flex"
                 >
                   <div
                     className={cn(
-                      "relative flex items-center gap-2 px-3 h-full max-w-[200px] cursor-pointer select-none min-w-[100px]",
+                      "relative flex items-center gap-2 px-3 h-full cursor-pointer select-none",
                       isActive
-                        ? "rounded-t-xl bg-on-background text-inverse-on-surface z-10"
-                        : "h-7 m-auto rounded-lg bg-secondary-container text-on-surface/80 hover:bg-on-secondary-container/50",
+                        ? "rounded-t-xl bg-on-background text-inverse-on-surface z-10 min-w-[100px] max-w-[200px]"
+                        : "h-7 m-auto rounded-lg bg-secondary-container text-on-surface/80 hover:bg-on-secondary-container/50 min-w-[80px] max-w-[140px]",
                     )}
                   >
-                    {/* Inverse corners for active tab (Chrome-tab style) */}
                     {isActive && (
                       <>
-                        <div
-                          className="absolute left-0 w-3 h-3 pointer-events-none"
-                          style={{
-                            bottom: 0,
-                            transform: "translateX(-100%)",
-                            backgroundColor: "var(--color-on-background)",
-                            maskImage: "radial-gradient(circle 12px at 0 0, transparent 12px, black 12px)",
-                            WebkitMaskImage: "radial-gradient(circle 12px at 0 0, transparent 12px, black 12px)",
-                          }}
-                        />
-                        <div
-                          className="absolute right-0 w-3 h-3 pointer-events-none"
-                          style={{
-                            bottom: 0,
-                            transform: "translateX(100%)",
-                            backgroundColor: "var(--color-on-background)",
-                            maskImage: "radial-gradient(circle 12px at 12px 0, transparent 12px, black 12px)",
-                            WebkitMaskImage: "radial-gradient(circle 12px at 12px 0, transparent 12px, black 12px)",
-                          }}
-                        />
+                        <div className="absolute left-0 w-3 h-3 pointer-events-none" style={{ bottom: 0, transform: "translateX(-100%)", backgroundColor: "var(--color-on-background)", maskImage: "radial-gradient(circle 12px at 0 0, transparent 12px, black 12px)", WebkitMaskImage: "radial-gradient(circle 12px at 0 0, transparent 12px, black 12px)" }} />
+                        <div className="absolute right-0 w-3 h-3 pointer-events-none" style={{ bottom: 0, transform: "translateX(100%)", backgroundColor: "var(--color-on-background)", maskImage: "radial-gradient(circle 12px at 12px 0, transparent 12px, black 12px)", WebkitMaskImage: "radial-gradient(circle 12px at 12px 0, transparent 12px, black 12px)" }} />
                       </>
                     )}
-
                     <Icon name="auto_awesome" size={14} className="shrink-0" />
                     <span className="text-[13px] font-normal truncate flex-1">{tab.title}</span>
                     {tabs.length > 1 && <span className="w-5 h-5 shrink-0" />}
                   </div>
                 </div>
-
-                {/* Close button — visible on hover, always visible when active */}
                 {tabs.length > 1 && (
                   <div
                     className={cn(
                       "absolute right-1 top-1/2 -translate-y-1/2 z-20 w-5 h-5 flex items-center justify-center rounded-full hover:bg-inverse-on-surface/15 transition-opacity cursor-pointer",
-                      isActive
-                        ? "opacity-70 hover:opacity-100"
-                        : "opacity-0 group-hover:opacity-70 group-hover:hover:opacity-100",
+                      isActive ? "opacity-70 hover:opacity-100" : "opacity-0 group-hover:opacity-70 group-hover:hover:opacity-100",
                     )}
                     onClick={(e) => handleCloseTab(tab.id, e)}
                     aria-label={`Close ${tab.title}`}
@@ -137,37 +150,49 @@ export function AgentSidebarHeader({
           })}
         </div>
 
+        {/* Overflow menu */}
+        {overflowTabs.length > 0 && (
+          <div ref={overflowRef} className="relative z-10 h-10 flex justify-center">
+            <IconButton
+              icon="more_horiz"
+              variant="text"
+              size="sm"
+              className="m-auto text-on-surface"
+              onClick={() => setShowOverflow(!showOverflow)}
+              aria-label={`${overflowTabs.length} more tabs`}
+            />
+            {showOverflow && (
+              <div className="absolute top-full left-0 mt-1 w-48 bg-surface-container rounded-lg shadow-lg overflow-hidden z-20">
+                <div className="py-1 px-1">
+                  {overflowTabs.map((tab) => (
+                    <button
+                      key={tab.id}
+                      className={cn(
+                        "w-full px-3 py-2 text-left text-sm rounded-lg transition-colors flex items-center gap-2",
+                        tab.id === activeTabId ? "bg-primary/10 text-primary" : "text-on-surface hover:bg-surface-container-high",
+                      )}
+                      onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
+                    >
+                      <Icon name="auto_awesome" size={14} />
+                      <span className="truncate">{tab.title}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
         {/* Add tab */}
         <div className="z-10 h-10 flex justify-center">
-          <IconButton
-            icon="add"
-            variant="text"
-            size="sm"
-            className="m-auto text-on-surface"
-            onClick={handleAddTab}
-            aria-label="New chat"
-          />
+          <IconButton icon="add" variant="text" size="sm" className="m-auto text-on-surface" onClick={handleAddTab} aria-label="New chat" />
         </div>
       </div>
 
       {/* Actions */}
       <div className="flex items-center gap-0.5 pr-1 shrink-0">
-        <IconButton
-          icon={isCollapsed ? "unfold_more" : "unfold_less"}
-          variant="text"
-          size="sm"
-          className="rotate-90 text-on-surface"
-          onClick={onToggleCollapse}
-          aria-label={isCollapsed ? "Expand" : "Collapse"}
-        />
-        <IconButton
-          icon="close"
-          variant="text"
-          size="sm"
-          className="text-on-surface"
-          onClick={onClose}
-          aria-label="Close sidebar"
-        />
+        <IconButton icon={isCollapsed ? "unfold_more" : "unfold_less"} variant="text" size="sm" className="rotate-90 text-on-surface" onClick={onToggleCollapse} aria-label={isCollapsed ? "Expand" : "Collapse"} />
+        <IconButton icon="close" variant="text" size="sm" className="text-on-surface" onClick={onClose} aria-label="Close sidebar" />
       </div>
     </div>
   );

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -161,7 +161,6 @@ export function AgentSidebarHeader({
                         <div className="absolute right-0 w-3 h-3 pointer-events-none" style={{ bottom: 0, transform: "translateX(100%)", backgroundColor: "var(--color-on-background)", maskImage: "radial-gradient(circle 12px at 12px 0, transparent 12px, black 12px)", WebkitMaskImage: "radial-gradient(circle 12px at 12px 0, transparent 12px, black 12px)" }} />
                       </>
                     )}
-                    <Icon name="auto_awesome" size={14} className="shrink-0" />
                     <span className="text-[13px] font-normal truncate flex-1">{tab.title}</span>
                     {tabs.length > 1 && <span className="w-5 h-5 shrink-0" />}
                   </div>
@@ -233,7 +232,6 @@ export function AgentSidebarHeader({
                 )}
                 onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
               >
-                <Icon name="auto_awesome" size={12} />
                 <span className="truncate">{tab.title}</span>
               </button>
             ))}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -149,7 +149,7 @@ export function AgentSidebarHeader({
         <Notch
           width={1000}
           height={1000}
-          notchWidth={HEADER_H}
+          notchWidth={HEADER_H - TAB_IR}
           notchHeight={activeTabRect.width}
           notchSide="bottom"
           notchOffset={100}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -185,22 +185,20 @@ export function AgentSidebarHeader({
       </div>
       {/* Overflow dropdown — rendered outside the clipped container */}
       {showOverflow && overflowTabs.length > 0 && (
-        <div className="absolute top-full left-10 mt-1 w-48 bg-surface-container rounded-lg shadow-lg z-50">
-          <div className="py-1 px-1">
-            {overflowTabs.map((tab) => (
-              <button
-                key={tab.id}
-                className={cn(
-                  "w-full px-3 py-2 text-left text-sm rounded-lg transition-colors flex items-center gap-2",
-                  tab.id === activeTabId ? "bg-primary/10 text-primary" : "text-on-surface hover:bg-surface-container-high",
-                )}
-                onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
-              >
-                <Icon name="auto_awesome" size={14} />
-                <span className="truncate">{tab.title}</span>
-              </button>
-            ))}
-          </div>
+        <div className="absolute top-full right-12 mt-1 w-40 bg-surface-container rounded-lg shadow-lg z-50 py-1">
+          {overflowTabs.map((tab) => (
+            <button
+              key={tab.id}
+              className={cn(
+                "w-full px-3 py-1.5 text-left text-xs rounded transition-colors flex items-center gap-2",
+                tab.id === activeTabId ? "bg-primary/10 text-primary" : "text-on-surface hover:bg-surface-container-high",
+              )}
+              onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
+            >
+              <Icon name="auto_awesome" size={12} />
+              <span className="truncate">{tab.title}</span>
+            </button>
+          ))}
         </div>
       )}
     </div>

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -158,27 +158,15 @@ export function AgentSidebarHeader({
           })}
         </div>
 
-        {overflowTabs.length > 0 ? (
-          <div ref={overflowRef} className="z-10 h-10 flex justify-center">
-            <IconButton
-              icon="more_horiz"
-              variant="text"
-              size="sm"
-              className="m-auto text-on-surface"
-              onClick={() => setShowOverflow(!showOverflow)}
-              aria-label={`${overflowTabs.length} more tabs`}
-            />
-          </div>
-        ) : (
-          <div className="z-10 h-10 flex justify-center">
-            <IconButton icon="add" variant="text" size="sm" className="m-auto text-on-surface" onClick={handleAddTab} aria-label="New chat" />
-          </div>
-        )}
-
       </div>
 
-      {/* Actions */}
-      <div className="flex items-center gap-0.5 pr-1 shrink-0">
+      {/* Actions — outside the clipped container */}
+      <div ref={overflowRef} className="flex items-center gap-0.5 pr-1 shrink-0">
+        {overflowTabs.length > 0 ? (
+          <IconButton icon="more_horiz" variant="text" size="sm" className="text-on-surface" onClick={() => setShowOverflow(!showOverflow)} aria-label={`${overflowTabs.length} more tabs`} />
+        ) : (
+          <IconButton icon="add" variant="text" size="sm" className="text-on-surface" onClick={handleAddTab} aria-label="New chat" />
+        )}
         <IconButton icon={isCollapsed ? "unfold_more" : "unfold_less"} variant="text" size="sm" className="rotate-90 text-on-surface" onClick={onToggleCollapse} aria-label={isCollapsed ? "Expand" : "Collapse"} />
         <IconButton icon="close" variant="text" size="sm" className="text-on-surface" onClick={onClose} aria-label="Close sidebar" />
       </div>

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -29,7 +29,7 @@ const HIST_W = 220;
 const HIST_NOTCH_H = 24;
 
 // Overflow dropdown notch dimensions
-const DD_W = 176;
+const DD_W = 220;
 const DD_NOTCH_W = 32; // matches IconButton sm
 const DD_NOTCH_H = 24; // full IconButton sm height (h-8)
 const DD_R = 8;

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -215,7 +215,7 @@ export function AgentSidebarHeader({
               radius={DD_R}
               inverseRadius={DD_IR}
               stroke="var(--color-primary)"
-              strokeWidth={1.5}
+              strokeWidth={1}
               className="absolute top-0 left-0"
             />
           )}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -158,8 +158,7 @@ export function AgentSidebarHeader({
           })}
         </div>
 
-        {/* Overflow trigger */}
-        {overflowTabs.length > 0 && (
+        {overflowTabs.length > 0 ? (
           <div ref={overflowRef} className="z-10 h-10 flex justify-center">
             <IconButton
               icon="more_horiz"
@@ -170,13 +169,16 @@ export function AgentSidebarHeader({
               aria-label={`${overflowTabs.length} more tabs`}
             />
           </div>
+        ) : (
+          <div className="z-10 h-10 flex justify-center">
+            <IconButton icon="add" variant="text" size="sm" className="m-auto text-on-surface" onClick={handleAddTab} aria-label="New chat" />
+          </div>
         )}
 
       </div>
 
       {/* Actions */}
       <div className="flex items-center gap-0.5 pr-1 shrink-0">
-        <IconButton icon="add" variant="text" size="sm" className="text-on-surface" onClick={handleAddTab} aria-label="New chat" />
         <IconButton icon={isCollapsed ? "unfold_more" : "unfold_less"} variant="text" size="sm" className="rotate-90 text-on-surface" onClick={onToggleCollapse} aria-label={isCollapsed ? "Expand" : "Collapse"} />
         <IconButton icon="close" variant="text" size="sm" className="text-on-surface" onClick={onClose} aria-label="Close sidebar" />
       </div>
@@ -196,6 +198,14 @@ export function AgentSidebarHeader({
               <span className="truncate">{tab.title}</span>
             </button>
           ))}
+          <div className="h-px bg-outline-variant mx-2 my-1" />
+          <button
+            className="w-full px-2.5 py-1 text-left text-xs rounded transition-colors flex items-center gap-1.5 text-primary hover:bg-surface-container-high"
+            onClick={() => { handleAddTab(); setShowOverflow(false); }}
+          >
+            <Icon name="add" size={12} />
+            <span>New chat</span>
+          </button>
         </div>
       )}
     </div>

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -174,34 +174,34 @@ export function AgentSidebarHeader({
           {visibleTabs.map((tab) => {
             const isActive = tab.id === activeTabId;
             return (
-              <div key={tab.id} className="group relative h-full flex">
+              <div
+                key={tab.id}
+                role="tab"
+                ref={isActive ? activeTabRef : undefined}
+                aria-selected={isActive}
+                tabIndex={isActive ? 0 : -1}
+                onClick={() => setActiveTabId(tab.id)}
+                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setActiveTabId(tab.id); } }}
+                className="group relative h-full flex"
+              >
                 <div
-                  role="tab"
-                  ref={isActive ? activeTabRef : undefined}
-                  aria-selected={isActive}
-                  tabIndex={isActive ? 0 : -1}
-                  onClick={() => setActiveTabId(tab.id)}
-                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setActiveTabId(tab.id); } }}
-                  className="relative h-full flex"
+                  className={cn(
+                    "relative flex items-center gap-2 px-3 h-full cursor-pointer select-none",
+                    isActive
+                      ? "text-inverse-on-surface z-10 min-w-[100px] max-w-[200px]"
+                      : "h-7 m-auto rounded-lg bg-secondary-container text-on-surface/80 hover:bg-on-secondary-container/50 min-w-[80px] max-w-[140px]",
+                  )}
                 >
-                  <div
-                    className={cn(
-                      "relative flex items-center gap-2 px-3 h-full cursor-pointer select-none",
-                      isActive
-                        ? "text-inverse-on-surface z-10 min-w-[100px] max-w-[200px]"
-                        : "h-7 m-auto rounded-lg bg-secondary-container text-on-surface/80 hover:bg-on-secondary-container/50 min-w-[80px] max-w-[140px]",
-                    )}
-                  >
-                    <span className="text-[13px] font-normal truncate flex-1">{tab.title}</span>
-                    {tabs.length > 1 && <span className="w-5 h-5 shrink-0" />}
-                  </div>
+                  <span className="text-[13px] font-normal truncate flex-1">{tab.title}</span>
+                  {tabs.length > 1 && <span className="w-5 h-5 shrink-0" />}
                 </div>
                 {tabs.length > 1 && (
                   <div
                     className={cn(
                       "absolute right-1 top-1/2 -translate-y-1/2 z-20 w-5 h-5 flex items-center justify-center rounded-full transition-opacity cursor-pointer",
-                      isActive ? "text-inverse-on-surface hover:bg-inverse-on-surface/20 opacity-70 hover:opacity-100" : "text-on-surface hover:bg-on-surface/10 opacity-70 hover:opacity-100",
-                      isActive ? "opacity-70 hover:opacity-100" : "opacity-0 group-hover:opacity-70 group-hover:hover:opacity-100",
+                      isActive
+                        ? "text-inverse-on-surface hover:bg-inverse-on-surface/20 opacity-70 hover:opacity-100"
+                        : "text-on-surface hover:bg-on-surface/10 opacity-0 group-hover:opacity-70 group-hover:hover:opacity-100",
                     )}
                     onClick={(e) => handleCloseTab(tab.id, e)}
                     aria-label={`Close ${tab.title}`}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -239,19 +239,19 @@ export function AgentSidebarHeader({
           )}
           <div
             ref={histContentRef}
-            className="relative z-10 pt-2 pb-1 px-1"
+            className="relative z-10 pt-1.5 pb-1 px-1"
             style={{ marginTop: HIST_NOTCH_H, width: HIST_W }}
           >
             {tabs.map((tab) => (
               <div
                 key={tab.id}
                 className={cn(
-                  "group/item flex items-center gap-1.5 px-2 py-1 rounded-md cursor-pointer transition-colors",
+                  "group/item flex items-center gap-1 px-1.5 py-0.5 rounded cursor-pointer transition-colors",
                   tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
                 )}
                 onClick={() => { setActiveTabId(tab.id); setShowHistory(false); }}
               >
-                <span className="text-xs truncate flex-1">{tab.title}</span>
+                <span className="text-[11px] truncate flex-1">{tab.title}</span>
                 {tabs.length > 1 && (
                   <div
                     className="w-4 h-4 shrink-0 flex items-center justify-center rounded-full opacity-0 group-hover/item:opacity-70 hover:!opacity-100 hover:bg-on-surface/10 transition-opacity"
@@ -351,14 +351,14 @@ export function AgentSidebarHeader({
           )}
           <div
             ref={ddContentRef}
-            className="relative z-10 py-1.5 px-1.5"
+            className="relative z-10 pt-1.5 pb-1 px-1"
             style={{ marginTop: DD_NOTCH_H, width: DD_W }}
           >
             {overflowTabs.map((tab) => (
               <button
                 key={tab.id}
                 className={cn(
-                  "w-full px-2.5 py-1.5 text-left text-xs rounded-md transition-colors flex items-center gap-1.5",
+                  "w-full px-1.5 py-0.5 text-left text-[11px] rounded transition-colors flex items-center gap-1",
                   tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
                 )}
                 onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
@@ -366,9 +366,9 @@ export function AgentSidebarHeader({
                 <span className="truncate">{tab.title}</span>
               </button>
             ))}
-            <div className="h-px bg-outline-variant mx-1 my-1" />
+            <div className="h-px bg-outline-variant mx-1 my-0.5" />
             <button
-              className="w-full px-2.5 py-1.5 text-left text-xs rounded-md transition-colors flex items-center gap-1.5 text-primary hover:bg-on-surface/10"
+              className="w-full px-1.5 py-0.5 text-left text-[11px] rounded transition-colors flex items-center gap-1 text-primary hover:bg-on-surface/10"
               onClick={() => { handleAddTab(); setShowOverflow(false); }}
             >
               <Icon name="add" size={12} />

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -202,7 +202,7 @@ export function AgentSidebarHeader({
         <div
           ref={dropdownRef}
           className="absolute z-50 overflow-visible"
-          style={{ right: 1, top: `calc(100% - ${DD_NOTCH_H}px)`, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
+          style={{ right: 1, top: `calc(100% - ${DD_NOTCH_H + 4}px)`, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
         >
           {ddContentH > 0 && (
             <Notch

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -22,7 +22,7 @@ const ADD_BTN = 40;
 // Overflow dropdown notch dimensions
 const DD_W = 176;
 const DD_NOTCH_W = 32; // matches IconButton sm
-const DD_NOTCH_H = 20; // must be >= DD_R + DD_IR for valid arcs
+const DD_NOTCH_H = 32; // full IconButton sm height (h-8)
 const DD_R = 10;
 const DD_IR = 6;
 
@@ -201,8 +201,8 @@ export function AgentSidebarHeader({
       {showOverflow && overflowTabs.length > 0 && (
         <div
           ref={dropdownRef}
-          className="absolute z-50"
-          style={{ right: 0, top: `calc(100% - ${DD_NOTCH_H}px)`, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
+          className="absolute z-50 overflow-visible"
+          style={{ right: 1, top: `calc(100% - ${DD_NOTCH_H}px)`, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
         >
           {ddContentH > 0 && (
             <Notch
@@ -214,7 +214,7 @@ export function AgentSidebarHeader({
               notchOffset={ddNotchX}
               radius={DD_R}
               inverseRadius={DD_IR}
-              stroke="var(--color-outline-variant)"
+              stroke="var(--color-primary)"
               className="absolute top-0 left-0"
             />
           )}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -176,19 +176,19 @@ export function AgentSidebarHeader({
       </div>
       {/* Overflow dropdown — rendered outside the clipped container */}
       {showOverflow && overflowTabs.length > 0 && (
-        <div ref={dropdownRef} className="absolute top-0 right-12 w-40 z-40">
-          {/* Notch behind the ... button */}
-          <div className="absolute top-0 -right-8 w-8 h-10 bg-surface-container rounded-t-lg" />
-          {/* Inverse corner where notch meets dropdown */}
+        <div ref={dropdownRef} className="absolute top-full right-4 z-40">
+          {/* Notch tab behind ... button */}
+          <div className="absolute -top-10 right-0 w-10 h-10 bg-surface-container-low rounded-t-xl border-t border-l border-r border-primary" />
+          {/* Inverse corner left of notch */}
           <div
-            className="absolute top-10 -right-8 w-3 h-3 pointer-events-none"
+            className="absolute -top-3 right-10 w-3 h-3 pointer-events-none"
             style={{
-              backgroundColor: "var(--color-surface-container)",
-              maskImage: "radial-gradient(circle 12px at 12px 0, transparent 12px, black 12px)",
-              WebkitMaskImage: "radial-gradient(circle 12px at 12px 0, transparent 12px, black 12px)",
+              backgroundColor: "var(--color-surface-container-low)",
+              maskImage: "radial-gradient(circle 12px at 0 0, transparent 12px, black 12px)",
+              WebkitMaskImage: "radial-gradient(circle 12px at 0 0, transparent 12px, black 12px)",
             }}
           />
-          <div className="mt-10 bg-surface-container rounded-b-lg rounded-tl-lg shadow-lg py-1 px-1">
+          <div className="bg-surface-container-low rounded-b-xl rounded-tl-xl border border-primary border-t-0 shadow-lg py-1.5 px-1.5">
           {overflowTabs.map((tab) => (
             <button
               key={tab.id}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -199,7 +199,8 @@ export function AgentSidebarHeader({
                 {tabs.length > 1 && (
                   <div
                     className={cn(
-                      "absolute right-1 top-1/2 -translate-y-1/2 z-20 w-5 h-5 flex items-center justify-center rounded-full hover:bg-inverse-on-surface/15 transition-opacity cursor-pointer",
+                      "absolute right-1 z-20 w-5 h-5 flex items-center justify-center rounded-full hover:bg-inverse-on-surface/15 transition-opacity cursor-pointer",
+                      isActive ? "top-[9px]" : "top-1/2 -translate-y-1/2",
                       isActive ? "opacity-70 hover:opacity-100" : "opacity-0 group-hover:opacity-70 group-hover:hover:opacity-100",
                     )}
                     onClick={(e) => handleCloseTab(tab.id, e)}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -176,7 +176,17 @@ export function AgentSidebarHeader({
       </div>
       {/* Overflow dropdown — rendered outside the clipped container */}
       {showOverflow && overflowTabs.length > 0 && (
-        <div ref={dropdownRef} className="absolute top-full right-12 mt-1 w-40 bg-surface-container rounded-lg shadow-lg z-50 py-1 px-1">
+        <div ref={dropdownRef} className="absolute top-[calc(100%-2px)] right-12 w-40 bg-surface-container rounded-b-lg rounded-tl-lg shadow-lg z-50 py-1 px-1">
+          {/* Inverse corner connecting to ... button */}
+          <div
+            className="absolute top-0 right-0 w-3 h-3 pointer-events-none"
+            style={{
+              transform: "translateX(100%) translateY(-100%)",
+              backgroundColor: "var(--color-surface-container)",
+              maskImage: "radial-gradient(circle 12px at 12px 12px, transparent 12px, black 12px)",
+              WebkitMaskImage: "radial-gradient(circle 12px at 12px 12px, transparent 12px, black 12px)",
+            }}
+          />
           {overflowTabs.map((tab) => (
             <button
               key={tab.id}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -266,7 +266,7 @@ const OverflowDropdown = forwardRef<HTMLDivElement, OverflowDropdownProps>(
       <div
         ref={ref}
         className="absolute z-50"
-        style={{ top: 0, right: 0, width: totalW, height: totalH }}
+        style={{ top: 0, right: -NOTCH_W, width: totalW, height: totalH }}
       >
         <svg
           className="absolute inset-0 pointer-events-none"

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -225,7 +225,7 @@ export function AgentSidebarHeader({
               notchWidth={DD_NOTCH_W}
               notchHeight={DD_NOTCH_H}
               notchSide="bottom"
-              notchOffset={histNotchX}
+              notchOffset={0}
               radius={DD_R}
               inverseRadius={DD_IR}
               stroke="var(--color-primary)"

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, forwardRef } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { cn } from "@/utils/cn";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 import { Icon } from "@/components/ui/media/icon/Icon";
@@ -17,55 +17,6 @@ export interface AgentSidebarHeaderProps {
 const TAB_WIDTH = 100;
 const GAP = 6;
 const ADD_BTN = 40;
-
-// SVG path: notch top-right, panel below — mirrored AppSwitcher approach
-const R = 8;
-const CR = 6;
-
-// Notch extends RIGHT from panel body. Total width = pw + nw.
-// Panel: x=0..pw, y=nh..nh+ph
-// Notch: x=pw..pw+nw, y=0..nh (extends right and up from panel top-right)
-function buildOutline(nw: number, nh: number, pw: number, ph: number) {
-  const tw = pw + nw; // total width
-  const th = nh + ph; // total height
-
-  return [
-    // Start at panel top-left
-    `M ${R},${nh}`,
-    // Panel top edge to where notch starts
-    `H ${pw - CR}`,
-    // Inverse concave corner (panel meets notch)
-    `A ${CR},${CR} 0 0,0 ${pw},${nh - CR}`,
-    // Notch left edge up
-    `V ${R}`,
-    // Notch top-left corner
-    `A ${R},${R} 0 0,1 ${pw + R},0`,
-    // Notch top edge
-    `H ${tw - R}`,
-    // Notch top-right corner
-    `A ${R},${R} 0 0,1 ${tw},${R}`,
-    // Notch right edge down
-    `V ${nh}`,
-    // Panel right edge down (panel right = notch right here, panel extends full width)
-    // Actually panel is narrower — go left then down
-    // No: panel right edge is at pw, notch right is at tw
-    // After notch bottom-right, go left to panel right, then down
-    `H ${pw}`,
-    // Panel right edge down (but panel right = pw < tw, no corner needed at pw,nh since notch covers it)
-    `V ${th - R}`,
-    // Panel bottom-right corner
-    `A ${R},${R} 0 0,1 ${pw - R},${th}`,
-    // Panel bottom edge
-    `H ${R}`,
-    // Panel bottom-left corner
-    `A ${R},${R} 0 0,1 0,${th - R}`,
-    // Panel left edge up
-    `V ${nh + R}`,
-    // Panel top-left corner
-    `A ${R},${R} 0 0,1 ${R},${nh}`,
-    `Z`,
-  ].join(" ");
-}
 
 export function AgentSidebarHeader({
   sidebarWidth,
@@ -220,80 +171,17 @@ export function AgentSidebarHeader({
         <IconButton icon="close" variant="text" size="sm" className="text-on-surface" onClick={onClose} aria-label="Close sidebar" />
       </div>
 
-      {/* Overflow dropdown with SVG outline */}
+      {/* Overflow dropdown — simple bordered card until NotchedOutline (#112) is built */}
       {showOverflow && overflowTabs.length > 0 && (
-        <OverflowDropdown
-          ref={dropdownRef}
-          tabs={overflowTabs}
-          activeTabId={activeTabId}
-          onSelect={(id) => { setActiveTabId(id); setShowOverflow(false); }}
-          onAddTab={() => { handleAddTab(); setShowOverflow(false); }}
-        />
-      )}
-    </div>
-  );
-}
-
-interface OverflowDropdownProps {
-  tabs: ChatTab[];
-  activeTabId: string;
-  onSelect: (id: string) => void;
-  onAddTab: () => void;
-}
-
-const NOTCH_W = 34;
-const NOTCH_H = 40;
-const PANEL_W = 176;
-// Notch extends right from panel. Total SVG width = PANEL_W + NOTCH_W.
-// Position: panel right-aligned with sidebar (right: 0), notch sticks out right.
-
-const OverflowDropdown = forwardRef<HTMLDivElement, OverflowDropdownProps>(
-  function OverflowDropdown({ tabs, activeTabId, onSelect, onAddTab }, ref) {
-    const contentRef = useRef<HTMLDivElement>(null);
-    const [panelH, setPanelH] = useState(80);
-
-    useEffect(() => {
-      if (contentRef.current) {
-        setPanelH(contentRef.current.offsetHeight);
-      }
-    }, [tabs.length]);
-
-    const totalW = PANEL_W + NOTCH_W;
-    const path = buildOutline(NOTCH_W, NOTCH_H, PANEL_W, panelH);
-    const totalH = NOTCH_H + panelH;
-
-    return (
-      <div
-        ref={ref}
-        className="absolute z-50"
-        style={{ top: 0, right: -NOTCH_W, width: totalW, height: totalH }}
-      >
-        <svg
-          className="absolute inset-0 pointer-events-none"
-          width={totalW}
-          height={totalH}
-          style={{ filter: "drop-shadow(0 4px 12px rgba(0,0,0,0.08))" }}
-        >
-          <path
-            d={path}
-            fill="var(--color-surface-container-low)"
-            stroke="var(--color-primary)"
-            strokeWidth="1"
-          />
-        </svg>
-        <div
-          ref={contentRef}
-          className="absolute py-1.5 px-1.5"
-          style={{ top: NOTCH_H, left: 0, width: PANEL_W }}
-        >
-          {tabs.map((tab) => (
+        <div ref={dropdownRef} className="absolute top-full right-0 mt-0.5 w-44 bg-surface-container-low border border-primary rounded-lg shadow-lg z-50 py-1.5 px-1.5">
+          {overflowTabs.map((tab) => (
             <button
               key={tab.id}
               className={cn(
                 "w-full px-2.5 py-1.5 text-left text-xs rounded-md transition-colors flex items-center gap-1.5",
                 tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
               )}
-              onClick={() => onSelect(tab.id)}
+              onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
             >
               <Icon name="auto_awesome" size={12} />
               <span className="truncate">{tab.title}</span>
@@ -302,13 +190,13 @@ const OverflowDropdown = forwardRef<HTMLDivElement, OverflowDropdownProps>(
           <div className="h-px bg-outline-variant mx-1 my-1" />
           <button
             className="w-full px-2.5 py-1.5 text-left text-xs rounded-md transition-colors flex items-center gap-1.5 text-primary hover:bg-on-surface/10"
-            onClick={onAddTab}
+            onClick={() => { handleAddTab(); setShowOverflow(false); }}
           >
             <Icon name="add" size={12} />
             <span>New chat</span>
           </button>
         </div>
-      </div>
-    );
-  },
-);
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -3,6 +3,54 @@ import { cn } from "@/utils/cn";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 import { Icon } from "@/components/ui/media/icon/Icon";
 
+/** Draws the unified notch+panel SVG path */
+function OverflowOutline({ notchW, notchH, panelW, panelH, r, concave }: {
+  notchW: number; notchH: number; panelW: number; panelH: number; r: number; concave: number;
+}) {
+  const totalH = notchH + panelH;
+  const nLeft = panelW - notchW;
+  const d = [
+    // Start at top-left of notch
+    `M ${nLeft + r},0`,
+    `H ${panelW - r}`,
+    `A ${r},${r} 0 0,1 ${panelW},${r}`,
+    // Down right side of notch
+    `V ${notchH - concave}`,
+    // Concave corner where notch meets panel right
+    `A ${concave},${concave} 0 0,0 ${panelW + concave},${notchH}`,
+    // This goes off-panel, skip — just go straight down
+  ].join(" ");
+
+  // Simpler: just draw the full shape
+  const path = [
+    `M ${nLeft + r},0`,
+    `H ${panelW - r}`,
+    `A ${r},${r} 0 0,1 ${panelW},${r}`,
+    `V ${notchH}`,
+    `H ${panelW}`,
+    `V ${totalH - r}`,
+    `A ${r},${r} 0 0,1 ${panelW - r},${totalH}`,
+    `H ${r}`,
+    `A ${r},${r} 0 0,1 0,${totalH - r}`,
+    `V ${notchH + r}`,
+    `A ${r},${r} 0 0,1 ${r},${notchH}`,
+    `H ${nLeft - concave}`,
+    `A ${concave},${concave} 0 0,0 ${nLeft},${notchH - concave}`,
+    `V ${r}`,
+    `A ${r},${r} 0 0,1 ${nLeft + r},0`,
+    `Z`,
+  ].join(" ");
+
+  return (
+    <path
+      d={path}
+      fill="var(--color-surface-container-low)"
+      stroke="var(--color-primary)"
+      strokeWidth="1"
+    />
+  );
+}
+
 interface ChatTab {
   id: string;
   title: string;
@@ -25,6 +73,8 @@ export function AgentSidebarHeader({
 }: AgentSidebarHeaderProps) {
   const isCollapsed = sidebarWidth <= 350;
 
+  const [dropdownContentHeight, setDropdownContentHeight] = useState(100);
+  const dropdownContentRef = useRef<HTMLDivElement>(null);
   const [tabs, setTabs] = useState<ChatTab[]>([{ id: "1", title: "Chat 1" }]);
   const [activeTabId, setActiveTabId] = useState("1");
   const [visibleCount, setVisibleCount] = useState(tabs.length);
@@ -70,6 +120,13 @@ export function AgentSidebarHeader({
     visibleTabs = swapped.slice(0, visibleCount);
     overflowTabs = swapped.slice(visibleCount);
   }
+
+  // Measure dropdown content height for SVG
+  useEffect(() => {
+    if (showOverflow && dropdownContentRef.current) {
+      setDropdownContentHeight(dropdownContentRef.current.offsetHeight);
+    }
+  }, [showOverflow, overflowTabs.length]);
 
   // Close overflow on outside click / Escape
   useEffect(() => {
@@ -174,21 +231,14 @@ export function AgentSidebarHeader({
         <IconButton icon={isCollapsed ? "unfold_more" : "unfold_less"} variant="text" size="sm" className="rotate-90 text-on-surface" onClick={onToggleCollapse} aria-label={isCollapsed ? "Expand" : "Collapse"} />
         <IconButton icon="close" variant="text" size="sm" className="text-on-surface" onClick={onClose} aria-label="Close sidebar" />
       </div>
-      {/* Overflow dropdown — rendered outside the clipped container */}
+      {/* Overflow dropdown — SVG outline for unified notch+panel shape */}
       {showOverflow && overflowTabs.length > 0 && (
-        <div ref={dropdownRef} className="absolute top-full right-4 z-40">
-          {/* Notch tab behind ... button */}
-          <div className="absolute -top-10 right-0 w-10 h-10 bg-surface-container-low rounded-t-xl border-t border-l border-r border-primary" />
-          {/* Inverse corner left of notch */}
-          <div
-            className="absolute -top-3 right-10 w-3 h-3 pointer-events-none"
-            style={{
-              backgroundColor: "var(--color-surface-container-low)",
-              maskImage: "radial-gradient(circle 12px at 0 0, transparent 12px, black 12px)",
-              WebkitMaskImage: "radial-gradient(circle 12px at 0 0, transparent 12px, black 12px)",
-            }}
-          />
-          <div className="bg-surface-container-low rounded-b-xl rounded-tl-xl border border-primary border-t-0 shadow-lg py-1.5 px-1.5">
+        <div ref={dropdownRef} className="absolute -top-0.5 right-4 z-40" style={{ width: 176 }}>
+          {/* SVG unified outline — notch on top-right + panel body */}
+          <svg className="absolute inset-0 w-full h-full pointer-events-none" style={{ overflow: "visible", top: -40 }}>
+            <OverflowOutline notchW={40} notchH={40} panelW={176} panelH={dropdownContentHeight} r={12} concave={8} />
+          </svg>
+          <div ref={dropdownContentRef} className="relative z-10 py-1.5 px-1.5">
           {overflowTabs.map((tab) => (
             <button
               key={tab.id}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -3,54 +3,6 @@ import { cn } from "@/utils/cn";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 import { Icon } from "@/components/ui/media/icon/Icon";
 
-/** Draws the unified notch+panel SVG path */
-function OverflowOutline({ notchW, notchH, panelW, panelH, r, concave }: {
-  notchW: number; notchH: number; panelW: number; panelH: number; r: number; concave: number;
-}) {
-  const totalH = notchH + panelH;
-  const nLeft = panelW - notchW;
-  const d = [
-    // Start at top-left of notch
-    `M ${nLeft + r},0`,
-    `H ${panelW - r}`,
-    `A ${r},${r} 0 0,1 ${panelW},${r}`,
-    // Down right side of notch
-    `V ${notchH - concave}`,
-    // Concave corner where notch meets panel right
-    `A ${concave},${concave} 0 0,0 ${panelW + concave},${notchH}`,
-    // This goes off-panel, skip — just go straight down
-  ].join(" ");
-
-  // Simpler: just draw the full shape
-  const path = [
-    `M ${nLeft + r},0`,
-    `H ${panelW - r}`,
-    `A ${r},${r} 0 0,1 ${panelW},${r}`,
-    `V ${notchH}`,
-    `H ${panelW}`,
-    `V ${totalH - r}`,
-    `A ${r},${r} 0 0,1 ${panelW - r},${totalH}`,
-    `H ${r}`,
-    `A ${r},${r} 0 0,1 0,${totalH - r}`,
-    `V ${notchH + r}`,
-    `A ${r},${r} 0 0,1 ${r},${notchH}`,
-    `H ${nLeft - concave}`,
-    `A ${concave},${concave} 0 0,0 ${nLeft},${notchH - concave}`,
-    `V ${r}`,
-    `A ${r},${r} 0 0,1 ${nLeft + r},0`,
-    `Z`,
-  ].join(" ");
-
-  return (
-    <path
-      d={path}
-      fill="var(--color-surface-container-low)"
-      stroke="var(--color-primary)"
-      strokeWidth="1"
-    />
-  );
-}
-
 interface ChatTab {
   id: string;
   title: string;
@@ -73,8 +25,6 @@ export function AgentSidebarHeader({
 }: AgentSidebarHeaderProps) {
   const isCollapsed = sidebarWidth <= 350;
 
-  const [dropdownContentHeight, setDropdownContentHeight] = useState(100);
-  const dropdownContentRef = useRef<HTMLDivElement>(null);
   const [tabs, setTabs] = useState<ChatTab[]>([{ id: "1", title: "Chat 1" }]);
   const [activeTabId, setActiveTabId] = useState("1");
   const [visibleCount, setVisibleCount] = useState(tabs.length);
@@ -94,7 +44,6 @@ export function AgentSidebarHeader({
       return;
     }
 
-    // Need overflow button — subtract its width
     const available = container - ADD_BTN;
     const count = Math.floor((available + GAP) / (TAB_WIDTH + GAP));
     setVisibleCount(Math.max(1, count));
@@ -110,7 +59,7 @@ export function AgentSidebarHeader({
     return () => observer.disconnect();
   }, [calculateVisible]);
 
-  // Ensure active tab is always visible by swapping it into visible range
+  // Ensure active tab is always visible
   let visibleTabs = tabs.slice(0, visibleCount);
   let overflowTabs = tabs.slice(visibleCount);
   const activeIdx = tabs.findIndex((t) => t.id === activeTabId);
@@ -120,13 +69,6 @@ export function AgentSidebarHeader({
     visibleTabs = swapped.slice(0, visibleCount);
     overflowTabs = swapped.slice(visibleCount);
   }
-
-  // Measure dropdown content height for SVG
-  useEffect(() => {
-    if (showOverflow && dropdownContentRef.current) {
-      setDropdownContentHeight(dropdownContentRef.current.offsetHeight);
-    }
-  }, [showOverflow, overflowTabs.length]);
 
   // Close overflow on outside click / Escape
   useEffect(() => {
@@ -168,7 +110,7 @@ export function AgentSidebarHeader({
         <IconButton icon="stat_minus_1" variant="text" size="sm" className="m-auto text-on-surface" aria-label="Chat history" />
       </div>
 
-      {/* Tabs + add */}
+      {/* Tabs */}
       <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-10 gap-1.5">
         <div role="tablist" aria-label="Chat sessions" className="flex h-full gap-1.5">
           {visibleTabs.map((tab) => {
@@ -218,10 +160,9 @@ export function AgentSidebarHeader({
             );
           })}
         </div>
-
       </div>
 
-      {/* Actions — outside the clipped container */}
+      {/* Actions */}
       <div ref={overflowRef} className="flex items-center gap-0.5 pr-1 shrink-0">
         {overflowTabs.length > 0 ? (
           <IconButton icon="more_horiz" variant="text" size="sm" className="text-on-surface" onClick={() => setShowOverflow(!showOverflow)} aria-label={`${overflowTabs.length} more tabs`} />
@@ -231,14 +172,10 @@ export function AgentSidebarHeader({
         <IconButton icon={isCollapsed ? "unfold_more" : "unfold_less"} variant="text" size="sm" className="rotate-90 text-on-surface" onClick={onToggleCollapse} aria-label={isCollapsed ? "Expand" : "Collapse"} />
         <IconButton icon="close" variant="text" size="sm" className="text-on-surface" onClick={onClose} aria-label="Close sidebar" />
       </div>
-      {/* Overflow dropdown — SVG outline for unified notch+panel shape */}
+
+      {/* Overflow dropdown */}
       {showOverflow && overflowTabs.length > 0 && (
-        <div ref={dropdownRef} className="absolute -top-0.5 right-4 z-40" style={{ width: 176 }}>
-          {/* SVG unified outline — notch on top-right + panel body */}
-          <svg className="absolute inset-0 w-full h-full pointer-events-none" style={{ overflow: "visible", top: -40 }}>
-            <OverflowOutline notchW={40} notchH={40} panelW={176} panelH={dropdownContentHeight} r={12} concave={8} />
-          </svg>
-          <div ref={dropdownContentRef} className="relative z-10 py-1.5 px-1.5">
+        <div ref={dropdownRef} className="absolute top-full right-1 mt-0.5 w-44 bg-surface-container-low border border-primary rounded-xl shadow-lg z-50 py-1.5 px-1.5">
           {overflowTabs.map((tab) => (
             <button
               key={tab.id}
@@ -260,7 +197,6 @@ export function AgentSidebarHeader({
             <Icon name="add" size={12} />
             <span>New chat</span>
           </button>
-          </div>
         </div>
       )}
     </div>

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -14,9 +14,9 @@ export interface AgentSidebarHeaderProps {
   onClose: () => void;
 }
 
-const TAB_WIDTH = 110;
+const TAB_WIDTH = 100;
 const GAP = 6;
-const RESERVED = 90;
+const ADD_BTN = 40;
 
 export function AgentSidebarHeader({
   sidebarWidth,
@@ -35,10 +35,18 @@ export function AgentSidebarHeader({
 
   const calculateVisible = useCallback(() => {
     if (!tabsContainerRef.current) return;
-    const available = tabsContainerRef.current.clientWidth - RESERVED;
-    const overflow = available - 40;
-    const count = Math.floor((overflow + GAP) / (TAB_WIDTH + GAP));
-    setVisibleCount(Math.max(1, Math.min(count, tabs.length)));
+    const container = tabsContainerRef.current.clientWidth;
+    const spaceForAll = tabs.length * TAB_WIDTH + (tabs.length - 1) * GAP + ADD_BTN;
+
+    if (spaceForAll <= container) {
+      setVisibleCount(tabs.length);
+      return;
+    }
+
+    // Need overflow button — subtract its width + add button
+    const available = container - ADD_BTN - ADD_BTN;
+    const count = Math.floor((available + GAP) / (TAB_WIDTH + GAP));
+    setVisibleCount(Math.max(1, count));
   }, [tabs.length]);
 
   useEffect(() => {

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -62,7 +62,6 @@ export function AgentSidebarHeader({
   const [ddNotchX, setDdNotchX] = useState(0);
   const histContentRef = useRef<HTMLDivElement>(null);
   const [histContentH, setHistContentH] = useState(0);
-  const [histNotchX, setHistNotchX] = useState(0);
 
   const calculateVisible = useCallback(() => {
     if (!tabsContainerRef.current) return;
@@ -130,13 +129,6 @@ export function AgentSidebarHeader({
   useLayoutEffect(() => {
     if (!showHistory || !histContentRef.current) return;
     setHistContentH(histContentRef.current.offsetHeight);
-    const btn = historyBtnRef.current;
-    const dd = historyDropdownRef.current;
-    if (btn && dd) {
-      const btnRect = btn.getBoundingClientRect();
-      const ddRect = dd.getBoundingClientRect();
-      setHistNotchX(btnRect.left - ddRect.left);
-    }
   }, [showHistory, tabs.length]);
 
   useLayoutEffect(() => {
@@ -166,19 +158,7 @@ export function AgentSidebarHeader({
     setActiveTabId(id);
   };
 
-  const handleDeleteHistory = (tabId: string) => {
-    if (tabs.length === 1) return;
-    const idx = tabs.findIndex((t) => t.id === tabId);
-    const newTabs = tabs.filter((t) => t.id !== tabId);
-    setTabs(newTabs);
-    if (tabId === activeTabId) {
-      const next = newTabs[Math.min(idx, newTabs.length - 1)];
-      if (next) setActiveTabId(next.id);
-    }
-  };
-
-  const handleCloseTab = (tabId: string, e: React.MouseEvent) => {
-    e.stopPropagation();
+  const removeTab = (tabId: string) => {
     if (tabs.length === 1) return;
     const idx = tabs.findIndex((t) => t.id === tabId);
     const newTabs = tabs.filter((t) => t.id !== tabId);
@@ -255,7 +235,7 @@ export function AgentSidebarHeader({
                 {tabs.length > 1 && (
                   <div
                     className="w-4 h-4 shrink-0 flex items-center justify-center rounded-full opacity-0 group-hover/item:opacity-70 hover:!opacity-100 hover:bg-on-surface/10 transition-opacity"
-                    onClick={(e) => { e.stopPropagation(); handleDeleteHistory(tab.id); }}
+                    onClick={(e) => { e.stopPropagation(); removeTab(tab.id); }}
                     aria-label={`Delete ${tab.title}`}
                   >
                     <Icon name="close" size={12} className="text-on-surface-variant" />
@@ -302,7 +282,7 @@ export function AgentSidebarHeader({
                         ? "text-inverse-on-surface hover:bg-inverse-on-surface/20 opacity-70 hover:opacity-100"
                         : "text-on-surface hover:bg-on-surface/10 opacity-0 group-hover:opacity-70 group-hover:hover:opacity-100",
                     )}
-                    onClick={(e) => handleCloseTab(tab.id, e)}
+                    onClick={(e) => { e.stopPropagation(); removeTab(tab.id); }}
                     aria-label={`Close ${tab.title}`}
                   >
                     <Icon name="close" size={14} />

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -108,7 +108,7 @@ export function AgentSidebarHeader({
       </div>
 
       {/* Tabs + add */}
-      <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-10 gap-1.5">
+      <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-x-clip overflow-y-visible pl-10 gap-1.5">
         <div role="tablist" aria-label="Chat sessions" className="flex h-full gap-1.5">
           {visibleTabs.map((tab) => {
             const isActive = tab.id === activeTabId;

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -234,9 +234,9 @@ interface OverflowDropdownProps {
 const NOTCH_W = 32;
 const NOTCH_H = 40;
 const PANEL_W = 180;
-// Right offset: collapse(32) + gap(2) + close(32) + pr(4) = 70, but the ... btn is 32px wide
-// So notch right edge should be at right: ~38px (after ... button ends before collapse starts)
-const DROPDOWN_RIGHT = 38;
+// ... button is 3rd from right: close(32) + gap(2) + collapse(32) + gap(2) + pr(4) = 72
+// Notch right edge should align with ... button's right edge
+const DROPDOWN_RIGHT = 72;
 
 const OverflowDropdown = forwardRef<HTMLDivElement, OverflowDropdownProps>(
   function OverflowDropdown({ tabs, activeTabId, onSelect, onAddTab }, ref) {

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -108,7 +108,7 @@ export function AgentSidebarHeader({
       </div>
 
       {/* Tabs + add */}
-      <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-x-clip overflow-y-visible pl-10 gap-1.5">
+      <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-10 gap-1.5">
         <div role="tablist" aria-label="Chat sessions" className="flex h-full gap-1.5">
           {visibleTabs.map((tab) => {
             const isActive = tab.id === activeTabId;
@@ -158,9 +158,9 @@ export function AgentSidebarHeader({
           })}
         </div>
 
-        {/* Overflow menu */}
+        {/* Overflow trigger */}
         {overflowTabs.length > 0 && (
-          <div ref={overflowRef} className="relative z-10 h-10 flex justify-center">
+          <div ref={overflowRef} className="z-10 h-10 flex justify-center">
             <IconButton
               icon="more_horiz"
               variant="text"
@@ -169,25 +169,6 @@ export function AgentSidebarHeader({
               onClick={() => setShowOverflow(!showOverflow)}
               aria-label={`${overflowTabs.length} more tabs`}
             />
-            {showOverflow && (
-              <div className="absolute top-full left-0 mt-1 w-48 bg-surface-container rounded-lg shadow-lg overflow-hidden z-20">
-                <div className="py-1 px-1">
-                  {overflowTabs.map((tab) => (
-                    <button
-                      key={tab.id}
-                      className={cn(
-                        "w-full px-3 py-2 text-left text-sm rounded-lg transition-colors flex items-center gap-2",
-                        tab.id === activeTabId ? "bg-primary/10 text-primary" : "text-on-surface hover:bg-surface-container-high",
-                      )}
-                      onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
-                    >
-                      <Icon name="auto_awesome" size={14} />
-                      <span className="truncate">{tab.title}</span>
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
           </div>
         )}
 
@@ -202,6 +183,26 @@ export function AgentSidebarHeader({
         <IconButton icon={isCollapsed ? "unfold_more" : "unfold_less"} variant="text" size="sm" className="rotate-90 text-on-surface" onClick={onToggleCollapse} aria-label={isCollapsed ? "Expand" : "Collapse"} />
         <IconButton icon="close" variant="text" size="sm" className="text-on-surface" onClick={onClose} aria-label="Close sidebar" />
       </div>
+      {/* Overflow dropdown — rendered outside the clipped container */}
+      {showOverflow && overflowTabs.length > 0 && (
+        <div className="absolute top-full left-10 mt-1 w-48 bg-surface-container rounded-lg shadow-lg z-50">
+          <div className="py-1 px-1">
+            {overflowTabs.map((tab) => (
+              <button
+                key={tab.id}
+                className={cn(
+                  "w-full px-3 py-2 text-left text-sm rounded-lg transition-colors flex items-center gap-2",
+                  tab.id === activeTabId ? "bg-primary/10 text-primary" : "text-on-surface hover:bg-surface-container-high",
+                )}
+                onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
+              >
+                <Icon name="auto_awesome" size={14} />
+                <span className="truncate">{tab.title}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -199,8 +199,8 @@ export function AgentSidebarHeader({
                 {tabs.length > 1 && (
                   <div
                     className={cn(
-                      "absolute right-1 z-20 w-5 h-5 flex items-center justify-center rounded-full hover:bg-inverse-on-surface/15 transition-opacity cursor-pointer",
-                      isActive ? "top-[9px]" : "top-1/2 -translate-y-1/2",
+                      "absolute right-1 top-1/2 -translate-y-1/2 z-20 w-5 h-5 flex items-center justify-center rounded-full transition-opacity cursor-pointer",
+                      isActive ? "text-inverse-on-surface hover:bg-inverse-on-surface/20 opacity-70 hover:opacity-100" : "hover:bg-inverse-on-surface/15 opacity-0 group-hover:opacity-70 group-hover:hover:opacity-100",
                       isActive ? "opacity-70 hover:opacity-100" : "opacity-0 group-hover:opacity-70 group-hover:hover:opacity-100",
                     )}
                     onClick={(e) => handleCloseTab(tab.id, e)}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, forwardRef } from "react";
 import { cn } from "@/utils/cn";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 import { Icon } from "@/components/ui/media/icon/Icon";
@@ -17,6 +17,31 @@ export interface AgentSidebarHeaderProps {
 const TAB_WIDTH = 100;
 const GAP = 6;
 const ADD_BTN = 40;
+
+// SVG path: notch top-right, panel below — mirrored AppSwitcher approach
+const R = 12;
+
+function buildOutline(nw: number, nh: number, pw: number, ph: number) {
+  const th = nh + ph;
+  const nl = pw - nw; // notch left x
+
+  return [
+    `M ${nl + R},0`,
+    `H ${pw - R}`,
+    `A ${R},${R} 0 0,1 ${pw},${R}`,
+    `V ${th - R}`,
+    `A ${R},${R} 0 0,1 ${pw - R},${th}`,
+    `H ${R}`,
+    `A ${R},${R} 0 0,1 0,${th - R}`,
+    `V ${nh + R}`,
+    `A ${R},${R} 0 0,1 ${R},${nh}`,
+    `H ${nl - R}`,
+    `A ${R},${R} 0 0,0 ${nl},${nh - R}`,
+    `V ${R}`,
+    `A ${R},${R} 0 0,1 ${nl + R},0`,
+    `Z`,
+  ].join(" ");
+}
 
 export function AgentSidebarHeader({
   sidebarWidth,
@@ -59,7 +84,6 @@ export function AgentSidebarHeader({
     return () => observer.disconnect();
   }, [calculateVisible]);
 
-  // Ensure active tab is always visible
   let visibleTabs = tabs.slice(0, visibleCount);
   let overflowTabs = tabs.slice(visibleCount);
   const activeIdx = tabs.findIndex((t) => t.id === activeTabId);
@@ -70,7 +94,6 @@ export function AgentSidebarHeader({
     overflowTabs = swapped.slice(visibleCount);
   }
 
-  // Close overflow on outside click / Escape
   useEffect(() => {
     if (!showOverflow) return;
     const handleKey = (e: KeyboardEvent) => { if (e.key === "Escape") setShowOverflow(false); };
@@ -165,32 +188,85 @@ export function AgentSidebarHeader({
       {/* Actions */}
       <div ref={overflowRef} className="flex items-center gap-0.5 pr-1 shrink-0">
         {overflowTabs.length > 0 ? (
-          <div className="relative">
-            <IconButton icon="more_horiz" variant="text" size="sm" className={cn("text-on-surface relative z-50", showOverflow && "bg-surface-container-low rounded-t-xl border-t border-l border-r border-primary")} onClick={() => setShowOverflow(!showOverflow)} aria-label={`${overflowTabs.length} more tabs`} />
-            {/* Dropdown anchored to ... button */}
-            {showOverflow && (
-              <div ref={dropdownRef} className="absolute top-full right-0 w-44 z-40">
-                {/* Panel body */}
-                <div className="bg-surface-container-low border border-primary border-t-0 rounded-b-xl rounded-tl-xl shadow-lg py-1.5 px-1.5">
-                  {/* Inverse corner top-right connecting to notch */}
-                  <div className="absolute -top-2 right-0 w-2 h-2 bg-surface-container-low" />
-                  {/* Inverse corner top-left of panel */}
-                  <div
-                    className="absolute top-0 -left-2 w-2 h-2 pointer-events-none"
-                    style={{
-                      backgroundColor: "var(--color-surface-container-low)",
-                      maskImage: "radial-gradient(circle 8px at 0 0, transparent 8px, black 8px)",
-                      WebkitMaskImage: "radial-gradient(circle 8px at 0 0, transparent 8px, black 8px)",
-                    }}
-                  />
-          {overflowTabs.map((tab) => (
+          <IconButton icon="more_horiz" variant="text" size="sm" className="text-on-surface" onClick={() => setShowOverflow(!showOverflow)} aria-label={`${overflowTabs.length} more tabs`} />
+        ) : (
+          <IconButton icon="add" variant="text" size="sm" className="text-on-surface" onClick={handleAddTab} aria-label="New chat" />
+        )}
+        <IconButton icon={isCollapsed ? "unfold_more" : "unfold_less"} variant="text" size="sm" className="rotate-90 text-on-surface" onClick={onToggleCollapse} aria-label={isCollapsed ? "Expand" : "Collapse"} />
+        <IconButton icon="close" variant="text" size="sm" className="text-on-surface" onClick={onClose} aria-label="Close sidebar" />
+      </div>
+
+      {/* Overflow dropdown with SVG outline */}
+      {showOverflow && overflowTabs.length > 0 && (
+        <OverflowDropdown
+          ref={dropdownRef}
+          tabs={overflowTabs}
+          activeTabId={activeTabId}
+          onSelect={(id) => { setActiveTabId(id); setShowOverflow(false); }}
+          onAddTab={() => { handleAddTab(); setShowOverflow(false); }}
+        />
+      )}
+    </div>
+  );
+}
+
+interface OverflowDropdownProps {
+  tabs: ChatTab[];
+  activeTabId: string;
+  onSelect: (id: string) => void;
+  onAddTab: () => void;
+}
+
+const NOTCH_W = 36;
+const NOTCH_H = 40;
+const PANEL_W = 176;
+
+const OverflowDropdown = forwardRef<HTMLDivElement, OverflowDropdownProps>(
+  function OverflowDropdown({ tabs, activeTabId, onSelect, onAddTab }, ref) {
+    const contentRef = useRef<HTMLDivElement>(null);
+    const [panelH, setPanelH] = useState(80);
+
+    useEffect(() => {
+      if (contentRef.current) {
+        setPanelH(contentRef.current.offsetHeight);
+      }
+    }, [tabs.length]);
+
+    const path = buildOutline(NOTCH_W, NOTCH_H, PANEL_W, panelH);
+    const totalH = NOTCH_H + panelH;
+
+    return (
+      <div
+        ref={ref}
+        className="absolute z-50"
+        style={{ top: 0, right: 4, width: PANEL_W, height: totalH }}
+      >
+        <svg
+          className="absolute inset-0 pointer-events-none"
+          width={PANEL_W}
+          height={totalH}
+          style={{ filter: "drop-shadow(0 4px 12px rgba(0,0,0,0.08))" }}
+        >
+          <path
+            d={path}
+            fill="var(--color-surface-container-low)"
+            stroke="var(--color-primary)"
+            strokeWidth="1"
+          />
+        </svg>
+        <div
+          ref={contentRef}
+          className="absolute py-1.5 px-1.5"
+          style={{ top: NOTCH_H, left: 0, width: PANEL_W }}
+        >
+          {tabs.map((tab) => (
             <button
               key={tab.id}
               className={cn(
                 "w-full px-2.5 py-1.5 text-left text-xs rounded-md transition-colors flex items-center gap-1.5",
                 tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
               )}
-              onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
+              onClick={() => onSelect(tab.id)}
             >
               <Icon name="auto_awesome" size={12} />
               <span className="truncate">{tab.title}</span>
@@ -199,21 +275,13 @@ export function AgentSidebarHeader({
           <div className="h-px bg-outline-variant mx-1 my-1" />
           <button
             className="w-full px-2.5 py-1.5 text-left text-xs rounded-md transition-colors flex items-center gap-1.5 text-primary hover:bg-on-surface/10"
-            onClick={() => { handleAddTab(); setShowOverflow(false); }}
+            onClick={onAddTab}
           >
             <Icon name="add" size={12} />
             <span>New chat</span>
           </button>
-                </div>
-              </div>
-            )}
-          </div>
-        ) : (
-          <IconButton icon="add" variant="text" size="sm" className="text-on-surface" onClick={handleAddTab} aria-label="New chat" />
-        )}
-        <IconButton icon={isCollapsed ? "unfold_more" : "unfold_less"} variant="text" size="sm" className="rotate-90 text-on-surface" onClick={onToggleCollapse} aria-label={isCollapsed ? "Expand" : "Collapse"} />
-        <IconButton icon="close" variant="text" size="sm" className="text-on-surface" onClick={onClose} aria-label="Close sidebar" />
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  },
+);

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -24,6 +24,9 @@ const TAB_R = 12;
 const TAB_IR = 12;
 const HEADER_H = 40;
 
+// History dropdown width
+const HIST_W = 148;
+
 // Overflow dropdown notch dimensions
 const DD_W = 176;
 const DD_NOTCH_W = 32; // matches IconButton sm
@@ -211,7 +214,7 @@ export function AgentSidebarHeader({
         <IconButton icon="expand_more" variant="text" size="sm" className="m-auto text-on-surface" onClick={() => setShowHistory(!showHistory)} aria-label="Chat history" />
       </div>
 
-      {/* History dropdown with notch tab connecting to the arrow button */}
+      {/* History dropdown */}
       {showHistory && (
         <div
           ref={historyDropdownRef}
@@ -220,7 +223,7 @@ export function AgentSidebarHeader({
         >
           {histContentH > 0 && (
             <Notch
-              width={DD_W}
+              width={HIST_W}
               height={histContentH}
               notchWidth={DD_NOTCH_W}
               notchHeight={DD_NOTCH_H}
@@ -235,15 +238,14 @@ export function AgentSidebarHeader({
           )}
           <div
             ref={histContentRef}
-            className="relative z-10 py-1.5 px-1.5"
-            style={{ marginTop: DD_NOTCH_H, width: DD_W }}
+            className="relative z-10 py-1 px-1"
+            style={{ marginTop: DD_NOTCH_H, width: HIST_W }}
           >
-            <div className="px-2 py-1 text-xs font-medium text-on-surface-variant">Chat history</div>
             {tabs.map((tab) => (
               <div
                 key={tab.id}
                 className={cn(
-                  "group/item flex items-center gap-2 px-2.5 py-1.5 rounded-md cursor-pointer transition-colors",
+                  "group/item flex items-center gap-1.5 px-2 py-1 rounded-md cursor-pointer transition-colors",
                   tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
                 )}
                 onClick={() => { setActiveTabId(tab.id); setShowHistory(false); }}
@@ -251,11 +253,11 @@ export function AgentSidebarHeader({
                 <span className="text-xs truncate flex-1">{tab.title}</span>
                 {tabs.length > 1 && (
                   <div
-                    className="w-5 h-5 shrink-0 flex items-center justify-center rounded-full opacity-0 group-hover/item:opacity-70 hover:!opacity-100 hover:bg-on-surface/10 transition-opacity"
+                    className="w-4 h-4 shrink-0 flex items-center justify-center rounded-full opacity-0 group-hover/item:opacity-70 hover:!opacity-100 hover:bg-on-surface/10 transition-opacity"
                     onClick={(e) => { e.stopPropagation(); handleDeleteHistory(tab.id); }}
                     aria-label={`Delete ${tab.title}`}
                   >
-                    <Icon name="delete" size={14} className="text-on-surface-variant" />
+                    <Icon name="close" size={12} className="text-on-surface-variant" />
                   </div>
                 )}
               </div>

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -56,6 +56,9 @@ export function AgentSidebarHeader({
   const ddContentRef = useRef<HTMLDivElement>(null);
   const [ddContentH, setDdContentH] = useState(0);
   const [ddNotchX, setDdNotchX] = useState(0);
+  const histContentRef = useRef<HTMLDivElement>(null);
+  const [histContentH, setHistContentH] = useState(0);
+  const [histNotchX, setHistNotchX] = useState(0);
 
   const calculateVisible = useCallback(() => {
     if (!tabsContainerRef.current) return;
@@ -119,6 +122,18 @@ export function AgentSidebarHeader({
     document.addEventListener("mousedown", handleClick);
     return () => { document.removeEventListener("keydown", handleKey); document.removeEventListener("mousedown", handleClick); };
   }, [showHistory]);
+
+  useLayoutEffect(() => {
+    if (!showHistory || !histContentRef.current) return;
+    setHistContentH(histContentRef.current.offsetHeight);
+    const btn = historyBtnRef.current;
+    const dd = historyDropdownRef.current;
+    if (btn && dd) {
+      const btnRect = btn.getBoundingClientRect();
+      const ddRect = dd.getBoundingClientRect();
+      setHistNotchX(btnRect.left - ddRect.left);
+    }
+  }, [showHistory, tabs.length]);
 
   useLayoutEffect(() => {
     const tab = activeTabRef.current;
@@ -192,35 +207,60 @@ export function AgentSidebarHeader({
       )}
 
       {/* History */}
-      <div ref={historyBtnRef} className="absolute left-0 top-0 z-10 w-10 h-10 flex justify-center">
+      <div ref={historyBtnRef} className="absolute left-0 top-0 z-[51] w-10 h-10 flex justify-center">
         <IconButton icon="expand_more" variant="text" size="sm" className="m-auto text-on-surface" onClick={() => setShowHistory(!showHistory)} aria-label="Chat history" />
       </div>
 
-      {/* History dropdown */}
+      {/* History dropdown with notch tab connecting to the arrow button */}
       {showHistory && (
-        <div ref={historyDropdownRef} className="absolute left-1 top-full z-50 w-56 bg-surface-container-low border border-outline-variant rounded-lg shadow-lg py-1">
-          <div className="px-3 py-1.5 text-xs font-medium text-on-surface-variant">Chat history</div>
-          {tabs.map((tab) => (
-            <div
-              key={tab.id}
-              className={cn(
-                "group/item flex items-center gap-2 px-3 py-1.5 mx-1 rounded-md cursor-pointer transition-colors",
-                tab.id === activeTabId ? "bg-primary/10 text-primary" : "text-on-surface hover:bg-on-surface/8",
-              )}
-              onClick={() => { setActiveTabId(tab.id); setShowHistory(false); }}
-            >
-              <span className="text-xs truncate flex-1">{tab.title}</span>
-              {tabs.length > 1 && (
-                <div
-                  className="w-5 h-5 shrink-0 flex items-center justify-center rounded-full opacity-0 group-hover/item:opacity-70 hover:!opacity-100 hover:bg-on-surface/10 transition-opacity"
-                  onClick={(e) => { e.stopPropagation(); handleDeleteHistory(tab.id); }}
-                  aria-label={`Delete ${tab.title}`}
-                >
-                  <Icon name="delete" size={14} className="text-on-surface-variant" />
-                </div>
-              )}
-            </div>
-          ))}
+        <div
+          ref={historyDropdownRef}
+          className="absolute z-50 overflow-visible"
+          style={{ left: 1, top: `calc(100% - ${DD_NOTCH_H + 4}px)`, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
+        >
+          {histContentH > 0 && (
+            <Notch
+              width={DD_W}
+              height={histContentH}
+              notchWidth={DD_NOTCH_W}
+              notchHeight={DD_NOTCH_H}
+              notchSide="bottom"
+              notchOffset={histNotchX}
+              radius={DD_R}
+              inverseRadius={DD_IR}
+              stroke="var(--color-primary)"
+              strokeWidth={1.5}
+              className="absolute top-0 left-0"
+            />
+          )}
+          <div
+            ref={histContentRef}
+            className="relative z-10 py-1.5 px-1.5"
+            style={{ marginTop: DD_NOTCH_H, width: DD_W }}
+          >
+            <div className="px-2 py-1 text-xs font-medium text-on-surface-variant">Chat history</div>
+            {tabs.map((tab) => (
+              <div
+                key={tab.id}
+                className={cn(
+                  "group/item flex items-center gap-2 px-2.5 py-1.5 rounded-md cursor-pointer transition-colors",
+                  tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
+                )}
+                onClick={() => { setActiveTabId(tab.id); setShowHistory(false); }}
+              >
+                <span className="text-xs truncate flex-1">{tab.title}</span>
+                {tabs.length > 1 && (
+                  <div
+                    className="w-5 h-5 shrink-0 flex items-center justify-center rounded-full opacity-0 group-hover/item:opacity-70 hover:!opacity-100 hover:bg-on-surface/10 transition-opacity"
+                    onClick={(e) => { e.stopPropagation(); handleDeleteHistory(tab.id); }}
+                    aria-label={`Delete ${tab.title}`}
+                  >
+                    <Icon name="delete" size={14} className="text-on-surface-variant" />
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
         </div>
       )}
 

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -187,7 +187,7 @@ export function AgentSidebarHeader({
       {/* Actions */}
       <div ref={overflowRef} className="flex items-center gap-0.5 pr-1 shrink-0">
         {overflowTabs.length > 0 ? (
-          <div ref={triggerBtnRef}>
+          <div ref={triggerBtnRef} className="relative z-[51]">
             <IconButton icon="more_horiz" variant="text" size="sm" className="text-on-surface" onClick={() => setShowOverflow(!showOverflow)} aria-label={`${overflowTabs.length} more tabs`} />
           </div>
         ) : (
@@ -215,6 +215,7 @@ export function AgentSidebarHeader({
               radius={DD_R}
               inverseRadius={DD_IR}
               stroke="var(--color-primary)"
+              strokeWidth={1.5}
               className="absolute top-0 left-0"
             />
           )}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -25,11 +25,11 @@ const TAB_IR = 12;
 const HEADER_H = 40;
 
 // History dropdown
-const HIST_W = 220;
+const HIST_W = 260;
 const HIST_NOTCH_H = 24;
 
 // Overflow dropdown notch dimensions
-const DD_W = 220;
+const DD_W = 260;
 const DD_NOTCH_W = 32; // matches IconButton sm
 const DD_NOTCH_H = 24; // full IconButton sm height (h-8)
 const DD_R = 8;

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -165,17 +165,24 @@ export function AgentSidebarHeader({
       {/* Actions */}
       <div ref={overflowRef} className="flex items-center gap-0.5 pr-1 shrink-0">
         {overflowTabs.length > 0 ? (
-          <IconButton icon="more_horiz" variant="text" size="sm" className="text-on-surface" onClick={() => setShowOverflow(!showOverflow)} aria-label={`${overflowTabs.length} more tabs`} />
-        ) : (
-          <IconButton icon="add" variant="text" size="sm" className="text-on-surface" onClick={handleAddTab} aria-label="New chat" />
-        )}
-        <IconButton icon={isCollapsed ? "unfold_more" : "unfold_less"} variant="text" size="sm" className="rotate-90 text-on-surface" onClick={onToggleCollapse} aria-label={isCollapsed ? "Expand" : "Collapse"} />
-        <IconButton icon="close" variant="text" size="sm" className="text-on-surface" onClick={onClose} aria-label="Close sidebar" />
-      </div>
-
-      {/* Overflow dropdown */}
-      {showOverflow && overflowTabs.length > 0 && (
-        <div ref={dropdownRef} className="absolute top-full right-1 mt-0.5 w-44 bg-surface-container-low border border-primary rounded-xl shadow-lg z-50 py-1.5 px-1.5">
+          <div className="relative">
+            <IconButton icon="more_horiz" variant="text" size="sm" className={cn("text-on-surface relative z-50", showOverflow && "bg-surface-container-low rounded-t-xl border-t border-l border-r border-primary")} onClick={() => setShowOverflow(!showOverflow)} aria-label={`${overflowTabs.length} more tabs`} />
+            {/* Dropdown anchored to ... button */}
+            {showOverflow && (
+              <div ref={dropdownRef} className="absolute top-full right-0 w-44 z-40">
+                {/* Panel body */}
+                <div className="bg-surface-container-low border border-primary border-t-0 rounded-b-xl rounded-tl-xl shadow-lg py-1.5 px-1.5">
+                  {/* Inverse corner top-right connecting to notch */}
+                  <div className="absolute -top-2 right-0 w-2 h-2 bg-surface-container-low" />
+                  {/* Inverse corner top-left of panel */}
+                  <div
+                    className="absolute top-0 -left-2 w-2 h-2 pointer-events-none"
+                    style={{
+                      backgroundColor: "var(--color-surface-container-low)",
+                      maskImage: "radial-gradient(circle 8px at 0 0, transparent 8px, black 8px)",
+                      WebkitMaskImage: "radial-gradient(circle 8px at 0 0, transparent 8px, black 8px)",
+                    }}
+                  />
           {overflowTabs.map((tab) => (
             <button
               key={tab.id}
@@ -197,8 +204,16 @@ export function AgentSidebarHeader({
             <Icon name="add" size={12} />
             <span>New chat</span>
           </button>
-        </div>
-      )}
+                </div>
+              </div>
+            )}
+          </div>
+        ) : (
+          <IconButton icon="add" variant="text" size="sm" className="text-on-surface" onClick={handleAddTab} aria-label="New chat" />
+        )}
+        <IconButton icon={isCollapsed ? "unfold_more" : "unfold_less"} variant="text" size="sm" className="rotate-90 text-on-surface" onClick={onToggleCollapse} aria-label={isCollapsed ? "Expand" : "Collapse"} />
+        <IconButton icon="close" variant="text" size="sm" className="text-on-surface" onClick={onClose} aria-label="Close sidebar" />
+      </div>
     </div>
   );
 }

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -36,15 +36,15 @@ export function AgentSidebarHeader({
   const calculateVisible = useCallback(() => {
     if (!tabsContainerRef.current) return;
     const container = tabsContainerRef.current.clientWidth;
-    const spaceForAll = tabs.length * TAB_WIDTH + (tabs.length - 1) * GAP + ADD_BTN;
+    const spaceForAll = tabs.length * TAB_WIDTH + (tabs.length - 1) * GAP;
 
     if (spaceForAll <= container) {
       setVisibleCount(tabs.length);
       return;
     }
 
-    // Need overflow button — subtract its width + add button
-    const available = container - ADD_BTN - ADD_BTN;
+    // Need overflow button — subtract its width
+    const available = container - ADD_BTN;
     const count = Math.floor((available + GAP) / (TAB_WIDTH + GAP));
     setVisibleCount(Math.max(1, count));
   }, [tabs.length]);
@@ -172,14 +172,11 @@ export function AgentSidebarHeader({
           </div>
         )}
 
-        {/* Add tab */}
-        <div className="z-10 h-10 flex justify-center">
-          <IconButton icon="add" variant="text" size="sm" className="m-auto text-on-surface" onClick={handleAddTab} aria-label="New chat" />
-        </div>
       </div>
 
       {/* Actions */}
       <div className="flex items-center gap-0.5 pr-1 shrink-0">
+        <IconButton icon="add" variant="text" size="sm" className="text-on-surface" onClick={handleAddTab} aria-label="New chat" />
         <IconButton icon={isCollapsed ? "unfold_more" : "unfold_less"} variant="text" size="sm" className="rotate-90 text-on-surface" onClick={onToggleCollapse} aria-label={isCollapsed ? "Expand" : "Collapse"} />
         <IconButton icon="close" variant="text" size="sm" className="text-on-surface" onClick={onClose} aria-label="Close sidebar" />
       </div>
@@ -190,7 +187,7 @@ export function AgentSidebarHeader({
             <button
               key={tab.id}
               className={cn(
-                "w-full px-3 py-1.5 text-left text-xs rounded transition-colors flex items-center gap-2",
+                "w-full px-2.5 py-1 text-left text-xs rounded transition-colors flex items-center gap-1.5",
                 tab.id === activeTabId ? "bg-primary/10 text-primary" : "text-on-surface hover:bg-surface-container-high",
               )}
               onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -19,6 +19,11 @@ const TAB_WIDTH = 100;
 const GAP = 6;
 const ADD_BTN = 40;
 
+// Active tab notch (headOnly)
+const TAB_R = 12;
+const TAB_IR = 12;
+const HEADER_H = 40;
+
 // Overflow dropdown notch dimensions
 const DD_W = 176;
 const DD_NOTCH_W = 32; // matches IconButton sm
@@ -38,6 +43,9 @@ export function AgentSidebarHeader({
   const [visibleCount, setVisibleCount] = useState(tabs.length);
   const [showOverflow, setShowOverflow] = useState(false);
   const nextIdRef = useRef(2);
+  const headerRef = useRef<HTMLDivElement>(null);
+  const activeTabRef = useRef<HTMLDivElement>(null);
+  const [activeTabRect, setActiveTabRect] = useState<{ left: number; width: number } | null>(null);
   const tabsContainerRef = useRef<HTMLDivElement>(null);
   const overflowRef = useRef<HTMLDivElement>(null);
   const triggerBtnRef = useRef<HTMLDivElement>(null);
@@ -96,6 +104,15 @@ export function AgentSidebarHeader({
   }, [showOverflow]);
 
   useLayoutEffect(() => {
+    const tab = activeTabRef.current;
+    const header = headerRef.current;
+    if (!tab || !header) { setActiveTabRect(null); return; }
+    const tRect = tab.getBoundingClientRect();
+    const hRect = header.getBoundingClientRect();
+    setActiveTabRect({ left: tRect.left - hRect.left, width: tRect.width });
+  }, [activeTabId, visibleCount]);
+
+  useLayoutEffect(() => {
     if (!showOverflow || !ddContentRef.current) return;
     setDdContentH(ddContentRef.current.offsetHeight);
     const triggerBtn = triggerBtnRef.current;
@@ -126,7 +143,26 @@ export function AgentSidebarHeader({
   };
 
   return (
-    <div className="relative flex items-center h-10 shrink-0">
+    <div ref={headerRef} className="relative flex items-center h-10 shrink-0">
+      {/* Active tab notch shape (rendered at header level to avoid overflow clip) */}
+      {activeTabRect && (
+        <Notch
+          width={1000}
+          height={1000}
+          notchWidth={HEADER_H}
+          notchHeight={activeTabRect.width}
+          notchSide="top"
+          notchOffset={100}
+          radius={TAB_R}
+          inverseRadius={TAB_IR}
+          fill="var(--color-on-background)"
+          stroke="none"
+          headOnly
+          className="absolute z-[5]"
+          style={{ left: activeTabRect.left - TAB_IR, top: 0 }}
+        />
+      )}
+
       {/* History */}
       <div className="absolute left-0 top-0 z-10 w-10 h-10 flex justify-center">
         <IconButton icon="stat_minus_1" variant="text" size="sm" className="m-auto text-on-surface" aria-label="Chat history" />
@@ -141,6 +177,7 @@ export function AgentSidebarHeader({
               <div key={tab.id} className="group relative h-full flex">
                 <div
                   role="tab"
+                  ref={isActive ? activeTabRef : undefined}
                   aria-selected={isActive}
                   tabIndex={isActive ? 0 : -1}
                   onClick={() => setActiveTabId(tab.id)}
@@ -151,16 +188,10 @@ export function AgentSidebarHeader({
                     className={cn(
                       "relative flex items-center gap-2 px-3 h-full cursor-pointer select-none",
                       isActive
-                        ? "rounded-t-xl bg-on-background text-inverse-on-surface z-10 min-w-[100px] max-w-[200px]"
+                        ? "text-inverse-on-surface z-10 min-w-[100px] max-w-[200px]"
                         : "h-7 m-auto rounded-lg bg-secondary-container text-on-surface/80 hover:bg-on-secondary-container/50 min-w-[80px] max-w-[140px]",
                     )}
                   >
-                    {isActive && (
-                      <>
-                        <div className="absolute left-0 w-3 h-3 pointer-events-none" style={{ bottom: 0, transform: "translateX(-100%)", backgroundColor: "var(--color-on-background)", maskImage: "radial-gradient(circle 12px at 0 0, transparent 12px, black 12px)", WebkitMaskImage: "radial-gradient(circle 12px at 0 0, transparent 12px, black 12px)" }} />
-                        <div className="absolute right-0 w-3 h-3 pointer-events-none" style={{ bottom: 0, transform: "translateX(100%)", backgroundColor: "var(--color-on-background)", maskImage: "radial-gradient(circle 12px at 12px 0, transparent 12px, black 12px)", WebkitMaskImage: "radial-gradient(circle 12px at 12px 0, transparent 12px, black 12px)" }} />
-                      </>
-                    )}
                     <span className="text-[13px] font-normal truncate flex-1">{tab.title}</span>
                     {tabs.length > 1 && <span className="w-5 h-5 shrink-0" />}
                   </div>

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -26,12 +26,12 @@ const HEADER_H = 40;
 
 // History dropdown
 const HIST_W = 148;
-const HIST_NOTCH_H = 28;
+const HIST_NOTCH_H = 24;
 
 // Overflow dropdown notch dimensions
 const DD_W = 176;
 const DD_NOTCH_W = 32; // matches IconButton sm
-const DD_NOTCH_H = 32; // full IconButton sm height (h-8)
+const DD_NOTCH_H = 24; // full IconButton sm height (h-8)
 const DD_R = 8;
 const DD_IR = 8;
 
@@ -206,7 +206,7 @@ export function AgentSidebarHeader({
           stroke="none"
           headOnly
           className="absolute z-[5]"
-          style={{ left: activeTabRect.left - TAB_IR, top: 0 }}
+          style={{ left: activeTabRect.left - TAB_IR, top: 4 }}
         />
       )}
 
@@ -220,7 +220,7 @@ export function AgentSidebarHeader({
         <div
           ref={historyDropdownRef}
           className="absolute z-50 overflow-visible"
-          style={{ left: 4, top: 6, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
+          style={{ left: 4, top: 4, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
         >
           {histContentH > 0 && (
             <Notch
@@ -332,7 +332,7 @@ export function AgentSidebarHeader({
         <div
           ref={dropdownRef}
           className="absolute z-50 overflow-visible"
-          style={{ right: 8, top: `calc(100% - ${DD_NOTCH_H + 4}px)`, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
+          style={{ right: 8, top: 4, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
         >
           {ddContentH > 0 && (
             <Notch

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -251,7 +251,7 @@ export function AgentSidebarHeader({
                 )}
                 onClick={() => { setActiveTabId(tab.id); setShowHistory(false); }}
               >
-                <span className="text-[11px] truncate flex-1">{tab.title}</span>
+                <span className="text-xs truncate flex-1">{tab.title}</span>
                 {tabs.length > 1 && (
                   <div
                     className="w-4 h-4 shrink-0 flex items-center justify-center rounded-full opacity-0 group-hover/item:opacity-70 hover:!opacity-100 hover:bg-on-surface/10 transition-opacity"
@@ -358,7 +358,7 @@ export function AgentSidebarHeader({
               <button
                 key={tab.id}
                 className={cn(
-                  "w-full px-1.5 py-0.5 text-left text-[11px] rounded transition-colors flex items-center gap-0.5",
+                  "w-full px-1.5 py-0.5 text-left text-xs rounded transition-colors flex items-center gap-0.5",
                   tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
                 )}
                 onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
@@ -368,7 +368,7 @@ export function AgentSidebarHeader({
             ))}
             <div className="h-px bg-outline-variant mx-1 my-0.5" />
             <button
-              className="w-full px-1.5 py-0.5 text-left text-[11px] rounded transition-colors flex items-center gap-0.5 text-primary hover:bg-on-surface/10"
+              className="w-full px-1.5 py-0.5 text-left text-xs rounded transition-colors flex items-center gap-0.5 text-primary hover:bg-on-surface/10"
               onClick={() => { handleAddTab(); setShowOverflow(false); }}
             >
               <Icon name="add" size={12} />

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -216,7 +216,7 @@ export function AgentSidebarHeader({
         <div
           ref={historyDropdownRef}
           className="absolute z-50 overflow-visible"
-          style={{ left: 1, top: `calc(100% - ${DD_NOTCH_H + 4}px)`, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
+          style={{ left: 4, top: `calc(100% - ${DD_NOTCH_H + 4}px)`, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
         >
           {histContentH > 0 && (
             <Notch

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -231,9 +231,12 @@ interface OverflowDropdownProps {
   onAddTab: () => void;
 }
 
-const NOTCH_W = 36;
+const NOTCH_W = 32;
 const NOTCH_H = 40;
-const PANEL_W = 176;
+const PANEL_W = 180;
+// Right offset: collapse(32) + gap(2) + close(32) + pr(4) = 70, but the ... btn is 32px wide
+// So notch right edge should be at right: ~38px (after ... button ends before collapse starts)
+const DROPDOWN_RIGHT = 38;
 
 const OverflowDropdown = forwardRef<HTMLDivElement, OverflowDropdownProps>(
   function OverflowDropdown({ tabs, activeTabId, onSelect, onAddTab }, ref) {
@@ -253,7 +256,7 @@ const OverflowDropdown = forwardRef<HTMLDivElement, OverflowDropdownProps>(
       <div
         ref={ref}
         className="absolute z-50"
-        style={{ top: 0, right: 0, width: PANEL_W, height: totalH }}
+        style={{ top: 0, right: DROPDOWN_RIGHT, width: PANEL_W, height: totalH }}
       >
         <svg
           className="absolute inset-0 pointer-events-none"

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -25,7 +25,7 @@ const TAB_IR = 12;
 const HEADER_H = 40;
 
 // History dropdown
-const HIST_W = 148;
+const HIST_W = 220;
 const HIST_NOTCH_H = 24;
 
 // Overflow dropdown notch dimensions

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -176,17 +176,19 @@ export function AgentSidebarHeader({
       </div>
       {/* Overflow dropdown — rendered outside the clipped container */}
       {showOverflow && overflowTabs.length > 0 && (
-        <div ref={dropdownRef} className="absolute top-[calc(100%-2px)] right-12 w-40 bg-surface-container rounded-b-lg rounded-tl-lg shadow-lg z-50 py-1 px-1">
-          {/* Inverse corner connecting to ... button */}
+        <div ref={dropdownRef} className="absolute top-0 right-12 w-40 z-40">
+          {/* Notch behind the ... button */}
+          <div className="absolute top-0 -right-8 w-8 h-10 bg-surface-container rounded-t-lg" />
+          {/* Inverse corner where notch meets dropdown */}
           <div
-            className="absolute top-0 right-0 w-3 h-3 pointer-events-none"
+            className="absolute top-10 -right-8 w-3 h-3 pointer-events-none"
             style={{
-              transform: "translateX(100%) translateY(-100%)",
               backgroundColor: "var(--color-surface-container)",
-              maskImage: "radial-gradient(circle 12px at 12px 12px, transparent 12px, black 12px)",
-              WebkitMaskImage: "radial-gradient(circle 12px at 12px 12px, transparent 12px, black 12px)",
+              maskImage: "radial-gradient(circle 12px at 12px 0, transparent 12px, black 12px)",
+              WebkitMaskImage: "radial-gradient(circle 12px at 12px 0, transparent 12px, black 12px)",
             }}
           />
+          <div className="mt-10 bg-surface-container rounded-b-lg rounded-tl-lg shadow-lg py-1 px-1">
           {overflowTabs.map((tab) => (
             <button
               key={tab.id}
@@ -208,6 +210,7 @@ export function AgentSidebarHeader({
             <Icon name="add" size={12} />
             <span>New chat</span>
           </button>
+          </div>
         </div>
       )}
     </div>

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -200,7 +200,7 @@ export function AgentSidebarHeader({
                   <div
                     className={cn(
                       "absolute right-1 top-1/2 -translate-y-1/2 z-20 w-5 h-5 flex items-center justify-center rounded-full transition-opacity cursor-pointer",
-                      isActive ? "text-inverse-on-surface hover:bg-inverse-on-surface/20 opacity-70 hover:opacity-100" : "hover:bg-inverse-on-surface/15 opacity-0 group-hover:opacity-70 group-hover:hover:opacity-100",
+                      isActive ? "text-inverse-on-surface hover:bg-inverse-on-surface/20 opacity-70 hover:opacity-100" : "text-on-surface hover:bg-on-surface/10 opacity-70 hover:opacity-100",
                       isActive ? "opacity-70 hover:opacity-100" : "opacity-0 group-hover:opacity-70 group-hover:hover:opacity-100",
                     )}
                     onClick={(e) => handleCloseTab(tab.id, e)}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -181,7 +181,7 @@ export function AgentSidebarHeader({
             <button
               key={tab.id}
               className={cn(
-                "w-full px-2.5 py-1 text-left text-xs rounded-md transition-colors flex items-center gap-1.5",
+                "w-full px-2.5 py-1.5 text-left text-xs rounded-md transition-colors flex items-center gap-1.5",
                 tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
               )}
               onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
@@ -192,7 +192,7 @@ export function AgentSidebarHeader({
           ))}
           <div className="h-px bg-outline-variant mx-1 my-1" />
           <button
-            className="w-full px-2.5 py-1 text-left text-xs rounded-md transition-colors flex items-center gap-1.5 text-primary hover:bg-on-surface/10"
+            className="w-full px-2.5 py-1.5 text-left text-xs rounded-md transition-colors flex items-center gap-1.5 text-primary hover:bg-on-surface/10"
             onClick={() => { handleAddTab(); setShowOverflow(false); }}
           >
             <Icon name="add" size={12} />

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -26,7 +26,7 @@ const HEADER_H = 40;
 
 // History dropdown
 const HIST_W = 148;
-const HIST_NOTCH_H = 20;
+const HIST_NOTCH_H = 28;
 
 // Overflow dropdown notch dimensions
 const DD_W = 176;
@@ -220,7 +220,7 @@ export function AgentSidebarHeader({
         <div
           ref={historyDropdownRef}
           className="absolute z-50 overflow-visible"
-          style={{ left: 4, top: 0, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
+          style={{ left: 4, top: 6, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
         >
           {histContentH > 0 && (
             <Notch

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -202,7 +202,7 @@ export function AgentSidebarHeader({
         <div
           ref={dropdownRef}
           className="absolute z-50 overflow-visible"
-          style={{ right: 3, top: `calc(100% - ${DD_NOTCH_H + 4}px)`, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
+          style={{ right: 8, top: `calc(100% - ${DD_NOTCH_H + 4}px)`, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
         >
           {ddContentH > 0 && (
             <Notch

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -1,0 +1,123 @@
+import { useState, useRef } from "react";
+import { cn } from "@/utils/cn";
+import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+import { Icon } from "@/components/ui/media/icon/Icon";
+
+interface ChatTab {
+  id: string;
+  title: string;
+}
+
+export interface AgentSidebarHeaderProps {
+  sidebarWidth: number;
+  onToggleCollapse: () => void;
+  onClose: () => void;
+}
+
+export function AgentSidebarHeader({
+  sidebarWidth,
+  onToggleCollapse,
+  onClose,
+}: AgentSidebarHeaderProps) {
+  const isCollapsed = sidebarWidth <= 350;
+
+  const [tabs, setTabs] = useState<ChatTab[]>([{ id: "1", title: "Chat 1" }]);
+  const [activeTabId, setActiveTabId] = useState("1");
+  const nextIdRef = useRef(2);
+  const tabsContainerRef = useRef<HTMLDivElement>(null);
+
+  const handleAddTab = () => {
+    const id = String(nextIdRef.current++);
+    const newTab: ChatTab = { id, title: `Chat ${id}` };
+    setTabs((prev) => [...prev, newTab]);
+    setActiveTabId(id);
+  };
+
+  const handleCloseTab = (tabId: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (tabs.length === 1) return;
+    const idx = tabs.findIndex((t) => t.id === tabId);
+    const newTabs = tabs.filter((t) => t.id !== tabId);
+    setTabs(newTabs);
+    if (tabId === activeTabId) {
+      const next = newTabs[Math.min(idx, newTabs.length - 1)];
+      if (next) setActiveTabId(next.id);
+    }
+  };
+
+  return (
+    <div className="relative flex items-center h-10 shrink-0">
+      <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-2 gap-1.5">
+        <div role="tablist" aria-label="Chat sessions" className="flex h-full gap-1.5">
+          {tabs.map((tab) => {
+            const isActive = tab.id === activeTabId;
+            return (
+              <div
+                key={tab.id}
+                role="tab"
+                aria-selected={isActive}
+                tabIndex={isActive ? 0 : -1}
+                onClick={() => setActiveTabId(tab.id)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setActiveTabId(tab.id);
+                  }
+                }}
+                className={cn(
+                  "flex items-center gap-2 px-3 h-full cursor-pointer select-none text-sm",
+                  isActive
+                    ? "rounded-t-xl bg-on-background text-inverse-on-surface"
+                    : "h-7 m-auto rounded-lg bg-secondary-container text-on-surface/80 hover:bg-on-secondary-container/50",
+                )}
+              >
+                <Icon name="auto_awesome" size={14} />
+                <span className="truncate max-w-[100px]">{tab.title}</span>
+                {tabs.length > 1 && (
+                  <button
+                    type="button"
+                    onClick={(e) => handleCloseTab(tab.id, e)}
+                    className="ml-1 opacity-60 hover:opacity-100"
+                    aria-label={`Close ${tab.title}`}
+                  >
+                    <Icon name="close" size={14} />
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="z-10 h-10 flex justify-center">
+          <IconButton
+            icon="add"
+            variant="text"
+            size="sm"
+            className="m-auto text-on-surface"
+            onClick={handleAddTab}
+            aria-label="New chat"
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-0.5 pr-1 shrink-0">
+        <IconButton
+          icon={isCollapsed ? "unfold_more" : "unfold_less"}
+          variant="text"
+          size="sm"
+          className="rotate-90 text-on-surface"
+          onClick={onToggleCollapse}
+          aria-label={isCollapsed ? "Expand" : "Collapse"}
+        />
+        <IconButton
+          icon="close"
+          variant="text"
+          size="sm"
+          className="text-on-surface"
+          onClick={onClose}
+          aria-label="Close sidebar"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -239,14 +239,14 @@ export function AgentSidebarHeader({
           )}
           <div
             ref={histContentRef}
-            className="relative z-10 pt-1.5 pb-1 px-1"
+            className="relative z-10 pt-2 pb-1.5 px-1.5"
             style={{ marginTop: HIST_NOTCH_H, width: HIST_W }}
           >
             {tabs.map((tab) => (
               <div
                 key={tab.id}
                 className={cn(
-                  "group/item flex items-center gap-1 px-2 py-1 rounded-md cursor-pointer transition-colors",
+                  "group/item flex items-center gap-1.5 px-2 py-1 rounded-md cursor-pointer transition-colors",
                   tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
                 )}
                 onClick={() => { setActiveTabId(tab.id); setShowHistory(false); }}
@@ -268,8 +268,8 @@ export function AgentSidebarHeader({
       )}
 
       {/* Tabs */}
-      <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-10 gap-0.5.5">
-        <div role="tablist" aria-label="Chat sessions" className="flex h-full gap-0.5.5">
+      <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-10 gap-1.5">
+        <div role="tablist" aria-label="Chat sessions" className="flex h-full gap-1.5">
           {visibleTabs.map((tab) => {
             const isActive = tab.id === activeTabId;
             return (
@@ -351,14 +351,14 @@ export function AgentSidebarHeader({
           )}
           <div
             ref={ddContentRef}
-            className="relative z-10 pt-1.5 pb-1 px-1"
+            className="relative z-10 pt-2 pb-1.5 px-1.5"
             style={{ marginTop: DD_NOTCH_H, width: DD_W }}
           >
             {overflowTabs.map((tab) => (
               <button
                 key={tab.id}
                 className={cn(
-                  "w-full px-2 py-1 text-left text-sm rounded-md transition-colors flex items-center gap-1",
+                  "w-full px-2 py-1 text-left text-sm rounded-md transition-colors flex items-center gap-1.5",
                   tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
                 )}
                 onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
@@ -366,9 +366,9 @@ export function AgentSidebarHeader({
                 <span className="truncate">{tab.title}</span>
               </button>
             ))}
-            <div className="h-px bg-outline-variant mx-1 my-0.5" />
+            <div className="h-px bg-outline-variant mx-1.5 my-1" />
             <button
-              className="w-full px-2 py-1 text-left text-sm rounded-md transition-colors flex items-center gap-1 text-primary hover:bg-on-surface/10"
+              className="w-full px-2 py-1 text-left text-sm rounded-md transition-colors flex items-center gap-1.5 text-primary hover:bg-on-surface/10"
               onClick={() => { handleAddTab(); setShowOverflow(false); }}
             >
               <Icon name="add" size={12} />

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -19,40 +19,50 @@ const GAP = 6;
 const ADD_BTN = 40;
 
 // SVG path: notch top-right, panel below — mirrored AppSwitcher approach
-const R = 8; // corner radius
-const CR = 6; // concave (inverse) corner radius
+const R = 8;
+const CR = 6;
 
+// Notch extends RIGHT from panel body. Total width = pw + nw.
+// Panel: x=0..pw, y=nh..nh+ph
+// Notch: x=pw..pw+nw, y=0..nh (extends right and up from panel top-right)
 function buildOutline(nw: number, nh: number, pw: number, ph: number) {
-  const th = nh + ph;
-  const nl = pw - nw; // notch left x
+  const tw = pw + nw; // total width
+  const th = nh + ph; // total height
 
   return [
-    // Top-left of notch
-    `M ${nl + R},0`,
-    // Top edge of notch
-    `H ${pw - R}`,
-    // Top-right corner of notch
-    `A ${R},${R} 0 0,1 ${pw},${R}`,
-    // Right edge all the way down (notch + panel share right edge)
-    `V ${th - R}`,
-    // Bottom-right corner
-    `A ${R},${R} 0 0,1 ${pw - R},${th}`,
-    // Bottom edge
-    `H ${R}`,
-    // Bottom-left corner
-    `A ${R},${R} 0 0,1 0,${th - R}`,
-    // Left edge of panel up
-    `V ${nh + R}`,
-    // Top-left corner of panel
-    `A ${R},${R} 0 0,1 ${R},${nh}`,
-    // Top edge of panel to inverse corner
-    `H ${nl - CR}`,
-    // Inverse concave corner (bottom-left of notch)
-    `A ${CR},${CR} 0 0,0 ${nl},${nh - CR}`,
-    // Left edge of notch up
+    // Start at panel top-left
+    `M ${R},${nh}`,
+    // Panel top edge to where notch starts
+    `H ${pw - CR}`,
+    // Inverse concave corner (panel meets notch)
+    `A ${CR},${CR} 0 0,0 ${pw},${nh - CR}`,
+    // Notch left edge up
     `V ${R}`,
-    // Top-left corner of notch
-    `A ${R},${R} 0 0,1 ${nl + R},0`,
+    // Notch top-left corner
+    `A ${R},${R} 0 0,1 ${pw + R},0`,
+    // Notch top edge
+    `H ${tw - R}`,
+    // Notch top-right corner
+    `A ${R},${R} 0 0,1 ${tw},${R}`,
+    // Notch right edge down
+    `V ${nh}`,
+    // Panel right edge down (panel right = notch right here, panel extends full width)
+    // Actually panel is narrower — go left then down
+    // No: panel right edge is at pw, notch right is at tw
+    // After notch bottom-right, go left to panel right, then down
+    `H ${pw}`,
+    // Panel right edge down (but panel right = pw < tw, no corner needed at pw,nh since notch covers it)
+    `V ${th - R}`,
+    // Panel bottom-right corner
+    `A ${R},${R} 0 0,1 ${pw - R},${th}`,
+    // Panel bottom edge
+    `H ${R}`,
+    // Panel bottom-left corner
+    `A ${R},${R} 0 0,1 0,${th - R}`,
+    // Panel left edge up
+    `V ${nh + R}`,
+    // Panel top-left corner
+    `A ${R},${R} 0 0,1 ${R},${nh}`,
     `Z`,
   ].join(" ");
 }
@@ -231,12 +241,11 @@ interface OverflowDropdownProps {
   onAddTab: () => void;
 }
 
-const NOTCH_W = 32;
+const NOTCH_W = 34;
 const NOTCH_H = 40;
-const PANEL_W = 180;
-// ... button is 3rd from right: close(32) + gap(2) + collapse(32) + gap(2) + pr(4) = 72
-// Notch right edge should align with ... button's right edge
-const DROPDOWN_RIGHT = 72;
+const PANEL_W = 176;
+// Notch extends right from panel. Total SVG width = PANEL_W + NOTCH_W.
+// Position: panel right-aligned with sidebar (right: 0), notch sticks out right.
 
 const OverflowDropdown = forwardRef<HTMLDivElement, OverflowDropdownProps>(
   function OverflowDropdown({ tabs, activeTabId, onSelect, onAddTab }, ref) {
@@ -249,6 +258,7 @@ const OverflowDropdown = forwardRef<HTMLDivElement, OverflowDropdownProps>(
       }
     }, [tabs.length]);
 
+    const totalW = PANEL_W + NOTCH_W;
     const path = buildOutline(NOTCH_W, NOTCH_H, PANEL_W, panelH);
     const totalH = NOTCH_H + panelH;
 
@@ -256,11 +266,11 @@ const OverflowDropdown = forwardRef<HTMLDivElement, OverflowDropdownProps>(
       <div
         ref={ref}
         className="absolute z-50"
-        style={{ top: 0, right: DROPDOWN_RIGHT, width: PANEL_W, height: totalH }}
+        style={{ top: 0, right: 0, width: totalW, height: totalH }}
       >
         <svg
           className="absolute inset-0 pointer-events-none"
-          width={PANEL_W}
+          width={totalW}
           height={totalH}
           style={{ filter: "drop-shadow(0 4px 12px rgba(0,0,0,0.08))" }}
         >

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -220,7 +220,7 @@ export function AgentSidebarHeader({
         <div
           ref={historyDropdownRef}
           className="absolute z-50 overflow-visible"
-          style={{ left: 4, top: HIST_NOTCH_H, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
+          style={{ left: 4, top: 0, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
         >
           {histContentH > 0 && (
             <Notch

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -24,7 +24,6 @@ export function AgentSidebarHeader({
   const [tabs, setTabs] = useState<ChatTab[]>([{ id: "1", title: "Chat 1" }]);
   const [activeTabId, setActiveTabId] = useState("1");
   const nextIdRef = useRef(2);
-  const tabsContainerRef = useRef<HTMLDivElement>(null);
 
   const handleAddTab = () => {
     const id = String(nextIdRef.current++);
@@ -47,47 +46,98 @@ export function AgentSidebarHeader({
 
   return (
     <div className="relative flex items-center h-10 shrink-0">
-      <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-2 gap-1.5">
+      {/* History */}
+      <div className="absolute left-0 top-0 z-10 w-10 h-10 flex justify-center">
+        <IconButton
+          icon="stat_minus_1"
+          variant="text"
+          size="sm"
+          className="m-auto text-on-surface"
+          aria-label="Chat history"
+        />
+      </div>
+
+      {/* Tabs */}
+      <div className="flex-1 flex h-full overflow-hidden pl-10 gap-1.5">
         <div role="tablist" aria-label="Chat sessions" className="flex h-full gap-1.5">
           {tabs.map((tab) => {
             const isActive = tab.id === activeTabId;
             return (
-              <div
-                key={tab.id}
-                role="tab"
-                aria-selected={isActive}
-                tabIndex={isActive ? 0 : -1}
-                onClick={() => setActiveTabId(tab.id)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault();
-                    setActiveTabId(tab.id);
-                  }
-                }}
-                className={cn(
-                  "flex items-center gap-2 px-3 h-full cursor-pointer select-none text-sm",
-                  isActive
-                    ? "rounded-t-xl bg-on-background text-inverse-on-surface"
-                    : "h-7 m-auto rounded-lg bg-secondary-container text-on-surface/80 hover:bg-on-secondary-container/50",
-                )}
-              >
-                <Icon name="auto_awesome" size={14} />
-                <span className="truncate max-w-[100px]">{tab.title}</span>
+              <div key={tab.id} className="group relative h-full flex">
+                <div
+                  role="tab"
+                  aria-selected={isActive}
+                  tabIndex={isActive ? 0 : -1}
+                  onClick={() => setActiveTabId(tab.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setActiveTabId(tab.id);
+                    }
+                  }}
+                  className="relative h-full flex"
+                >
+                  <div
+                    className={cn(
+                      "relative flex items-center gap-2 px-3 h-full max-w-[200px] cursor-pointer select-none min-w-[100px]",
+                      isActive
+                        ? "rounded-t-xl bg-on-background text-inverse-on-surface z-10"
+                        : "h-7 m-auto rounded-lg bg-secondary-container text-on-surface/80 hover:bg-on-secondary-container/50",
+                    )}
+                  >
+                    {/* Inverse corners for active tab (Chrome-tab style) */}
+                    {isActive && (
+                      <>
+                        <div
+                          className="absolute left-0 w-3 h-3 pointer-events-none"
+                          style={{
+                            bottom: 0,
+                            transform: "translateX(-100%)",
+                            backgroundColor: "var(--color-on-background)",
+                            maskImage: "radial-gradient(circle 12px at 0 0, transparent 12px, black 12px)",
+                            WebkitMaskImage: "radial-gradient(circle 12px at 0 0, transparent 12px, black 12px)",
+                          }}
+                        />
+                        <div
+                          className="absolute right-0 w-3 h-3 pointer-events-none"
+                          style={{
+                            bottom: 0,
+                            transform: "translateX(100%)",
+                            backgroundColor: "var(--color-on-background)",
+                            maskImage: "radial-gradient(circle 12px at 12px 0, transparent 12px, black 12px)",
+                            WebkitMaskImage: "radial-gradient(circle 12px at 12px 0, transparent 12px, black 12px)",
+                          }}
+                        />
+                      </>
+                    )}
+
+                    <Icon name="auto_awesome" size={14} className="shrink-0" />
+                    <span className="text-[13px] font-normal truncate flex-1">{tab.title}</span>
+                    {tabs.length > 1 && <span className="w-5 h-5 shrink-0" />}
+                  </div>
+                </div>
+
+                {/* Close button — visible on hover, always visible when active */}
                 {tabs.length > 1 && (
-                  <button
-                    type="button"
+                  <div
+                    className={cn(
+                      "absolute right-1 top-1/2 -translate-y-1/2 z-20 w-5 h-5 flex items-center justify-center rounded-full hover:bg-inverse-on-surface/15 transition-opacity cursor-pointer",
+                      isActive
+                        ? "opacity-70 hover:opacity-100"
+                        : "opacity-0 group-hover:opacity-70 group-hover:hover:opacity-100",
+                    )}
                     onClick={(e) => handleCloseTab(tab.id, e)}
-                    className="ml-1 opacity-60 hover:opacity-100"
                     aria-label={`Close ${tab.title}`}
                   >
                     <Icon name="close" size={14} />
-                  </button>
+                  </div>
                 )}
               </div>
             );
           })}
         </div>
 
+        {/* Add tab */}
         <div className="z-10 h-10 flex justify-center">
           <IconButton
             icon="add"
@@ -100,6 +150,7 @@ export function AgentSidebarHeader({
         </div>
       </div>
 
+      {/* Actions */}
       <div className="flex items-center gap-0.5 pr-1 shrink-0">
         <IconButton
           icon={isCollapsed ? "unfold_more" : "unfold_less"}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -32,6 +32,7 @@ export function AgentSidebarHeader({
   const nextIdRef = useRef(2);
   const tabsContainerRef = useRef<HTMLDivElement>(null);
   const overflowRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
   const calculateVisible = useCallback(() => {
     if (!tabsContainerRef.current) return;
@@ -75,7 +76,10 @@ export function AgentSidebarHeader({
     if (!showOverflow) return;
     const handleKey = (e: KeyboardEvent) => { if (e.key === "Escape") setShowOverflow(false); };
     const handleClick = (e: MouseEvent) => {
-      if (overflowRef.current && !overflowRef.current.contains(e.target as Node)) setShowOverflow(false);
+      const target = e.target as Node;
+      if (overflowRef.current?.contains(target)) return;
+      if (dropdownRef.current?.contains(target)) return;
+      setShowOverflow(false);
     };
     document.addEventListener("keydown", handleKey);
     document.addEventListener("mousedown", handleClick);
@@ -172,13 +176,13 @@ export function AgentSidebarHeader({
       </div>
       {/* Overflow dropdown — rendered outside the clipped container */}
       {showOverflow && overflowTabs.length > 0 && (
-        <div className="absolute top-full right-12 mt-1 w-40 bg-surface-container rounded-lg shadow-lg z-50 py-1">
+        <div ref={dropdownRef} className="absolute top-full right-12 mt-1 w-40 bg-surface-container rounded-lg shadow-lg z-50 py-1 px-1">
           {overflowTabs.map((tab) => (
             <button
               key={tab.id}
               className={cn(
-                "w-full px-2.5 py-1 text-left text-xs rounded transition-colors flex items-center gap-1.5",
-                tab.id === activeTabId ? "bg-primary/10 text-primary" : "text-on-surface hover:bg-surface-container-high",
+                "w-full px-2.5 py-1 text-left text-xs rounded-md transition-colors flex items-center gap-1.5",
+                tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
               )}
               onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
             >
@@ -186,9 +190,9 @@ export function AgentSidebarHeader({
               <span className="truncate">{tab.title}</span>
             </button>
           ))}
-          <div className="h-px bg-outline-variant mx-2 my-1" />
+          <div className="h-px bg-outline-variant mx-1 my-1" />
           <button
-            className="w-full px-2.5 py-1 text-left text-xs rounded transition-colors flex items-center gap-1.5 text-primary hover:bg-surface-container-high"
+            className="w-full px-2.5 py-1 text-left text-xs rounded-md transition-colors flex items-center gap-1.5 text-primary hover:bg-on-surface/10"
             onClick={() => { handleAddTab(); setShowOverflow(false); }}
           >
             <Icon name="add" size={12} />

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -206,7 +206,7 @@ export function AgentSidebarHeader({
           stroke="none"
           headOnly
           className="absolute z-[5]"
-          style={{ left: activeTabRect.left - TAB_IR, top: 4 }}
+          style={{ left: activeTabRect.left - TAB_IR, top: 0 }}
         />
       )}
 
@@ -246,7 +246,7 @@ export function AgentSidebarHeader({
               <div
                 key={tab.id}
                 className={cn(
-                  "group/item flex items-center gap-1 px-1.5 py-0.5 rounded cursor-pointer transition-colors",
+                  "group/item flex items-center gap-0.5 px-1.5 py-0.5 rounded cursor-pointer transition-colors",
                   tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
                 )}
                 onClick={() => { setActiveTabId(tab.id); setShowHistory(false); }}
@@ -268,8 +268,8 @@ export function AgentSidebarHeader({
       )}
 
       {/* Tabs */}
-      <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-10 gap-1.5">
-        <div role="tablist" aria-label="Chat sessions" className="flex h-full gap-1.5">
+      <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-10 gap-0.5.5">
+        <div role="tablist" aria-label="Chat sessions" className="flex h-full gap-0.5.5">
           {visibleTabs.map((tab) => {
             const isActive = tab.id === activeTabId;
             return (
@@ -358,7 +358,7 @@ export function AgentSidebarHeader({
               <button
                 key={tab.id}
                 className={cn(
-                  "w-full px-1.5 py-0.5 text-left text-[11px] rounded transition-colors flex items-center gap-1",
+                  "w-full px-1.5 py-0.5 text-left text-[11px] rounded transition-colors flex items-center gap-0.5",
                   tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
                 )}
                 onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
@@ -368,7 +368,7 @@ export function AgentSidebarHeader({
             ))}
             <div className="h-px bg-outline-variant mx-1 my-0.5" />
             <button
-              className="w-full px-1.5 py-0.5 text-left text-[11px] rounded transition-colors flex items-center gap-1 text-primary hover:bg-on-surface/10"
+              className="w-full px-1.5 py-0.5 text-left text-[11px] rounded transition-colors flex items-center gap-0.5 text-primary hover:bg-on-surface/10"
               onClick={() => { handleAddTab(); setShowOverflow(false); }}
             >
               <Icon name="add" size={12} />

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -251,7 +251,7 @@ export function AgentSidebarHeader({
                 )}
                 onClick={() => { setActiveTabId(tab.id); setShowHistory(false); }}
               >
-                <span className="text-xs truncate flex-1">{tab.title}</span>
+                <span className="text-sm truncate flex-1">{tab.title}</span>
                 {tabs.length > 1 && (
                   <div
                     className="w-4 h-4 shrink-0 flex items-center justify-center rounded-full opacity-0 group-hover/item:opacity-70 hover:!opacity-100 hover:bg-on-surface/10 transition-opacity"
@@ -358,7 +358,7 @@ export function AgentSidebarHeader({
               <button
                 key={tab.id}
                 className={cn(
-                  "w-full px-1.5 py-0.5 text-left text-xs rounded transition-colors flex items-center gap-0.5",
+                  "w-full px-1.5 py-0.5 text-left text-sm rounded transition-colors flex items-center gap-0.5",
                   tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
                 )}
                 onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
@@ -368,7 +368,7 @@ export function AgentSidebarHeader({
             ))}
             <div className="h-px bg-outline-variant mx-1 my-0.5" />
             <button
-              className="w-full px-1.5 py-0.5 text-left text-xs rounded transition-colors flex items-center gap-0.5 text-primary hover:bg-on-surface/10"
+              className="w-full px-1.5 py-0.5 text-left text-sm rounded transition-colors flex items-center gap-0.5 text-primary hover:bg-on-surface/10"
               onClick={() => { handleAddTab(); setShowOverflow(false); }}
             >
               <Icon name="add" size={12} />

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -19,25 +19,39 @@ const GAP = 6;
 const ADD_BTN = 40;
 
 // SVG path: notch top-right, panel below — mirrored AppSwitcher approach
-const R = 12;
+const R = 8; // corner radius
+const CR = 6; // concave (inverse) corner radius
 
 function buildOutline(nw: number, nh: number, pw: number, ph: number) {
   const th = nh + ph;
   const nl = pw - nw; // notch left x
 
   return [
+    // Top-left of notch
     `M ${nl + R},0`,
+    // Top edge of notch
     `H ${pw - R}`,
+    // Top-right corner of notch
     `A ${R},${R} 0 0,1 ${pw},${R}`,
+    // Right edge all the way down (notch + panel share right edge)
     `V ${th - R}`,
+    // Bottom-right corner
     `A ${R},${R} 0 0,1 ${pw - R},${th}`,
+    // Bottom edge
     `H ${R}`,
+    // Bottom-left corner
     `A ${R},${R} 0 0,1 0,${th - R}`,
+    // Left edge of panel up
     `V ${nh + R}`,
+    // Top-left corner of panel
     `A ${R},${R} 0 0,1 ${R},${nh}`,
-    `H ${nl - R}`,
-    `A ${R},${R} 0 0,0 ${nl},${nh - R}`,
+    // Top edge of panel to inverse corner
+    `H ${nl - CR}`,
+    // Inverse concave corner (bottom-left of notch)
+    `A ${CR},${CR} 0 0,0 ${nl},${nh - CR}`,
+    // Left edge of notch up
     `V ${R}`,
+    // Top-left corner of notch
     `A ${R},${R} 0 0,1 ${nl + R},0`,
     `Z`,
   ].join(" ");
@@ -239,7 +253,7 @@ const OverflowDropdown = forwardRef<HTMLDivElement, OverflowDropdownProps>(
       <div
         ref={ref}
         className="absolute z-50"
-        style={{ top: 0, right: 4, width: PANEL_W, height: totalH }}
+        style={{ top: 0, right: 0, width: PANEL_W, height: totalH }}
       >
         <svg
           className="absolute inset-0 pointer-events-none"

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -29,7 +29,7 @@ const DD_W = 176;
 const DD_NOTCH_W = 32; // matches IconButton sm
 const DD_NOTCH_H = 32; // full IconButton sm height (h-8)
 const DD_R = 8;
-const DD_IR = 5;
+const DD_IR = 8;
 
 export function AgentSidebarHeader({
   sidebarWidth,
@@ -42,10 +42,13 @@ export function AgentSidebarHeader({
   const [activeTabId, setActiveTabId] = useState("1");
   const [visibleCount, setVisibleCount] = useState(tabs.length);
   const [showOverflow, setShowOverflow] = useState(false);
+  const [showHistory, setShowHistory] = useState(false);
   const nextIdRef = useRef(2);
   const headerRef = useRef<HTMLDivElement>(null);
   const activeTabRef = useRef<HTMLDivElement>(null);
   const [activeTabRect, setActiveTabRect] = useState<{ left: number; width: number } | null>(null);
+  const historyBtnRef = useRef<HTMLDivElement>(null);
+  const historyDropdownRef = useRef<HTMLDivElement>(null);
   const tabsContainerRef = useRef<HTMLDivElement>(null);
   const overflowRef = useRef<HTMLDivElement>(null);
   const triggerBtnRef = useRef<HTMLDivElement>(null);
@@ -103,6 +106,20 @@ export function AgentSidebarHeader({
     return () => { document.removeEventListener("keydown", handleKey); document.removeEventListener("mousedown", handleClick); };
   }, [showOverflow]);
 
+  useEffect(() => {
+    if (!showHistory) return;
+    const handleKey = (e: KeyboardEvent) => { if (e.key === "Escape") setShowHistory(false); };
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (historyBtnRef.current?.contains(target)) return;
+      if (historyDropdownRef.current?.contains(target)) return;
+      setShowHistory(false);
+    };
+    document.addEventListener("keydown", handleKey);
+    document.addEventListener("mousedown", handleClick);
+    return () => { document.removeEventListener("keydown", handleKey); document.removeEventListener("mousedown", handleClick); };
+  }, [showHistory]);
+
   useLayoutEffect(() => {
     const tab = activeTabRef.current;
     const header = headerRef.current;
@@ -128,6 +145,17 @@ export function AgentSidebarHeader({
     const id = String(nextIdRef.current++);
     setTabs((prev) => [...prev, { id, title: `Chat ${id}` }]);
     setActiveTabId(id);
+  };
+
+  const handleDeleteHistory = (tabId: string) => {
+    if (tabs.length === 1) return;
+    const idx = tabs.findIndex((t) => t.id === tabId);
+    const newTabs = tabs.filter((t) => t.id !== tabId);
+    setTabs(newTabs);
+    if (tabId === activeTabId) {
+      const next = newTabs[Math.min(idx, newTabs.length - 1)];
+      if (next) setActiveTabId(next.id);
+    }
   };
 
   const handleCloseTab = (tabId: string, e: React.MouseEvent) => {
@@ -164,9 +192,37 @@ export function AgentSidebarHeader({
       )}
 
       {/* History */}
-      <div className="absolute left-0 top-0 z-10 w-10 h-10 flex justify-center">
-        <IconButton icon="stat_minus_1" variant="text" size="sm" className="m-auto text-on-surface" aria-label="Chat history" />
+      <div ref={historyBtnRef} className="absolute left-0 top-0 z-10 w-10 h-10 flex justify-center">
+        <IconButton icon="expand_more" variant="text" size="sm" className="m-auto text-on-surface" onClick={() => setShowHistory(!showHistory)} aria-label="Chat history" />
       </div>
+
+      {/* History dropdown */}
+      {showHistory && (
+        <div ref={historyDropdownRef} className="absolute left-1 top-full z-50 w-56 bg-surface-container-low border border-outline-variant rounded-lg shadow-lg py-1">
+          <div className="px-3 py-1.5 text-xs font-medium text-on-surface-variant">Chat history</div>
+          {tabs.map((tab) => (
+            <div
+              key={tab.id}
+              className={cn(
+                "group/item flex items-center gap-2 px-3 py-1.5 mx-1 rounded-md cursor-pointer transition-colors",
+                tab.id === activeTabId ? "bg-primary/10 text-primary" : "text-on-surface hover:bg-on-surface/8",
+              )}
+              onClick={() => { setActiveTabId(tab.id); setShowHistory(false); }}
+            >
+              <span className="text-xs truncate flex-1">{tab.title}</span>
+              {tabs.length > 1 && (
+                <div
+                  className="w-5 h-5 shrink-0 flex items-center justify-center rounded-full opacity-0 group-hover/item:opacity-70 hover:!opacity-100 hover:bg-on-surface/10 transition-opacity"
+                  onClick={(e) => { e.stopPropagation(); handleDeleteHistory(tab.id); }}
+                  aria-label={`Delete ${tab.title}`}
+                >
+                  <Icon name="delete" size={14} className="text-on-surface-variant" />
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* Tabs */}
       <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-10 gap-1.5">

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -202,7 +202,7 @@ export function AgentSidebarHeader({
         <div
           ref={dropdownRef}
           className="absolute z-50 overflow-visible"
-          style={{ right: 1, top: `calc(100% - ${DD_NOTCH_H + 4}px)`, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
+          style={{ right: 3, top: `calc(100% - ${DD_NOTCH_H + 4}px)`, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
         >
           {ddContentH > 0 && (
             <Notch

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -151,7 +151,7 @@ export function AgentSidebarHeader({
           height={1000}
           notchWidth={HEADER_H}
           notchHeight={activeTabRect.width}
-          notchSide="top"
+          notchSide="bottom"
           notchOffset={100}
           radius={TAB_R}
           inverseRadius={TAB_IR}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarInput.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarInput.tsx
@@ -5,7 +5,6 @@ import {
   type KeyboardEvent,
   type ChangeEvent,
 } from "react";
-import { cn } from "@/utils/cn";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 
 export interface AgentSidebarInputProps {
@@ -23,17 +22,13 @@ export function AgentSidebarInput({
 }: AgentSidebarInputProps) {
   const [text, setText] = useState("");
   const [isComposing, setIsComposing] = useState(false);
-  const [isMultiline, setIsMultiline] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
     const el = textareaRef.current;
     if (!el) return;
     el.style.height = "auto";
-    const scrollH = el.scrollHeight;
-    const singleLineH = parseInt(getComputedStyle(el).lineHeight) || 20;
-    el.style.height = `${Math.min(scrollH, 150)}px`;
-    setIsMultiline(scrollH > singleLineH + 4);
+    el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
   }, [text]);
 
   const send = () => {
@@ -63,97 +58,45 @@ export function AgentSidebarInput({
           Tip — ctrl + c to interrupt
         </span>
       </div>
-      <div className="flex flex-col w-full border border-outline-variant/30 rounded-xl bg-inverse-on-surface/8">
-        <div
-          className={cn(
-            "justify-between w-full p-1 flex gap-0.5",
-            isMultiline ? "flex-col" : "flex-row items-center",
-          )}
-        >
-          {isMultiline ? (
-            <>
-              <textarea
-                ref={textareaRef}
-                value={text}
-                onChange={handleChange}
-                onKeyDown={handleKeyDown}
-                onCompositionStart={() => setIsComposing(true)}
-                onCompositionEnd={() => setIsComposing(false)}
-                className="w-full text-inverse-on-surface placeholder:text-inverse-on-surface/30 rounded-lg px-2 py-1 resize-none focus:outline-none bg-transparent text-sm"
-                placeholder={placeholder}
-                aria-label="Message to agent"
-                rows={1}
-              />
-              <div className="flex w-full gap-0.5 items-center">
-                <IconButton
-                  icon="attach_file_add"
-                  variant="text"
-                  size="sm"
-                  className={iconBtnCls}
-                  onClick={onAttachFile}
-                  aria-label="Attach file"
-                />
-                <IconButton
-                  icon="mic"
-                  variant="text"
-                  size="sm"
-                  className={iconBtnCls}
-                  onClick={onMic}
-                  aria-label="Voice input"
-                />
-                <div className="flex-1" />
-                <IconButton
-                  icon="send"
-                  variant="filled"
-                  size="sm"
-                  className="bg-primary text-on-primary"
-                  onClick={send}
-                  aria-label="Send message"
-                />
-              </div>
-            </>
-          ) : (
-            <>
-              <IconButton
-                icon="attach_file_add"
-                variant="text"
-                size="sm"
-                className={cn("shrink-0", iconBtnCls)}
-                onClick={onAttachFile}
-                aria-label="Attach file"
-              />
-              <textarea
-                ref={textareaRef}
-                value={text}
-                onChange={handleChange}
-                onKeyDown={handleKeyDown}
-                onCompositionStart={() => setIsComposing(true)}
-                onCompositionEnd={() => setIsComposing(false)}
-                className="w-full text-inverse-on-surface placeholder:text-inverse-on-surface/30 rounded-lg px-2 py-1 resize-none focus:outline-none bg-transparent text-sm"
-                placeholder={placeholder}
-                aria-label="Message to agent"
-                rows={1}
-              />
-              <div className="flex gap-0.5">
-                <IconButton
-                  icon="mic"
-                  variant="text"
-                  size="sm"
-                  className={iconBtnCls}
-                  onClick={onMic}
-                  aria-label="Voice input"
-                />
-                <IconButton
-                  icon="send"
-                  variant="filled"
-                  size="sm"
-                  className="bg-primary text-on-primary"
-                  onClick={send}
-                  aria-label="Send message"
-                />
-              </div>
-            </>
-          )}
+      <div className="flex flex-col w-full border border-outline-variant/30 rounded-xl bg-inverse-on-surface/8 p-1">
+        <textarea
+          ref={textareaRef}
+          value={text}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          onCompositionStart={() => setIsComposing(true)}
+          onCompositionEnd={() => setIsComposing(false)}
+          className="w-full text-inverse-on-surface placeholder:text-inverse-on-surface/30 rounded-lg px-2 py-1 resize-none focus:outline-none bg-transparent text-sm"
+          placeholder={placeholder}
+          aria-label="Message to agent"
+          rows={1}
+        />
+        <div className="flex w-full gap-0.5 items-center">
+          <IconButton
+            icon="attach_file_add"
+            variant="text"
+            size="sm"
+            className={iconBtnCls}
+            onClick={onAttachFile}
+            aria-label="Attach file"
+          />
+          <IconButton
+            icon="mic"
+            variant="text"
+            size="sm"
+            className={iconBtnCls}
+            onClick={onMic}
+            aria-label="Voice input"
+          />
+          <div className="flex-1" />
+          <IconButton
+            icon="send"
+            variant="filled"
+            size="sm"
+            className="bg-primary text-on-primary"
+            onClick={send}
+            aria-label="Send message"
+          />
         </div>
       </div>
     </div>

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarInput.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarInput.tsx
@@ -30,8 +30,10 @@ export function AgentSidebarInput({
     const el = textareaRef.current;
     if (!el) return;
     el.style.height = "auto";
-    el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
-    setIsMultiline(text.includes("\n") || el.scrollHeight > el.clientHeight + 2);
+    const scrollH = el.scrollHeight;
+    const singleLineH = parseInt(getComputedStyle(el).lineHeight) || 20;
+    el.style.height = `${Math.min(scrollH, 150)}px`;
+    setIsMultiline(scrollH > singleLineH + 4);
   }, [text]);
 
   const send = () => {

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarInput.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarInput.tsx
@@ -52,19 +52,19 @@ export function AgentSidebarInput({
     setText(e.target.value);
   };
 
-  const iconBtnCls = "text-inverse-on-surface hover:bg-primary-container hover:text-primary";
+  const iconBtnCls = "text-inverse-on-surface/60 hover:text-inverse-on-surface";
 
   return (
     <div className="p-3 pt-2 shrink-0 flex flex-col">
-      <div className="w-full p-1">
-        <span className="text-background/80 text-sm">
+      <div className="w-full px-1 pb-1">
+        <span className="text-inverse-on-surface/40 text-xs">
           Tip — ctrl + c to interrupt
         </span>
       </div>
-      <div className="flex flex-col w-full border-3 border-inverse-primary rounded-xl">
+      <div className="flex flex-col w-full border border-outline-variant/30 rounded-xl bg-inverse-on-surface/8">
         <div
           className={cn(
-            "justify-between w-full p-0.5 flex gap-0.5",
+            "justify-between w-full p-1 flex gap-0.5",
             isMultiline ? "flex-col" : "flex-row items-center",
           )}
         >
@@ -77,7 +77,7 @@ export function AgentSidebarInput({
                 onKeyDown={handleKeyDown}
                 onCompositionStart={() => setIsComposing(true)}
                 onCompositionEnd={() => setIsComposing(false)}
-                className="w-full text-on-secondary rounded-lg px-2 py-1 resize-none focus:outline-none bg-transparent"
+                className="w-full text-inverse-on-surface placeholder:text-inverse-on-surface/30 rounded-lg px-2 py-1 resize-none focus:outline-none bg-transparent text-sm"
                 placeholder={placeholder}
                 aria-label="Message to agent"
                 rows={1}
@@ -104,7 +104,7 @@ export function AgentSidebarInput({
                   icon="send"
                   variant="filled"
                   size="sm"
-                  className="bg-tertiary-container hover:bg-tertiary-container-dim"
+                  className="bg-primary text-on-primary"
                   onClick={send}
                   aria-label="Send message"
                 />
@@ -127,7 +127,7 @@ export function AgentSidebarInput({
                 onKeyDown={handleKeyDown}
                 onCompositionStart={() => setIsComposing(true)}
                 onCompositionEnd={() => setIsComposing(false)}
-                className="w-full text-on-secondary rounded-lg px-2 py-1 resize-none focus:outline-none bg-transparent"
+                className="w-full text-inverse-on-surface placeholder:text-inverse-on-surface/30 rounded-lg px-2 py-1 resize-none focus:outline-none bg-transparent text-sm"
                 placeholder={placeholder}
                 aria-label="Message to agent"
                 rows={1}
@@ -145,7 +145,7 @@ export function AgentSidebarInput({
                   icon="send"
                   variant="filled"
                   size="sm"
-                  className="bg-tertiary-container hover:bg-tertiary-container-dim"
+                  className="bg-primary text-on-primary"
                   onClick={send}
                   aria-label="Send message"
                 />

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarInput.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarInput.tsx
@@ -55,65 +55,103 @@ export function AgentSidebarInput({
   const iconBtnCls = "text-inverse-on-surface hover:bg-primary-container hover:text-primary";
 
   return (
-    <div className="p-3 pt-2 shrink-0">
-      <div className="flex flex-col border-3 border-inverse-primary rounded-xl">
+    <div className="p-3 pt-2 shrink-0 flex flex-col">
+      <div className="w-full p-1">
+        <span className="text-background/80 text-sm">
+          Tip — ctrl + c to interrupt
+        </span>
+      </div>
+      <div className="flex flex-col w-full border-3 border-inverse-primary rounded-xl">
         <div
           className={cn(
-            "w-full p-0.5 flex gap-0.5",
-            isMultiline ? "flex-col" : "items-center",
+            "justify-between w-full p-0.5 flex gap-0.5",
+            isMultiline ? "flex-col" : "flex-row items-center",
           )}
         >
-          {!isMultiline && (
-            <IconButton
-              icon="attach_file_add"
-              variant="text"
-              size="sm"
-              className={cn("shrink-0", iconBtnCls)}
-              onClick={onAttachFile}
-              aria-label="Attach file"
-            />
-          )}
-          <textarea
-            ref={textareaRef}
-            value={text}
-            onChange={handleChange}
-            onKeyDown={handleKeyDown}
-            onCompositionStart={() => setIsComposing(true)}
-            onCompositionEnd={() => setIsComposing(false)}
-            className="w-full text-on-secondary rounded-lg px-2 py-1 resize-none focus:outline-none bg-transparent"
-            placeholder={placeholder}
-            aria-label="Message to agent"
-            rows={1}
-          />
-          <div className={cn("flex gap-0.5", isMultiline && "items-center")}>
-            {isMultiline && (
+          {isMultiline ? (
+            <>
+              <textarea
+                ref={textareaRef}
+                value={text}
+                onChange={handleChange}
+                onKeyDown={handleKeyDown}
+                onCompositionStart={() => setIsComposing(true)}
+                onCompositionEnd={() => setIsComposing(false)}
+                className="w-full text-on-secondary rounded-lg px-2 py-1 resize-none focus:outline-none bg-transparent"
+                placeholder={placeholder}
+                aria-label="Message to agent"
+                rows={1}
+              />
+              <div className="flex w-full gap-0.5 items-center">
+                <IconButton
+                  icon="attach_file_add"
+                  variant="text"
+                  size="sm"
+                  className={iconBtnCls}
+                  onClick={onAttachFile}
+                  aria-label="Attach file"
+                />
+                <IconButton
+                  icon="mic"
+                  variant="text"
+                  size="sm"
+                  className={iconBtnCls}
+                  onClick={onMic}
+                  aria-label="Voice input"
+                />
+                <div className="flex-1" />
+                <IconButton
+                  icon="send"
+                  variant="filled"
+                  size="sm"
+                  className="bg-tertiary-container hover:bg-tertiary-container-dim"
+                  onClick={send}
+                  aria-label="Send message"
+                />
+              </div>
+            </>
+          ) : (
+            <>
               <IconButton
                 icon="attach_file_add"
                 variant="text"
                 size="sm"
-                className={iconBtnCls}
+                className={cn("shrink-0", iconBtnCls)}
                 onClick={onAttachFile}
                 aria-label="Attach file"
               />
-            )}
-            <IconButton
-              icon="mic"
-              variant="text"
-              size="sm"
-              className={iconBtnCls}
-              onClick={onMic}
-              aria-label="Voice input"
-            />
-            {isMultiline && <div className="flex-1" />}
-            <IconButton
-              icon="send"
-              variant="filled"
-              size="sm"
-              className="bg-tertiary-container hover:bg-tertiary-container-dim"
-              onClick={send}
-              aria-label="Send message"
-            />
-          </div>
+              <textarea
+                ref={textareaRef}
+                value={text}
+                onChange={handleChange}
+                onKeyDown={handleKeyDown}
+                onCompositionStart={() => setIsComposing(true)}
+                onCompositionEnd={() => setIsComposing(false)}
+                className="w-full text-on-secondary rounded-lg px-2 py-1 resize-none focus:outline-none bg-transparent"
+                placeholder={placeholder}
+                aria-label="Message to agent"
+                rows={1}
+              />
+              <div className="flex gap-0.5">
+                <IconButton
+                  icon="mic"
+                  variant="text"
+                  size="sm"
+                  className={iconBtnCls}
+                  onClick={onMic}
+                  aria-label="Voice input"
+                />
+                <IconButton
+                  icon="send"
+                  variant="filled"
+                  size="sm"
+                  className="bg-tertiary-container hover:bg-tertiary-container-dim"
+                  onClick={send}
+                  aria-label="Send message"
+                />
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarInput.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarInput.tsx
@@ -1,0 +1,121 @@
+import {
+  useState,
+  useRef,
+  useEffect,
+  type KeyboardEvent,
+  type ChangeEvent,
+} from "react";
+import { cn } from "@/utils/cn";
+import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+
+export interface AgentSidebarInputProps {
+  onSend?: (message: string) => void;
+  onAttachFile?: () => void;
+  onMic?: () => void;
+  placeholder?: string;
+}
+
+export function AgentSidebarInput({
+  onSend,
+  onAttachFile,
+  onMic,
+  placeholder = "Type a message...",
+}: AgentSidebarInputProps) {
+  const [text, setText] = useState("");
+  const [isComposing, setIsComposing] = useState(false);
+  const [isMultiline, setIsMultiline] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
+    setIsMultiline(text.includes("\n") || el.scrollHeight > el.clientHeight + 2);
+  }, [text]);
+
+  const send = () => {
+    if (!text.trim()) return;
+    onSend?.(text);
+    setText("");
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (isComposing || e.nativeEvent.isComposing) return;
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  };
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setText(e.target.value);
+  };
+
+  const iconBtnCls = "text-inverse-on-surface hover:bg-primary-container hover:text-primary";
+
+  return (
+    <div className="p-3 pt-2 shrink-0">
+      <div className="flex flex-col border-3 border-inverse-primary rounded-xl">
+        <div
+          className={cn(
+            "w-full p-0.5 flex gap-0.5",
+            isMultiline ? "flex-col" : "items-center",
+          )}
+        >
+          {!isMultiline && (
+            <IconButton
+              icon="attach_file_add"
+              variant="text"
+              size="sm"
+              className={cn("shrink-0", iconBtnCls)}
+              onClick={onAttachFile}
+              aria-label="Attach file"
+            />
+          )}
+          <textarea
+            ref={textareaRef}
+            value={text}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            onCompositionStart={() => setIsComposing(true)}
+            onCompositionEnd={() => setIsComposing(false)}
+            className="w-full text-on-secondary rounded-lg px-2 py-1 resize-none focus:outline-none bg-transparent"
+            placeholder={placeholder}
+            aria-label="Message to agent"
+            rows={1}
+          />
+          <div className={cn("flex gap-0.5", isMultiline && "items-center")}>
+            {isMultiline && (
+              <IconButton
+                icon="attach_file_add"
+                variant="text"
+                size="sm"
+                className={iconBtnCls}
+                onClick={onAttachFile}
+                aria-label="Attach file"
+              />
+            )}
+            <IconButton
+              icon="mic"
+              variant="text"
+              size="sm"
+              className={iconBtnCls}
+              onClick={onMic}
+              aria-label="Voice input"
+            />
+            {isMultiline && <div className="flex-1" />}
+            <IconButton
+              icon="send"
+              variant="filled"
+              size="sm"
+              className="bg-tertiary-container hover:bg-tertiary-container-dim"
+              onClick={send}
+              aria-label="Send message"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,3 +132,9 @@ export {
   type NavDrawerItem,
   type NavDrawerSection,
 } from "./components/ui/navigation/nav-drawer/NavDrawer";
+export {
+  AgentSidebarHeader,
+  type AgentSidebarHeaderProps,
+  AgentSidebarInput,
+  type AgentSidebarInputProps,
+} from "./components/ui/surfaces/agent-sidebar/AgentSidebar";


### PR DESCRIPTION
## Summary
- **AgentSidebarHeader**: Chrome-tab style tabs with inverse corners, history button, add/close/switch, collapse/close
- **AgentSidebarInput**: auto-expanding textarea, attach/mic/send, IME support, tip text
- Stories: Header, Input, Playground (combined)

Closes #10

## Test plan
- [x] `pnpm components validate` — pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 7 tests pass
- [ ] Visual review in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)