### PR TITLE
feat: add AppShell layout (#12)

### DIFF
--- a/src/components/layout/app-shell/app-shell/AppShell.stories.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.stories.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { AppShell } from "./AppShell";
-import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+import { NavigationRail } from "@/components/ui/navigation/navigation-rail/NavigationRail";
+import { NavigationButton } from "@/components/ui/navigation/navigation-button/NavigationButton";
+import { Avatar } from "@/components/ui/media/avatar/Avatar";
 
 const meta: Meta<typeof AppShell> = {
   title: "Layout/AppShell",
@@ -15,36 +16,35 @@ export default meta;
 type Story = StoryObj<typeof AppShell>;
 
 export const Playground: Story = {
-  render: () => {
-    const [agentOpen, setAgentOpen] = useState(false);
-    return (
-      <AppShell
-        navigation={
-          <div className="pl-2 py-4">
-            <div className="ml-2 px-4 py-6 gap-4 flex flex-col items-center rounded-2xl shadow-2xl bg-surface-bright">
-              <IconButton icon="home" variant="tonal" size="sm" aria-label="Home" />
-              <IconButton icon="search" variant="text" size="sm" aria-label="Search" />
-              <IconButton icon="notifications" variant="text" size="sm" aria-label="Notifications" />
-            </div>
-          </div>
-        }
-        agentSidebar={
-          <div className="rounded-2xl bg-on-background h-full flex flex-col">
-            <div className="flex-1 p-4 text-inverse-on-surface text-sm">
-              Agent chat content...
-            </div>
-          </div>
-        }
-        agentSidebarOpen={agentOpen}
-        onAgentSidebarToggle={() => setAgentOpen(!agentOpen)}
-      >
-        <div className="max-w-4xl mx-auto">
-          <h1 className="text-2xl font-bold text-on-surface mb-4">Dashboard</h1>
-          <p className="text-on-surface-variant">
-            Main content area. The agent sidebar can be toggled with the floating button.
-          </p>
+  render: () => (
+    <AppShell
+      navigation={
+        <NavigationRail
+          header={
+            <Avatar fallback="M" size="md" square />
+          }
+          footer={
+            <NavigationButton icon="settings" label="Settings" variant="secondary" />
+          }
+        >
+          <NavigationButton icon="home" label="Home" variant="primary" />
+          <NavigationButton icon="data_table" label="Apps" variant="secondary" />
+          <NavigationButton icon="notifications" label="Alerts" variant="secondary" />
+        </NavigationRail>
+      }
+      agentSidebarContent={
+        <div className="text-inverse-on-surface text-sm">
+          Chat messages would appear here...
         </div>
-      </AppShell>
-    );
-  },
+      }
+      onAgentSend={(msg) => console.log("Send:", msg)}
+    >
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-2xl font-bold text-on-surface mb-4">Dashboard</h1>
+        <p className="text-on-surface-variant">
+          Main content area. The agent sidebar can be toggled with the floating button.
+        </p>
+      </div>
+    </AppShell>
+  ),
 };

--- a/src/components/layout/app-shell/app-shell/AppShell.stories.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.stories.tsx
@@ -1,8 +1,8 @@
+import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { AppShell } from "./AppShell";
 import { NavigationRail } from "@/components/ui/navigation/navigation-rail/NavigationRail";
 import { NavigationButton } from "@/components/ui/navigation/navigation-button/NavigationButton";
-import { Avatar } from "@/components/ui/media/avatar/Avatar";
 
 const meta: Meta<typeof AppShell> = {
   title: "Layout/AppShell",
@@ -16,35 +16,78 @@ export default meta;
 type Story = StoryObj<typeof AppShell>;
 
 export const Playground: Story = {
-  render: () => (
-    <AppShell
-      navigation={
-        <NavigationRail
-          header={
-            <Avatar fallback="M" size="md" square />
-          }
-          footer={
-            <NavigationButton icon="settings" label="Settings" variant="secondary" />
-          }
-        >
-          <NavigationButton icon="home" label="Home" variant="primary" />
-          <NavigationButton icon="data_table" label="Apps" variant="secondary" />
-          <NavigationButton icon="notifications" label="Alerts" variant="secondary" />
-        </NavigationRail>
-      }
-      agentSidebarContent={
-        <div className="text-inverse-on-surface text-sm">
-          Chat messages would appear here...
+  render: () => {
+    const [selected, setSelected] = useState("apps");
+    return (
+      <AppShell
+        navigation={
+          <NavigationRail
+            logo={
+              <NavigationButton
+                customIcon={
+                  <div className="w-full h-full bg-primary/20 flex items-center justify-center">
+                    <span className="text-primary font-semibold text-lg">M</span>
+                  </div>
+                }
+                label="My App"
+                variant="secondary"
+                disableHoverExpand
+                className="border border-primary"
+              />
+            }
+          >
+            <div className="w-full gap-2 flex flex-col">
+              <NavigationButton
+                icon="space_dashboard"
+                label="Dashboard"
+                variant="primary"
+                selected={selected === "dashboard"}
+                onClick={() => setSelected("dashboard")}
+              />
+              <NavigationButton
+                icon="data_table"
+                label="Your Apps"
+                selected={selected === "apps"}
+                onClick={() => setSelected("apps")}
+              />
+            </div>
+            <div className="h-px rounded-full w-full bg-outline" />
+            <div className="w-full gap-2 flex flex-col">
+              <NavigationButton
+                icon="extension"
+                label="Add-ons"
+                selected={selected === "addons"}
+                onClick={() => setSelected("addons")}
+              />
+              <NavigationButton
+                icon="rocket_launch"
+                label="Deployment"
+                selected={selected === "deployment"}
+                onClick={() => setSelected("deployment")}
+              />
+              <NavigationButton
+                icon="settings"
+                label="Settings"
+                selected={selected === "settings"}
+                onClick={() => setSelected("settings")}
+              />
+            </div>
+          </NavigationRail>
+        }
+        agentSidebarContent={
+          <div className="text-inverse-on-surface text-sm">
+            Chat messages would appear here...
+          </div>
+        }
+        onAgentSend={(msg) => console.log("Send:", msg)}
+      >
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-2xl font-bold text-on-surface mb-4">Dashboard</h1>
+          <p className="text-on-surface-variant">
+            Main content area. The agent sidebar can be toggled with the floating button.
+          </p>
         </div>
-      }
-      onAgentSend={(msg) => console.log("Send:", msg)}
-    >
-      <div className="max-w-4xl mx-auto">
-        <h1 className="text-2xl font-bold text-on-surface mb-4">Dashboard</h1>
-        <p className="text-on-surface-variant">
-          Main content area. The agent sidebar can be toggled with the floating button.
-        </p>
-      </div>
-    </AppShell>
-  ),
+      </AppShell>
+    );
+  },
 };

--- a/src/components/layout/app-shell/app-shell/AppShell.stories.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.stories.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { AppShell } from "./AppShell";
+import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+
+const meta: Meta<typeof AppShell> = {
+  title: "Layout/AppShell",
+  component: AppShell,
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AppShell>;
+
+export const Playground: Story = {
+  render: () => {
+    const [agentOpen, setAgentOpen] = useState(false);
+    return (
+      <AppShell
+        navigation={
+          <div className="pl-2 py-4">
+            <div className="ml-2 px-4 py-6 gap-4 flex flex-col items-center rounded-2xl shadow-2xl bg-surface-bright">
+              <IconButton icon="home" variant="tonal" size="sm" aria-label="Home" />
+              <IconButton icon="search" variant="text" size="sm" aria-label="Search" />
+              <IconButton icon="notifications" variant="text" size="sm" aria-label="Notifications" />
+            </div>
+          </div>
+        }
+        agentSidebar={
+          <div className="rounded-2xl bg-on-background h-full flex flex-col">
+            <div className="flex-1 p-4 text-inverse-on-surface text-sm">
+              Agent chat content...
+            </div>
+          </div>
+        }
+        agentSidebarOpen={agentOpen}
+        onAgentSidebarToggle={() => setAgentOpen(!agentOpen)}
+      >
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-2xl font-bold text-on-surface mb-4">Dashboard</h1>
+          <p className="text-on-surface-variant">
+            Main content area. The agent sidebar can be toggled with the floating button.
+          </p>
+        </div>
+      </AppShell>
+    );
+  },
+};

--- a/src/components/layout/app-shell/app-shell/AppShell.stories.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.stories.tsx
@@ -3,6 +3,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { AppShell } from "./AppShell";
 import { NavigationRail } from "@/components/ui/navigation/navigation-rail/NavigationRail";
 import { NavigationButton } from "@/components/ui/navigation/navigation-button/NavigationButton";
+import { AppSwitcher } from "@/components/ui/navigation/app-switcher/AppSwitcher";
+import { Logo } from "@/components/ui/media/logo-mirrorstack/LogoMirrorStack";
+import { NavDrawer, type NavDrawerItem } from "@/components/ui/navigation/nav-drawer/NavDrawer";
+import { Avatar } from "@/components/ui/media/avatar/Avatar";
 
 const meta: Meta<typeof AppShell> = {
   title: "Layout/AppShell",
@@ -15,7 +19,21 @@ const meta: Meta<typeof AppShell> = {
 export default meta;
 type Story = StoryObj<typeof AppShell>;
 
-export const Playground: Story = {
+const apps = [
+  { id: "account", label: "Account", description: "Profile & security settings", icon: "shield_person", href: "#" },
+  { id: "apps", label: "Apps", description: "Manage your applications", icon: "data_table", href: "#" },
+];
+
+const DemoContent = () => (
+  <div className="max-w-4xl mx-auto">
+    <h1 className="text-2xl font-bold text-on-surface mb-4">Dashboard</h1>
+    <p className="text-on-surface-variant">
+      Main content area. The agent sidebar can be toggled with the floating button.
+    </p>
+  </div>
+);
+
+export const WithNavigationRail: Story = {
   render: () => {
     const [selected, setSelected] = useState("apps");
     return (
@@ -74,6 +92,14 @@ export const Playground: Story = {
             </div>
           </NavigationRail>
         }
+        appSwitcher={
+          <AppSwitcher
+            currentApp="Account"
+            logo={<div className="w-8 h-8"><Logo /></div>}
+            apps={apps}
+            activeAppId="account"
+          />
+        }
         agentSidebarContent={
           <div className="text-inverse-on-surface text-sm">
             Chat messages would appear here...
@@ -81,12 +107,130 @@ export const Playground: Story = {
         }
         onAgentSend={(msg) => console.log("Send:", msg)}
       >
-        <div className="max-w-4xl mx-auto">
-          <h1 className="text-2xl font-bold text-on-surface mb-4">Dashboard</h1>
-          <p className="text-on-surface-variant">
-            Main content area. The agent sidebar can be toggled with the floating button.
-          </p>
-        </div>
+        <DemoContent />
+      </AppShell>
+    );
+  },
+};
+
+const navSections = [
+  {
+    label: "Account",
+    items: [
+      { id: "profile", label: "Profile", icon: "person" },
+      { id: "security", label: "Security", icon: "shield" },
+      { id: "preferences", label: "Preferences", icon: "tune" },
+    ],
+  },
+  {
+    items: [
+      { id: "organizations", label: "Organizations", icon: "apartment" },
+    ],
+  },
+  {
+    items: [
+      { id: "sign-out", label: "Sign out", icon: "logout", variant: "danger" as const },
+    ],
+  },
+];
+
+export const WithNavDrawer: Story = {
+  render: () => {
+    const [active, setActive] = useState("profile");
+    return (
+      <AppShell
+        navigation={
+          <NavDrawer
+            contextSwitcher={
+              <div className="flex items-center gap-3 p-3 rounded-xl">
+                <Avatar size="md" fallback="J" />
+                <div className="min-w-0 flex-1 space-y-0.5">
+                  <p className="text-sm font-medium text-on-surface truncate">John Doe</p>
+                  <p className="text-xs text-on-surface-variant">Personal Account</p>
+                </div>
+              </div>
+            }
+            sections={navSections}
+            activeItemId={active}
+            onItemClick={(item: NavDrawerItem) => setActive(item.id)}
+          />
+        }
+        appSwitcher={
+          <AppSwitcher
+            currentApp="Account"
+            logo={<div className="w-8 h-8"><Logo /></div>}
+            apps={apps}
+            activeAppId="account"
+          />
+        }
+        agentSidebarContent={
+          <div className="text-inverse-on-surface text-sm">
+            Chat messages would appear here...
+          </div>
+        }
+        onAgentSend={(msg) => console.log("Send:", msg)}
+      >
+        <DemoContent />
+      </AppShell>
+    );
+  },
+};
+
+export const Playground: Story = {
+  render: () => {
+    const [selected, setSelected] = useState("apps");
+    return (
+      <AppShell
+        navigation={
+          <NavigationRail
+            logo={
+              <NavigationButton
+                customIcon={
+                  <div className="w-full h-full bg-primary/20 flex items-center justify-center">
+                    <span className="text-primary font-semibold text-lg">M</span>
+                  </div>
+                }
+                label="My App"
+                variant="secondary"
+                disableHoverExpand
+                className="border border-primary"
+              />
+            }
+          >
+            <div className="w-full gap-2 flex flex-col">
+              <NavigationButton
+                icon="space_dashboard"
+                label="Dashboard"
+                variant="primary"
+                selected={selected === "dashboard"}
+                onClick={() => setSelected("dashboard")}
+              />
+              <NavigationButton
+                icon="data_table"
+                label="Your Apps"
+                selected={selected === "apps"}
+                onClick={() => setSelected("apps")}
+              />
+            </div>
+            <div className="h-px rounded-full w-full bg-outline" />
+            <div className="w-full gap-2 flex flex-col">
+              <NavigationButton
+                icon="settings"
+                label="Settings"
+                selected={selected === "settings"}
+                onClick={() => setSelected("settings")}
+              />
+            </div>
+          </NavigationRail>
+        }
+        agentSidebarContent={
+          <div className="text-inverse-on-surface text-sm">
+            Chat messages would appear here...
+          </div>
+        }
+        onAgentSend={(msg) => console.log("Send:", msg)}
+      >
+        <DemoContent />
       </AppShell>
     );
   },

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -60,6 +60,8 @@ function AppShellInner({
   const startX = useRef(0);
   const startWidth = useRef(0);
   const maxWidthRef = useRef(800);
+  const dragWidthRef = useRef(0);
+  const sidebarElRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const update = () => {
@@ -89,11 +91,15 @@ function AppShellInner({
 
     const onMove = (e: MouseEvent) => {
       const diff = startX.current - e.clientX;
-      const next = startWidth.current + diff;
-      setSidebarWidth(Math.min(Math.max(next, MIN_WIDTH), maxWidthRef.current));
+      const next = Math.min(Math.max(startWidth.current + diff, MIN_WIDTH), maxWidthRef.current);
+      dragWidthRef.current = next;
+      if (sidebarElRef.current) {
+        sidebarElRef.current.style.width = `${next}px`;
+      }
     };
 
     const onUp = () => {
+      setSidebarWidth(dragWidthRef.current);
       setIsResizing(false);
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
@@ -108,6 +114,9 @@ function AppShellInner({
       document.body.style.userSelect = "";
     };
   }, [isResizing, setSidebarWidth]);
+
+  // Keep dragWidthRef in sync when sidebar opens
+  useEffect(() => { dragWidthRef.current = sidebarWidth; }, [sidebarWidth]);
 
   const handleToggleCollapse = () => {
     if (sidebarWidth <= MIN_WIDTH) {
@@ -184,6 +193,7 @@ function AppShellInner({
             />
 
             <div
+              ref={sidebarElRef}
               className="overflow-hidden relative my-2 mr-2 flex flex-col"
               style={{ width: `${sidebarWidth}px`, height: "calc(100vh - 1rem)" }}
             >

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -136,7 +136,7 @@ function AppShellInner({
 
           <div className="h-full flex">
             {navigation && (
-              <div className="hidden lg:flex h-full shrink-0 items-center">
+              <div className="hidden lg:flex h-full shrink-0 items-center [&>*]:max-h-[calc(100%-2rem)]">
                 {navigation}
               </div>
             )}

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -1,0 +1,176 @@
+import { useState, useRef, useEffect, type ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+
+export const meta: ComponentMeta = {
+  name: "AppShell",
+  description:
+    "Top-level application layout with navigation, app switcher, resizable agent sidebar, and content area",
+};
+
+const MIN_WIDTH = 350;
+const PADDING = 20;
+
+export interface AppShellProps {
+  children: ReactNode;
+  navigation?: ReactNode;
+  appSwitcher?: ReactNode;
+  className?: string;
+  appSwitcherClassName?: string;
+  contentClassName?: string;
+  agentSidebar?: ReactNode;
+  agentSidebarOpen?: boolean;
+  onAgentSidebarToggle?: () => void;
+}
+
+export function AppShell({
+  children,
+  navigation,
+  appSwitcher,
+  className,
+  appSwitcherClassName = "max-w-7xl",
+  contentClassName,
+  agentSidebar,
+  agentSidebarOpen = false,
+  onAgentSidebarToggle,
+}: AppShellProps) {
+  const [sidebarWidth, setSidebarWidth] = useState(MIN_WIDTH);
+  const [isResizing, setIsResizing] = useState(false);
+  const [windowWidth, setWindowWidth] = useState(0);
+  const startX = useRef(0);
+  const startWidth = useRef(0);
+  const maxWidthRef = useRef(800);
+
+  useEffect(() => {
+    const update = () => {
+      setWindowWidth(window.innerWidth);
+      maxWidthRef.current = window.innerWidth - PADDING;
+    };
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
+
+  const isOverlaying =
+    agentSidebarOpen &&
+    windowWidth > 0 &&
+    windowWidth < sidebarWidth + 800;
+
+  const startResize = (e: React.MouseEvent) => {
+    setIsResizing(true);
+    startX.current = e.clientX;
+    startWidth.current = sidebarWidth;
+    document.body.style.cursor = "ew-resize";
+    document.body.style.userSelect = "none";
+  };
+
+  useEffect(() => {
+    if (!isResizing) return;
+
+    const onMove = (e: MouseEvent) => {
+      const diff = startX.current - e.clientX;
+      const next = startWidth.current + diff;
+      setSidebarWidth(Math.min(Math.max(next, MIN_WIDTH), maxWidthRef.current));
+    };
+
+    const onUp = () => {
+      setIsResizing(false);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+    return () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+  }, [isResizing]);
+
+  return (
+    <div className="h-dvh flex bg-background text-on-background overflow-hidden">
+      <div className="flex-1 min-w-0 h-dvh overflow-hidden">
+        <div className={cn("mx-auto w-full h-full relative", className)}>
+          {appSwitcher && (
+            <div className="hidden lg:block absolute top-2 left-0 right-0 z-20 pointer-events-none">
+              <div className={cn("mx-auto w-full px-4", appSwitcherClassName)}>
+                <div className="pointer-events-auto w-fit">
+                  {appSwitcher}
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div className="h-full flex">
+            {navigation && (
+              <div className="hidden lg:flex h-full shrink-0 items-center">
+                {navigation}
+              </div>
+            )}
+
+            <div className="flex-1 min-w-0 flex flex-col h-full overflow-hidden">
+              <main className="relative flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
+                <div
+                  className={cn(
+                    "mx-auto w-full px-6 pb-8",
+                    appSwitcher ? "pt-20" : "pt-6",
+                    contentClassName,
+                  )}
+                >
+                  {children}
+                </div>
+              </main>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {agentSidebarOpen && agentSidebar && (
+        <div
+          className={cn(
+            "flex justify-end shrink-0",
+            isOverlaying
+              ? "fixed top-0 right-0 h-screen z-30"
+              : "relative z-50",
+            !isResizing && "transition-all duration-300",
+          )}
+          style={isOverlaying ? undefined : { width: `${sidebarWidth + 10}px` }}
+        >
+          {isOverlaying && (
+            <div
+              className="fixed inset-0 bg-black/20 -z-10"
+              onClick={onAgentSidebarToggle}
+            />
+          )}
+
+          <div className="flex">
+            <div
+              className="w-2 flex cursor-ew-resize z-20 rounded-full hover:bg-primary-container transition-colors shrink-0"
+              onMouseDown={startResize}
+            />
+            <div
+              className="overflow-hidden relative my-2 mr-2 flex flex-col"
+              style={{ width: `${sidebarWidth}px`, height: "calc(100vh - 1rem)" }}
+            >
+              {agentSidebar}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {!agentSidebarOpen && agentSidebar && (
+        <IconButton
+          icon="smart_toy"
+          variant="tonal"
+          size="md"
+          className="fixed top-2 right-2 z-50"
+          onClick={onAgentSidebarToggle}
+          aria-label="Open agent"
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -136,7 +136,7 @@ function AppShellInner({
 
           <div className="h-full flex">
             {navigation && (
-              <div className="hidden lg:flex h-full shrink-0 items-center [&>*]:max-h-[calc(100%-2rem)]">
+              <div className="hidden lg:flex h-full shrink-0 items-center [&>*]:h-auto">
                 {navigation}
               </div>
             )}

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -2,6 +2,9 @@ import { useState, useRef, useEffect, type ReactNode } from "react";
 import { cn } from "@/utils/cn";
 import type { ComponentMeta } from "@/types/component-meta";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+import { SidebarProvider, useSidebarWidth } from "@/context/sidebar/SidebarProvider";
+import { AgentSidebarHeader } from "@/components/ui/surfaces/agent-sidebar/AgentSidebarHeader";
+import { AgentSidebarInput } from "@/components/ui/surfaces/agent-sidebar/AgentSidebarInput";
 
 export const meta: ComponentMeta = {
   name: "AppShell",
@@ -14,28 +17,44 @@ const PADDING = 20;
 
 export interface AppShellProps {
   children: ReactNode;
+  /** Navigation slot — inject a NavigationRail, NavDrawer, or custom nav */
   navigation?: ReactNode;
+  /** App switcher slot — positioned top-left after nav area */
   appSwitcher?: ReactNode;
+  /** Class for the outer shell */
   className?: string;
+  /** Class for the app switcher container */
   appSwitcherClassName?: string;
+  /** Class for the content area */
   contentClassName?: string;
-  agentSidebar?: ReactNode;
-  agentSidebarOpen?: boolean;
-  onAgentSidebarToggle?: () => void;
+  /** Agent sidebar chat content */
+  agentSidebarContent?: ReactNode;
+  onAgentSend?: (message: string) => void;
+  onAgentAttachFile?: () => void;
+  onAgentMic?: () => void;
 }
 
-export function AppShell({
+export function AppShell(props: AppShellProps) {
+  return (
+    <SidebarProvider defaultWidth={0}>
+      <AppShellInner {...props} />
+    </SidebarProvider>
+  );
+}
+
+function AppShellInner({
   children,
   navigation,
   appSwitcher,
   className,
   appSwitcherClassName = "max-w-7xl",
   contentClassName,
-  agentSidebar,
-  agentSidebarOpen = false,
-  onAgentSidebarToggle,
+  agentSidebarContent,
+  onAgentSend,
+  onAgentAttachFile,
+  onAgentMic,
 }: AppShellProps) {
-  const [sidebarWidth, setSidebarWidth] = useState(MIN_WIDTH);
+  const { sidebarWidth, setSidebarWidth } = useSidebarWidth();
   const [isResizing, setIsResizing] = useState(false);
   const [windowWidth, setWindowWidth] = useState(0);
   const startX = useRef(0);
@@ -53,7 +72,7 @@ export function AppShell({
   }, []);
 
   const isOverlaying =
-    agentSidebarOpen &&
+    sidebarWidth > 0 &&
     windowWidth > 0 &&
     windowWidth < sidebarWidth + 800;
 
@@ -88,10 +107,21 @@ export function AppShell({
       document.body.style.cursor = "";
       document.body.style.userSelect = "";
     };
-  }, [isResizing]);
+  }, [isResizing, setSidebarWidth]);
+
+  const handleToggleCollapse = () => {
+    if (sidebarWidth <= MIN_WIDTH) {
+      setSidebarWidth(Math.min((windowWidth || 1000) * 0.5, maxWidthRef.current));
+    } else {
+      setSidebarWidth(MIN_WIDTH);
+    }
+  };
+
+  const handleClose = () => setSidebarWidth(0);
 
   return (
     <div className="h-dvh flex bg-background text-on-background overflow-hidden">
+      {/* Left: app content area */}
       <div className="flex-1 min-w-0 h-dvh overflow-hidden">
         <div className={cn("mx-auto w-full h-full relative", className)}>
           {appSwitcher && (
@@ -111,7 +141,7 @@ export function AppShell({
               </div>
             )}
 
-            <div className="flex-1 min-w-0 flex flex-col h-full overflow-hidden">
+            <div className="flex-1 min-w-0 flex flex-col h-full overflow-hidden relative">
               <main className="relative flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
                 <div
                   className={cn(
@@ -128,7 +158,8 @@ export function AppShell({
         </div>
       </div>
 
-      {agentSidebarOpen && agentSidebar && (
+      {/* Right: agent sidebar */}
+      {sidebarWidth > 0 && (
         <div
           className={cn(
             "flex justify-end shrink-0",
@@ -142,7 +173,7 @@ export function AppShell({
           {isOverlaying && (
             <div
               className="fixed inset-0 bg-black/20 -z-10"
-              onClick={onAgentSidebarToggle}
+              onClick={handleClose}
             />
           )}
 
@@ -151,23 +182,41 @@ export function AppShell({
               className="w-2 flex cursor-ew-resize z-20 rounded-full hover:bg-primary-container transition-colors shrink-0"
               onMouseDown={startResize}
             />
+
             <div
               className="overflow-hidden relative my-2 mr-2 flex flex-col"
               style={{ width: `${sidebarWidth}px`, height: "calc(100vh - 1rem)" }}
             >
-              {agentSidebar}
+              <AgentSidebarHeader
+                sidebarWidth={sidebarWidth}
+                onToggleCollapse={handleToggleCollapse}
+                onClose={handleClose}
+              />
+
+              <div className="rounded-2xl bg-on-background h-full flex flex-col">
+                <div className="flex-1 overflow-y-auto overflow-x-hidden p-4">
+                  {agentSidebarContent}
+                </div>
+
+                <AgentSidebarInput
+                  onSend={onAgentSend}
+                  onAttachFile={onAgentAttachFile}
+                  onMic={onAgentMic}
+                />
+              </div>
             </div>
           </div>
         </div>
       )}
 
-      {!agentSidebarOpen && agentSidebar && (
+      {/* Agent toggle button */}
+      {sidebarWidth === 0 && (
         <IconButton
           icon="smart_toy"
           variant="tonal"
           size="md"
           className="fixed top-2 right-2 z-50"
-          onClick={onAgentSidebarToggle}
+          onClick={() => setSidebarWidth(MIN_WIDTH)}
           aria-label="Open agent"
         />
       )}

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -138,7 +138,7 @@ export function AgentSidebarHeader({
     const tRect = tab.getBoundingClientRect();
     const hRect = header.getBoundingClientRect();
     setActiveTabRect({ left: tRect.left - hRect.left, width: tRect.width });
-  }, [activeTabId, visibleCount]);
+  }, [activeTabId, visibleCount, sidebarWidth]);
 
   useLayoutEffect(() => {
     if (!showOverflow || !ddContentRef.current) return;

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -261,7 +261,7 @@ export function AgentSidebarHeader({
                 tabIndex={isActive ? 0 : -1}
                 onClick={() => setActiveTabId(tab.id)}
                 onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setActiveTabId(tab.id); } }}
-                className={cn("group relative h-full flex", overflowTabs.length > 0 && "flex-1")}
+                className="group relative h-full flex flex-1"
               >
                 <div
                   className={cn(
@@ -269,7 +269,7 @@ export function AgentSidebarHeader({
                     isActive
                       ? "text-inverse-on-surface z-10 min-w-[100px]"
                       : "h-7 m-auto rounded-lg bg-secondary-container text-on-surface/80 hover:bg-on-secondary-container/50 min-w-[80px]",
-                    overflowTabs.length > 0 ? "w-full" : isActive ? "max-w-[200px]" : "max-w-[140px]",
+                    "w-full",
                   )}
                 >
                   <span className="text-[13px] font-normal truncate flex-1">{tab.title}</span>

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -249,7 +249,7 @@ export function AgentSidebarHeader({
 
       {/* Tabs */}
       <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-10 gap-1.5">
-        <div role="tablist" aria-label="Chat sessions" className="flex h-full gap-1.5">
+        <div role="tablist" aria-label="Chat sessions" className="flex flex-1 h-full gap-1.5">
           {visibleTabs.map((tab) => {
             const isActive = tab.id === activeTabId;
             return (

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -261,14 +261,15 @@ export function AgentSidebarHeader({
                 tabIndex={isActive ? 0 : -1}
                 onClick={() => setActiveTabId(tab.id)}
                 onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setActiveTabId(tab.id); } }}
-                className="group relative h-full flex"
+                className={cn("group relative h-full flex", overflowTabs.length > 0 && "flex-1")}
               >
                 <div
                   className={cn(
                     "relative flex items-center gap-2 px-3 h-full cursor-pointer select-none",
                     isActive
-                      ? "text-inverse-on-surface z-10 min-w-[100px] max-w-[200px]"
-                      : "h-7 m-auto rounded-lg bg-secondary-container text-on-surface/80 hover:bg-on-secondary-container/50 min-w-[80px] max-w-[140px]",
+                      ? "text-inverse-on-surface z-10 min-w-[100px]"
+                      : "h-7 m-auto rounded-lg bg-secondary-container text-on-surface/80 hover:bg-on-secondary-container/50 min-w-[80px]",
+                    overflowTabs.length > 0 ? "w-full" : isActive ? "max-w-[200px]" : "max-w-[140px]",
                   )}
                 >
                   <span className="text-[13px] font-normal truncate flex-1">{tab.title}</span>

--- a/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/surfaces/agent-sidebar/AgentSidebarHeader.tsx
@@ -248,7 +248,7 @@ export function AgentSidebarHeader({
       )}
 
       {/* Tabs */}
-      <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-10 gap-1.5">
+      <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-10 pr-1.5 gap-1.5">
         <div role="tablist" aria-label="Chat sessions" className="flex flex-1 h-full gap-1.5">
           {visibleTabs.map((tab) => {
             const isActive = tab.id === activeTabId;

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,3 +132,7 @@ export {
   type NavDrawerItem,
   type NavDrawerSection,
 } from "./components/ui/navigation/nav-drawer/NavDrawer";
+export {
+  AppShell,
+  type AppShellProps,
+} from "./components/layout/app-shell/app-shell/AppShell";


### PR DESCRIPTION
## Summary
- Top-level layout with navigation, app switcher, resizable agent sidebar, content area
- Agent sidebar: resizable via mouse drag (min 350px), overlay on narrow viewports
- Floating toggle button when sidebar closed
- Stories: Playground

Closes #12

## Test plan
- [x] `pnpm components validate` — pass
- [x] `pnpm typecheck` — clean
- [ ] Visual review in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)