### PR TITLE
feat: add Notch component (#112)

### DIFF
--- a/src/components/ui/surfaces/notch/Notch.stories.tsx
+++ b/src/components/ui/surfaces/notch/Notch.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Notch } from "./Notch";
+
+const meta: Meta<typeof Notch> = {
+  title: "UI/Surfaces/Notch",
+  component: Notch,
+  args: {
+    width: 200,
+    height: 150,
+    notchWidth: 40,
+    notchHeight: 50,
+    notchSide: "right",
+    notchOffset: 0,
+    radius: 8,
+    inverseRadius: 6,
+    strokeWidth: 1,
+  },
+  argTypes: {
+    notchSide: { control: "select", options: ["top", "bottom", "left", "right"] },
+    width: { control: { type: "range", min: 100, max: 400, step: 10 } },
+    height: { control: { type: "range", min: 80, max: 300, step: 10 } },
+    notchWidth: { control: { type: "range", min: 20, max: 80, step: 2 } },
+    notchHeight: { control: { type: "range", min: 20, max: 100, step: 2 } },
+    notchOffset: { control: { type: "range", min: -100, max: 100, step: 1 } },
+    radius: { control: { type: "range", min: 0, max: 20, step: 1 } },
+    inverseRadius: { control: { type: "range", min: 0, max: 16, step: 1 } },
+    strokeWidth: { control: { type: "range", min: 0, max: 4, step: 0.5 } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Notch>;
+
+export const Playground: Story = {};
+
+export const AllSides: Story = {
+  render: () => (
+    <div className="grid grid-cols-2 gap-8 p-4">
+      {(["right", "left", "top", "bottom"] as const).map((side) => (
+        <div key={side}>
+          <p className="text-xs text-on-surface-variant mb-2">{side}</p>
+          <Notch width={160} height={120} notchWidth={36} notchHeight={40} notchSide={side} notchOffset={10} />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const FillOnly: Story = {
+  args: { stroke: "none" },
+};
+
+export const OutlineOnly: Story = {
+  args: { fill: "none" },
+};
+
+export const NegativeOffset: Story = {
+  args: { notchOffset: -10 },
+};
+
+export const HeadOnly: Story = {
+  args: {
+    headOnly: true,
+    notchWidth: 60,
+    notchHeight: 40,
+  },
+};

--- a/src/components/ui/surfaces/notch/Notch.stories.tsx
+++ b/src/components/ui/surfaces/notch/Notch.stories.tsx
@@ -94,3 +94,22 @@ export const HeadOnly: Story = {
     </div>
   ),
 };
+
+export const HeadOnlyWithOffset: Story = {
+  render: () => (
+    <div className="grid grid-cols-2 gap-8 p-4">
+      {(["right", "left", "top", "bottom"] as const).map((side) => (
+        <div key={side}>
+          <p className="text-xs text-on-surface-variant mb-2">headOnly — {side} — offset 30</p>
+          <Notch
+            width={160} height={120}
+            notchWidth={60} notchHeight={40}
+            notchSide={side}
+            notchOffset={30}
+            headOnly
+          />
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/src/components/ui/surfaces/notch/Notch.stories.tsx
+++ b/src/components/ui/surfaces/notch/Notch.stories.tsx
@@ -54,8 +54,27 @@ export const OutlineOnly: Story = {
   args: { fill: "none" },
 };
 
-export const NegativeOffset: Story = {
-  args: { notchOffset: -10 },
+export const WithOffset: Story = {
+  render: () => (
+    <div className="grid grid-cols-2 gap-8 p-4">
+      <div>
+        <p className="text-xs text-on-surface-variant mb-2">offset: 0 (start)</p>
+        <Notch width={160} height={120} notchWidth={36} notchHeight={40} notchOffset={0} />
+      </div>
+      <div>
+        <p className="text-xs text-on-surface-variant mb-2">offset: 30</p>
+        <Notch width={160} height={120} notchWidth={36} notchHeight={40} notchOffset={30} />
+      </div>
+      <div>
+        <p className="text-xs text-on-surface-variant mb-2">offset: -0 (end)</p>
+        <Notch width={160} height={120} notchWidth={36} notchHeight={40} notchOffset={-0} />
+      </div>
+      <div>
+        <p className="text-xs text-on-surface-variant mb-2">offset: -30</p>
+        <Notch width={160} height={120} notchWidth={36} notchHeight={40} notchOffset={-30} />
+      </div>
+    </div>
+  ),
 };
 
 export const HeadOnly: Story = {

--- a/src/components/ui/surfaces/notch/Notch.stories.tsx
+++ b/src/components/ui/surfaces/notch/Notch.stories.tsx
@@ -78,9 +78,19 @@ export const WithOffset: Story = {
 };
 
 export const HeadOnly: Story = {
-  args: {
-    headOnly: true,
-    notchWidth: 60,
-    notchHeight: 40,
-  },
+  render: () => (
+    <div className="grid grid-cols-2 gap-8 p-4">
+      {(["right", "left", "top", "bottom"] as const).map((side) => (
+        <div key={side}>
+          <p className="text-xs text-on-surface-variant mb-2">headOnly — {side}</p>
+          <Notch
+            width={160} height={120}
+            notchWidth={60} notchHeight={40}
+            notchSide={side}
+            headOnly
+          />
+        </div>
+      ))}
+    </div>
+  ),
 };

--- a/src/components/ui/surfaces/notch/Notch.stories.tsx
+++ b/src/components/ui/surfaces/notch/Notch.stories.tsx
@@ -57,22 +57,12 @@ export const OutlineOnly: Story = {
 export const WithOffset: Story = {
   render: () => (
     <div className="grid grid-cols-2 gap-8 p-4">
-      <div>
-        <p className="text-xs text-on-surface-variant mb-2">offset: 0 (start)</p>
-        <Notch width={160} height={120} notchWidth={36} notchHeight={40} notchOffset={0} />
-      </div>
-      <div>
-        <p className="text-xs text-on-surface-variant mb-2">offset: 30</p>
-        <Notch width={160} height={120} notchWidth={36} notchHeight={40} notchOffset={30} />
-      </div>
-      <div>
-        <p className="text-xs text-on-surface-variant mb-2">offset: -0 (end)</p>
-        <Notch width={160} height={120} notchWidth={36} notchHeight={40} notchOffset={-0} />
-      </div>
-      <div>
-        <p className="text-xs text-on-surface-variant mb-2">offset: -30</p>
-        <Notch width={160} height={120} notchWidth={36} notchHeight={40} notchOffset={-30} />
-      </div>
+      {[0, 30, 50, -30].map((offset) => (
+        <div key={offset}>
+          <p className="text-xs text-on-surface-variant mb-2">offset: {offset}</p>
+          <Notch width={160} height={120} notchWidth={36} notchHeight={40} notchOffset={offset} />
+        </div>
+      ))}
     </div>
   ),
 };

--- a/src/components/ui/surfaces/notch/Notch.stories.tsx
+++ b/src/components/ui/surfaces/notch/Notch.stories.tsx
@@ -39,7 +39,7 @@ export const AllSides: Story = {
       {(["right", "left", "top", "bottom"] as const).map((side) => (
         <div key={side}>
           <p className="text-xs text-on-surface-variant mb-2">{side}</p>
-          <Notch width={160} height={120} notchWidth={36} notchHeight={40} notchSide={side} notchOffset={10} />
+          <Notch width={160} height={120} notchWidth={36} notchHeight={40} notchSide={side} notchOffset={0} />
         </div>
       ))}
     </div>

--- a/src/components/ui/surfaces/notch/Notch.test.tsx
+++ b/src/components/ui/surfaces/notch/Notch.test.tsx
@@ -37,8 +37,9 @@ describe("Notch", () => {
       <Notch width={200} height={150} notchWidth={60} notchHeight={40} headOnly />,
     );
     const svg = container.querySelector("svg");
-    // pathW = notchWidth(60) + ir(6) = 66, + strokeWidth(1) = 67
-    // pathH = notchHeight(40) + ir(6) = 46, + strokeWidth(1) = 47
+    // offset=0 → atStart=true, topIr=0, botIr=6
+    // pathW = 60 + 6 = 66, + stroke = 67
+    // pathH = 40 + 0 + 6 = 46, + stroke = 47
     expect(svg).toHaveAttribute("width", "67");
     expect(svg).toHaveAttribute("height", "47");
   });

--- a/src/components/ui/surfaces/notch/Notch.test.tsx
+++ b/src/components/ui/surfaces/notch/Notch.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, render } from "@testing-library/react";
+import { describe, expect, it, afterEach } from "vitest";
+import { Notch } from "./Notch";
+
+afterEach(cleanup);
+
+describe("Notch", () => {
+  it("renders an SVG with path", () => {
+    const { container } = render(
+      <Notch width={200} height={150} notchWidth={40} notchHeight={50} />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+    expect(svg?.querySelector("path")).toBeInTheDocument();
+  });
+
+  it("sets correct SVG dimensions for right notch", () => {
+    const { container } = render(
+      <Notch width={200} height={150} notchWidth={40} notchHeight={50} notchSide="right" />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveAttribute("width", "240");
+    expect(svg).toHaveAttribute("height", "150");
+  });
+
+  it("sets correct SVG dimensions for bottom notch", () => {
+    const { container } = render(
+      <Notch width={200} height={150} notchWidth={40} notchHeight={50} notchSide="bottom" />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveAttribute("width", "200");
+    expect(svg).toHaveAttribute("height", "200");
+  });
+
+  it("renders head only", () => {
+    const { container } = render(
+      <Notch width={200} height={150} notchWidth={60} notchHeight={40} headOnly />,
+    );
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveAttribute("width", "60");
+    expect(svg).toHaveAttribute("height", "40");
+  });
+
+  it("applies fill and stroke", () => {
+    const { container } = render(
+      <Notch width={200} height={150} notchWidth={40} notchHeight={50} fill="red" stroke="blue" strokeWidth={2} />,
+    );
+    const path = container.querySelector("path");
+    expect(path).toHaveAttribute("fill", "red");
+    expect(path).toHaveAttribute("stroke", "blue");
+    expect(path).toHaveAttribute("stroke-width", "2");
+  });
+
+  it("supports fill none for outline only", () => {
+    const { container } = render(
+      <Notch width={200} height={150} notchWidth={40} notchHeight={50} fill="none" />,
+    );
+    const path = container.querySelector("path");
+    expect(path).toHaveAttribute("fill", "none");
+  });
+});

--- a/src/components/ui/surfaces/notch/Notch.test.tsx
+++ b/src/components/ui/surfaces/notch/Notch.test.tsx
@@ -37,7 +37,8 @@ describe("Notch", () => {
       <Notch width={200} height={150} notchWidth={60} notchHeight={40} headOnly />,
     );
     const svg = container.querySelector("svg");
-    expect(svg).toHaveAttribute("width", "61");
+    // totalW = notchWidth(60) + inverseRadius(6)*2 + strokeWidth(1) = 73
+    expect(svg).toHaveAttribute("width", "73");
     expect(svg).toHaveAttribute("height", "41");
   });
 

--- a/src/components/ui/surfaces/notch/Notch.test.tsx
+++ b/src/components/ui/surfaces/notch/Notch.test.tsx
@@ -38,9 +38,9 @@ describe("Notch", () => {
     );
     const svg = container.querySelector("svg");
     // pathW = notchWidth(60) + ir(6) = 66, + strokeWidth(1) = 67
-    // pathH = notchHeight(40) + ir(6)*2 = 52, + strokeWidth(1) = 53
+    // pathH = notchHeight(40) + ir(6) = 46, + strokeWidth(1) = 47
     expect(svg).toHaveAttribute("width", "67");
-    expect(svg).toHaveAttribute("height", "53");
+    expect(svg).toHaveAttribute("height", "47");
   });
 
   it("applies fill and stroke", () => {

--- a/src/components/ui/surfaces/notch/Notch.test.tsx
+++ b/src/components/ui/surfaces/notch/Notch.test.tsx
@@ -19,8 +19,8 @@ describe("Notch", () => {
       <Notch width={200} height={150} notchWidth={40} notchHeight={50} notchSide="right" />,
     );
     const svg = container.querySelector("svg");
-    expect(svg).toHaveAttribute("width", "240");
-    expect(svg).toHaveAttribute("height", "150");
+    expect(svg).toHaveAttribute("width", "241");
+    expect(svg).toHaveAttribute("height", "151");
   });
 
   it("sets correct SVG dimensions for bottom notch", () => {
@@ -28,8 +28,8 @@ describe("Notch", () => {
       <Notch width={200} height={150} notchWidth={40} notchHeight={50} notchSide="bottom" />,
     );
     const svg = container.querySelector("svg");
-    expect(svg).toHaveAttribute("width", "200");
-    expect(svg).toHaveAttribute("height", "200");
+    expect(svg).toHaveAttribute("width", "201");
+    expect(svg).toHaveAttribute("height", "201");
   });
 
   it("renders head only", () => {
@@ -37,8 +37,8 @@ describe("Notch", () => {
       <Notch width={200} height={150} notchWidth={60} notchHeight={40} headOnly />,
     );
     const svg = container.querySelector("svg");
-    expect(svg).toHaveAttribute("width", "60");
-    expect(svg).toHaveAttribute("height", "40");
+    expect(svg).toHaveAttribute("width", "61");
+    expect(svg).toHaveAttribute("height", "41");
   });
 
   it("applies fill and stroke", () => {

--- a/src/components/ui/surfaces/notch/Notch.test.tsx
+++ b/src/components/ui/surfaces/notch/Notch.test.tsx
@@ -37,9 +37,10 @@ describe("Notch", () => {
       <Notch width={200} height={150} notchWidth={60} notchHeight={40} headOnly />,
     );
     const svg = container.querySelector("svg");
-    // totalW = notchWidth(60) + inverseRadius(6)*2 + strokeWidth(1) = 73
-    expect(svg).toHaveAttribute("width", "73");
-    expect(svg).toHaveAttribute("height", "41");
+    // pathW = notchWidth(60) + ir(6) = 66, + strokeWidth(1) = 67
+    // pathH = notchHeight(40) + ir(6)*2 = 52, + strokeWidth(1) = 53
+    expect(svg).toHaveAttribute("width", "67");
+    expect(svg).toHaveAttribute("height", "53");
   });
 
   it("applies fill and stroke", () => {

--- a/src/components/ui/surfaces/notch/Notch.tsx
+++ b/src/components/ui/surfaces/notch/Notch.tsx
@@ -1,0 +1,154 @@
+import type { CSSProperties } from "react";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "Notch",
+  description: "SVG shape with a notch tab on any edge",
+};
+
+export type NotchSide = "top" | "bottom" | "left" | "right";
+
+export interface NotchProps {
+  width: number;
+  height: number;
+  notchWidth: number;
+  notchHeight: number;
+  notchSide?: NotchSide;
+  /** Offset from start of edge. Positive = from top/left, negative = from bottom/right */
+  notchOffset?: number;
+  radius?: number;
+  inverseRadius?: number;
+  /** SVG fill color. Defaults to surface-container-low. Set "none" to disable. */
+  fill?: string;
+  /** SVG stroke color. Defaults to primary. Set "none" to disable. */
+  stroke?: string;
+  strokeWidth?: number;
+  /** Render only the notch tab, no body */
+  headOnly?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+
+/**
+ * Builds path for body + notch on the RIGHT edge.
+ * Other sides use SVG transform.
+ */
+function buildPath(
+  w: number, h: number,
+  nw: number, nh: number,
+  ny: number,
+  r: number, ir: number,
+) {
+  const tw = w + nw;
+  const nb = ny + nh;
+
+  return [
+    `M ${r},0`,
+    `H ${w - r}`,
+    `A ${r},${r} 0 0,1 ${w},${r}`,
+    `V ${ny - ir}`,
+    `A ${ir},${ir} 0 0,0 ${w + ir},${ny}`,
+    `H ${tw - r}`,
+    `A ${r},${r} 0 0,1 ${tw},${ny + r}`,
+    `V ${nb - r}`,
+    `A ${r},${r} 0 0,1 ${tw - r},${nb}`,
+    `H ${w + ir}`,
+    `A ${ir},${ir} 0 0,0 ${w},${nb + ir}`,
+    `V ${h - r}`,
+    `A ${r},${r} 0 0,1 ${w - r},${h}`,
+    `H ${r}`,
+    `A ${r},${r} 0 0,1 0,${h - r}`,
+    `V ${r}`,
+    `A ${r},${r} 0 0,1 ${r},0`,
+    `Z`,
+  ].join(" ");
+}
+
+function buildHeadPath(w: number, h: number, r: number) {
+  return [
+    `M ${r},0`,
+    `H ${w - r}`,
+    `A ${r},${r} 0 0,1 ${w},${r}`,
+    `V ${h - r}`,
+    `A ${r},${r} 0 0,1 ${w - r},${h}`,
+    `H ${r}`,
+    `A ${r},${r} 0 0,1 0,${h - r}`,
+    `V ${r}`,
+    `A ${r},${r} 0 0,1 ${r},0`,
+    `Z`,
+  ].join(" ");
+}
+
+function resolveOffset(offset: number, edge: number, notch: number) {
+  return offset >= 0 ? offset : edge - notch + offset;
+}
+
+export function Notch({
+  width,
+  height,
+  notchWidth,
+  notchHeight,
+  notchSide = "right",
+  notchOffset = 0,
+  radius = 8,
+  inverseRadius = 6,
+  fill = "var(--color-surface-container-low)",
+  stroke = "var(--color-primary)",
+  strokeWidth = 1,
+  headOnly = false,
+  className,
+  style,
+}: NotchProps) {
+  if (headOnly) {
+    return (
+      <svg width={notchWidth} height={notchHeight} className={cn("pointer-events-none", className)} style={style}>
+        <path d={buildHeadPath(notchWidth, notchHeight, radius)} fill={fill} stroke={stroke} strokeWidth={strokeWidth} />
+      </svg>
+    );
+  }
+
+  const horiz = notchSide === "right" || notchSide === "left";
+
+  // Always build path as "notch on right edge"
+  // For top/bottom: swap axes — treat width as height and vice versa
+  const bw = horiz ? width : height;
+  const bh = horiz ? height : width;
+  const bnw = horiz ? notchWidth : notchHeight;
+  const bnh = horiz ? notchHeight : notchWidth;
+  const edge = horiz ? height : width;
+  const notchLen = horiz ? notchHeight : notchWidth;
+  const ny = resolveOffset(notchOffset, edge, notchLen);
+
+  const path = buildPath(bw, bh, bnw, bnh, ny, radius, inverseRadius);
+
+  const svgW = horiz ? width + notchWidth : width;
+  const svgH = horiz ? height : height + notchHeight;
+
+  // Transform to target side
+  let transform: string | undefined;
+  const pw = bw + bnw; // path total width
+  const ph = bh; // path total height
+
+  switch (notchSide) {
+    case "right":
+      break;
+    case "left":
+      transform = `translate(${pw}, 0) scale(-1, 1)`;
+      break;
+    case "bottom":
+      // path is drawn horizontally (notch on right), rotate -90° to put notch on bottom
+      transform = `translate(0, ${pw}) rotate(-90)`;
+      break;
+    case "top":
+      // rotate -90° then flip vertically
+      transform = `translate(${ph}, 0) rotate(90)`;
+      break;
+  }
+
+  return (
+    <svg width={svgW} height={svgH} className={cn("pointer-events-none", className)} style={style}>
+      <path d={path} fill={fill} stroke={stroke} strokeWidth={strokeWidth} transform={transform} />
+    </svg>
+  );
+}

--- a/src/components/ui/surfaces/notch/Notch.tsx
+++ b/src/components/ui/surfaces/notch/Notch.tsx
@@ -123,10 +123,18 @@ export function Notch({
   className,
   style,
 }: NotchProps) {
+  const pad = strokeWidth / 2;
+
   if (headOnly) {
     return (
-      <svg width={notchWidth} height={notchHeight} className={cn("pointer-events-none", className)} style={style}>
-        <path d={buildHeadPath(notchWidth, notchHeight, radius)} fill={fill} stroke={stroke} strokeWidth={strokeWidth} vectorEffect="non-scaling-stroke" />
+      <svg
+        width={notchWidth + strokeWidth}
+        height={notchHeight + strokeWidth}
+        viewBox={`${-pad} ${-pad} ${notchWidth + strokeWidth} ${notchHeight + strokeWidth}`}
+        className={cn("pointer-events-none", className)}
+        style={style}
+      >
+        <path d={buildHeadPath(notchWidth, notchHeight, radius)} fill={fill} stroke={stroke} strokeWidth={strokeWidth} />
       </svg>
     );
   }
@@ -191,7 +199,13 @@ export function Notch({
   }
 
   return (
-    <svg width={svgW} height={svgH} className={cn("pointer-events-none", className)} style={style}>
+    <svg
+      width={svgW + strokeWidth}
+      height={svgH + strokeWidth}
+      viewBox={`${-pad} ${-pad} ${svgW + strokeWidth} ${svgH + strokeWidth}`}
+      className={cn("pointer-events-none", className)}
+      style={style}
+    >
       <path d={path} fill={fill} stroke={stroke} strokeWidth={strokeWidth} transform={transform} />
     </svg>
   );

--- a/src/components/ui/surfaces/notch/Notch.tsx
+++ b/src/components/ui/surfaces/notch/Notch.tsx
@@ -16,13 +16,13 @@ export interface NotchProps {
   notchWidth: number;
   notchHeight: number;
   notchSide?: NotchSide;
-  /** Offset from start of edge. Positive = from top/left, negative = from bottom/right */
+  /** Positive = from top/left, negative = from bottom/right */
   notchOffset?: number;
   radius?: number;
   inverseRadius?: number;
-  /** SVG fill color. Defaults to surface-container-low. Set "none" to disable. */
+  /** Set "none" to disable */
   fill?: string;
-  /** SVG stroke color. Defaults to primary. Set "none" to disable. */
+  /** Set "none" to disable */
   stroke?: string;
   strokeWidth?: number;
   /** Render only the notch tab, no body */
@@ -31,10 +31,8 @@ export interface NotchProps {
   style?: CSSProperties;
 }
 
-/**
- * Builds path for body + notch on the RIGHT edge.
- * Other sides use SVG transform.
- */
+// --- Path builders (always draw notch on RIGHT edge, transform for others) ---
+
 function buildPath(
   w: number, h: number,
   nw: number, nh: number,
@@ -47,15 +45,12 @@ function buildPath(
   const atEnd = nb >= h;
   const d: string[] = [];
 
-  // Top-left corner
   d.push(`M ${r},0`);
 
   if (atStart) {
-    // Notch starts at top — no body corner on top-right, notch IS the top-right
     d.push(`H ${tw - r}`);
     d.push(`A ${r},${r} 0 0,1 ${tw},${r}`);
   } else {
-    // Body top-right corner, then inverse corner down to notch
     d.push(`H ${w - r}`);
     d.push(`A ${r},${r} 0 0,1 ${w},${r}`);
     d.push(`V ${ny - ir}`);
@@ -65,11 +60,9 @@ function buildPath(
   }
 
   if (atEnd) {
-    // Notch ends at bottom — notch IS the bottom-right
     d.push(`V ${h - r}`);
     d.push(`A ${r},${r} 0 0,1 ${tw - r},${h}`);
   } else {
-    // Notch bottom-right corner, inverse corner, then body bottom-right
     d.push(`V ${nb - r}`);
     d.push(`A ${r},${r} 0 0,1 ${tw - r},${nb}`);
     d.push(`H ${w + ir}`);
@@ -78,7 +71,6 @@ function buildPath(
     d.push(`A ${r},${r} 0 0,1 ${w - r},${h}`);
   }
 
-  // Bottom-left and left edge
   d.push(`H ${r}`);
   d.push(`A ${r},${r} 0 0,1 0,${h - r}`);
   d.push(`V ${r}`);
@@ -88,41 +80,27 @@ function buildPath(
   return d.join(" ");
 }
 
-// Head only: the notch tab cut from the full shape.
-// atStart: notch at edge start → top-left is sharp, bottom-left has inverse corner
-// atEnd: notch at edge end → bottom-left is sharp, top-left has inverse corner
-// middle: both top-left and bottom-left have inverse corners
 function buildHeadPath(nw: number, nh: number, r: number, ir: number, atStart: boolean, atEnd: boolean) {
-  const w = nw + ir; // inverse corner extends left
+  const w = nw + ir;
   const topIr = atStart ? 0 : ir;
   const botIr = atEnd ? 0 : ir;
-  const h = nh + topIr + botIr;
-
   const d: string[] = [];
 
-  // The left edge at x=0 represents the body's right edge.
-  // Inverse corners match the full shape: arc going RIGHT-DOWN (sweep=0).
-
   if (!atStart) {
-    // Top: sharp corner at (0,0), inverse corner from (0,0) to (ir, topIr)
     d.push(`M 0,0`);
     d.push(`A ${ir},${ir} 0 0,0 ${ir},${topIr}`);
   } else {
     d.push(`M 0,${topIr}`);
   }
 
-  // Top edge of notch
   d.push(`H ${w - r}`);
   d.push(`A ${r},${r} 0 0,1 ${w},${topIr + r}`);
-  // Right edge down
   d.push(`V ${topIr + nh - r}`);
   d.push(`A ${r},${r} 0 0,1 ${w - r},${topIr + nh}`);
-  // Bottom edge to left
   d.push(`H ${ir}`);
 
   if (!atEnd) {
-    // Bottom inverse: from (ir, topIr+nh) to (0, topIr+nh+ir) — LEFT-DOWN
-    d.push(`A ${ir},${ir} 0 0,0 0,${topIr + nh + ir}`);
+    d.push(`A ${ir},${ir} 0 0,0 0,${topIr + nh + botIr}`);
   }
 
   d.push(`V 0`);
@@ -131,9 +109,49 @@ function buildHeadPath(nw: number, nh: number, r: number, ir: number, atStart: b
   return d.join(" ");
 }
 
+// --- Shared helpers ---
+
 function resolveOffset(offset: number, edge: number, notch: number) {
   return offset >= 0 ? offset : edge - notch + offset;
 }
+
+function resolveEdgeParams(side: NotchSide, width: number, height: number, nw: number, nh: number) {
+  const horiz = side === "right" || side === "left";
+  return {
+    horiz,
+    edge: horiz ? height : width,
+    notchLen: horiz ? nh : nw,
+  };
+}
+
+function clampOffset(ny: number, edge: number, notchLen: number, minGap: number, notchOffset: number) {
+  let clamped = ny;
+  if (clamped > 0 && clamped < minGap) {
+    if (isDev) {
+      console.warn(`[Notch] notchOffset ${notchOffset} too small — must be 0 or >= ${minGap}. Clamping to 0.`);
+    }
+    clamped = 0;
+  }
+  const endGap = edge - notchLen - clamped;
+  if (endGap > 0 && endGap < minGap) {
+    if (isDev) {
+      console.warn(`[Notch] notch too close to far edge — gap ${endGap} < ${minGap}. Clamping to edge.`);
+    }
+    clamped = edge - notchLen;
+  }
+  return clamped;
+}
+
+function getTransform(side: NotchSide, pw: number, ph: number): string | undefined {
+  switch (side) {
+    case "right": return undefined;
+    case "left": return `translate(${pw}, 0) scale(-1, 1)`;
+    case "bottom": return `translate(0, ${pw}) rotate(-90)`;
+    case "top": return `translate(${ph}, 0) rotate(90)`;
+  }
+}
+
+// --- Component ---
 
 export function Notch({
   width,
@@ -152,16 +170,14 @@ export function Notch({
   style,
 }: NotchProps) {
   const pad = strokeWidth / 2;
+  const { horiz, edge, notchLen } = resolveEdgeParams(notchSide, width, height, notchWidth, notchHeight);
+  const ir = inverseRadius;
+  const minGap = radius + ir;
 
   if (headOnly) {
-    const ir = inverseRadius;
-    const horiz = notchSide === "right" || notchSide === "left";
-    const edge = horiz ? height : width;
-    const notchLen = horiz ? notchHeight : notchWidth;
     const resolvedOff = resolveOffset(notchOffset, edge, notchLen);
-    const minGap = radius + ir;
-    const atStart = resolvedOff === 0 || resolvedOff < minGap;
-    const atEnd = (edge - notchLen - resolvedOff) === 0 || (edge - notchLen - resolvedOff) < minGap;
+    const atStart = resolvedOff < minGap;
+    const atEnd = (edge - notchLen - resolvedOff) < minGap;
 
     const topIr = atStart ? 0 : ir;
     const botIr = atEnd ? 0 : ir;
@@ -169,27 +185,11 @@ export function Notch({
     const pathH = notchHeight + topIr + botIr;
     const headPath = buildHeadPath(notchWidth, notchHeight, radius, ir, atStart, atEnd);
 
-    // For other sides, transform the right-edge tab
     let svgW: number, svgH: number;
-    let transform: string | undefined;
+    if (horiz) { svgW = pathW; svgH = pathH; }
+    else { svgW = pathH; svgH = pathW; }
 
-    switch (notchSide) {
-      case "right":
-        svgW = pathW; svgH = pathH;
-        break;
-      case "left":
-        svgW = pathW; svgH = pathH;
-        transform = `translate(${pathW}, 0) scale(-1, 1)`;
-        break;
-      case "bottom":
-        svgW = pathH; svgH = pathW;
-        transform = `translate(0, ${pathW}) rotate(-90)`;
-        break;
-      case "top":
-        svgW = pathH; svgH = pathW;
-        transform = `translate(${pathH}, 0) rotate(90)`;
-        break;
-    }
+    const transform = getTransform(notchSide, pathW, pathH);
 
     return (
       <svg
@@ -204,64 +204,20 @@ export function Notch({
     );
   }
 
-  const horiz = notchSide === "right" || notchSide === "left";
-
-  // Always build path as "notch on right edge"
-  // For top/bottom: swap axes — treat width as height and vice versa
   const bw = horiz ? width : height;
   const bh = horiz ? height : width;
   const bnw = horiz ? notchWidth : notchHeight;
   const bnh = horiz ? notchHeight : notchWidth;
-  const edge = horiz ? height : width;
-  const notchLen = horiz ? notchHeight : notchWidth;
   const rawNy = resolveOffset(notchOffset, edge, notchLen);
-  const minGap = radius + inverseRadius;
+  const ny = clampOffset(rawNy, edge, notchLen, minGap, notchOffset);
 
-  // Offset must be 0 or >= minGap from either edge
-  let ny = rawNy;
-  if (ny > 0 && ny < minGap) {
-    if (isDev) {
-      console.warn(
-        `[Notch] notchOffset ${notchOffset} is too small — must be 0 or >= ${minGap} (radius + inverseRadius). Clamping to 0.`,
-      );
-    }
-    ny = 0;
-  }
-  const endGap = edge - notchLen - ny;
-  if (endGap > 0 && endGap < minGap) {
-    if (isDev) {
-      console.warn(
-        `[Notch] notch is too close to the far edge — gap ${endGap} < ${minGap}. Clamping to edge.`,
-      );
-    }
-    ny = edge - notchLen;
-  }
-
-  const path = buildPath(bw, bh, bnw, bnh, ny, radius, inverseRadius);
+  const path = buildPath(bw, bh, bnw, bnh, ny, radius, ir);
 
   const svgW = horiz ? width + notchWidth : width;
   const svgH = horiz ? height : height + notchHeight;
-
-  // Transform to target side
-  let transform: string | undefined;
-  const pw = bw + bnw; // path total width
-  const ph = bh; // path total height
-
-  switch (notchSide) {
-    case "right":
-      break;
-    case "left":
-      transform = `translate(${pw}, 0) scale(-1, 1)`;
-      break;
-    case "bottom":
-      // path is drawn horizontally (notch on right), rotate -90° to put notch on bottom
-      transform = `translate(0, ${pw}) rotate(-90)`;
-      break;
-    case "top":
-      // rotate -90° then flip vertically
-      transform = `translate(${ph}, 0) rotate(90)`;
-      break;
-  }
+  const pw = bw + bnw;
+  const ph = bh;
+  const transform = getTransform(notchSide, pw, ph);
 
   return (
     <svg

--- a/src/components/ui/surfaces/notch/Notch.tsx
+++ b/src/components/ui/surfaces/notch/Notch.tsx
@@ -100,32 +100,31 @@ function buildHeadPath(nw: number, nh: number, r: number, ir: number, atStart: b
 
   const d: string[] = [];
 
-  // Start top-left
-  d.push(`M 0,0`);
+  // The left edge at x=0 represents the body's right edge.
+  // Inverse corners match the full shape: arc going RIGHT-DOWN (sweep=0).
 
   if (!atStart) {
-    // Top-left inverse corner (body continues up)
-    d.push(`V ${topIr}`);
-    d.push(`A ${ir},${ir} 0 0,0 ${ir},0`);
+    // Top: sharp corner at (0,0), inverse corner from (0,0) to (ir, topIr)
+    d.push(`M 0,0`);
+    d.push(`A ${ir},${ir} 0 0,0 ${ir},${topIr}`);
+  } else {
+    d.push(`M 0,${topIr}`);
   }
 
-  // Top edge
+  // Top edge of notch
   d.push(`H ${w - r}`);
-  // Top-right rounded corner
   d.push(`A ${r},${r} 0 0,1 ${w},${topIr + r}`);
   // Right edge down
   d.push(`V ${topIr + nh - r}`);
-  // Bottom-right rounded corner
   d.push(`A ${r},${r} 0 0,1 ${w - r},${topIr + nh}`);
   // Bottom edge to left
   d.push(`H ${ir}`);
 
   if (!atEnd) {
-    // Bottom-left inverse corner (body continues down)
-    d.push(`A ${ir},${ir} 0 0,0 0,${h}`);
+    // Bottom inverse: from (ir, topIr+nh) to (0, topIr+nh+ir) — LEFT-DOWN
+    d.push(`A ${ir},${ir} 0 0,0 0,${topIr + nh + ir}`);
   }
 
-  // Sharp cut left edge back to start
   d.push(`V 0`);
   d.push(`Z`);
 

--- a/src/components/ui/surfaces/notch/Notch.tsx
+++ b/src/components/ui/surfaces/notch/Notch.tsx
@@ -88,33 +88,34 @@ function buildPath(
   return d.join(" ");
 }
 
-// Head only: just the notch tab cut from the full shape.
-// Drawn as right-edge notch tab: inverse corners on left, rounded corners on right.
-// nw = notch width, nh = notch height, r = corner radius, ir = inverse radius
-// Total size: (nw + ir) wide, (nh + ir*2) tall
+// Head only: the notch tab cut from the full shape at offset=0.
+// For a right-edge notch at offset=0:
+//   - Top edge is shared with body top → normal rounded corner on top-left and top-right
+//   - Bottom has inverse corner on left (where body would continue down)
+//   - Right side has normal rounded corners
+//   - Left side: straight down, then inverse corner, then sharp cut
+// Size: (nw + ir) wide, (nh + ir) tall
 function buildHeadPath(nw: number, nh: number, r: number, ir: number) {
-  const w = nw + ir; // total width
-  const h = nh + ir * 2; // total height
+  const w = nw + ir; // total width (notch + inverse corner extends left)
+  const h = nh + ir; // total height (notch + inverse corner extends down)
 
   return [
-    // Top-left: sharp edge then inverse corner going right
+    // Top-left corner (shared with body)
     `M 0,0`,
-    `V ${ir}`,
-    `A ${ir},${ir} 0 0,0 ${ir},0`,
-    // Top edge of notch
+    // Top edge
     `H ${w - r}`,
-    // Top-right corner
+    // Top-right rounded corner
     `A ${r},${r} 0 0,1 ${w},${r}`,
     // Right edge down
-    `V ${h - r}`,
-    // Bottom-right corner
-    `A ${r},${r} 0 0,1 ${w - r},${h}`,
-    // Bottom edge back to left
+    `V ${nh - r}`,
+    // Bottom-right rounded corner
+    `A ${r},${r} 0 0,1 ${w - r},${nh}`,
+    // Bottom edge to inverse corner
     `H ${ir}`,
-    // Bottom-left inverse corner
-    `A ${ir},${ir} 0 0,0 0,${h - ir}`,
-    // Sharp edge down
-    `V ${h}`,
+    // Inverse corner (same as in full shape: concave, body continues down-left)
+    `A ${ir},${ir} 0 0,0 0,${h}`,
+    // Sharp cut at left edge
+    `V 0`,
     `Z`,
   ].join(" ");
 }
@@ -145,7 +146,7 @@ export function Notch({
     const ir = inverseRadius;
     // Path is always drawn as a right-edge tab
     const pathW = notchWidth + ir;
-    const pathH = notchHeight + ir * 2;
+    const pathH = notchHeight + ir;
     const headPath = buildHeadPath(notchWidth, notchHeight, radius, ir);
 
     // For other sides, transform the right-edge tab

--- a/src/components/ui/surfaces/notch/Notch.tsx
+++ b/src/components/ui/surfaces/notch/Notch.tsx
@@ -106,7 +106,7 @@ function buildHeadPath(nw: number, nh: number, r: number, ir: number, atStart: b
   if (!atStart) {
     // Top-left inverse corner (body continues up)
     d.push(`V ${topIr}`);
-    d.push(`A ${ir},${ir} 0 0,0 ${ir},0`);
+    d.push(`A ${ir},${ir} 0 0,1 ${ir},0`);
   }
 
   // Top edge
@@ -122,7 +122,7 @@ function buildHeadPath(nw: number, nh: number, r: number, ir: number, atStart: b
 
   if (!atEnd) {
     // Bottom-left inverse corner (body continues down)
-    d.push(`A ${ir},${ir} 0 0,0 0,${h}`);
+    d.push(`A ${ir},${ir} 0 0,1 0,${h}`);
   }
 
   // Sharp cut left edge back to start

--- a/src/components/ui/surfaces/notch/Notch.tsx
+++ b/src/components/ui/surfaces/notch/Notch.tsx
@@ -88,30 +88,32 @@ function buildPath(
   return d.join(" ");
 }
 
-// Hat shape: rounded top, flat bottom with inverse corners extending outward
-function buildHeadPath(w: number, h: number, r: number, ir: number) {
-  // Total width = ir + w + ir (inverse corners extend beyond the tab)
+// Head only: just the notch tab cut from the full shape.
+// Drawn as right-edge notch tab: inverse corners on left, rounded corners on right.
+// nw = notch width, nh = notch height, r = corner radius, ir = inverse radius
+// Total size: (nw + ir) wide, (nh + ir*2) tall
+function buildHeadPath(nw: number, nh: number, r: number, ir: number) {
+  const w = nw + ir; // total width
+  const h = nh + ir * 2; // total height
+
   return [
-    // Start at bottom-left (below the inverse corner)
-    `M 0,${h}`,
-    // Up to inverse corner
-    `V ${h - ir}`,
-    // Inverse corner bottom-left (concave)
-    `A ${ir},${ir} 0 0,0 ${ir},${h}`,
-    // Flat bottom of tab (but we're going up into the tab)
-    // Actually: go up the left side of the tab
-    `V ${r}`,
-    // Top-left corner
-    `A ${r},${r} 0 0,1 ${ir + r},0`,
-    // Top edge
-    `H ${ir + w - r}`,
+    // Top-left: sharp edge then inverse corner going right
+    `M 0,0`,
+    `V ${ir}`,
+    `A ${ir},${ir} 0 0,0 ${ir},0`,
+    // Top edge of notch
+    `H ${w - r}`,
     // Top-right corner
-    `A ${r},${r} 0 0,1 ${ir + w},${r}`,
-    // Right side down
-    `V ${h}`,
-    // Inverse corner bottom-right (concave)
-    `A ${ir},${ir} 0 0,0 ${ir + w + ir},${h - ir}`,
-    // Down to bottom
+    `A ${r},${r} 0 0,1 ${w},${r}`,
+    // Right edge down
+    `V ${h - r}`,
+    // Bottom-right corner
+    `A ${r},${r} 0 0,1 ${w - r},${h}`,
+    // Bottom edge back to left
+    `H ${ir}`,
+    // Bottom-left inverse corner
+    `A ${ir},${ir} 0 0,0 0,${h - ir}`,
+    // Sharp edge down
     `V ${h}`,
     `Z`,
   ].join(" ");
@@ -141,16 +143,42 @@ export function Notch({
 
   if (headOnly) {
     const ir = inverseRadius;
-    const totalW = notchWidth + ir * 2;
+    // Path is always drawn as a right-edge tab
+    const pathW = notchWidth + ir;
+    const pathH = notchHeight + ir * 2;
+    const headPath = buildHeadPath(notchWidth, notchHeight, radius, ir);
+
+    // For other sides, transform the right-edge tab
+    let svgW: number, svgH: number;
+    let transform: string | undefined;
+
+    switch (notchSide) {
+      case "right":
+        svgW = pathW; svgH = pathH;
+        break;
+      case "left":
+        svgW = pathW; svgH = pathH;
+        transform = `translate(${pathW}, 0) scale(-1, 1)`;
+        break;
+      case "bottom":
+        svgW = pathH; svgH = pathW;
+        transform = `translate(0, ${pathW}) rotate(-90)`;
+        break;
+      case "top":
+        svgW = pathH; svgH = pathW;
+        transform = `translate(${pathH}, 0) rotate(90)`;
+        break;
+    }
+
     return (
       <svg
-        width={totalW + strokeWidth}
-        height={notchHeight + strokeWidth}
-        viewBox={`${-pad} ${-pad} ${totalW + strokeWidth} ${notchHeight + strokeWidth}`}
+        width={svgW + strokeWidth}
+        height={svgH + strokeWidth}
+        viewBox={`${-pad} ${-pad} ${svgW + strokeWidth} ${svgH + strokeWidth}`}
         className={cn("pointer-events-none", className)}
         style={style}
       >
-        <path d={buildHeadPath(notchWidth, notchHeight, radius, ir)} fill={fill} stroke={stroke} strokeWidth={strokeWidth} />
+        <path d={headPath} fill={fill} stroke={stroke} strokeWidth={strokeWidth} vectorEffect="non-scaling-stroke" transform={transform} />
       </svg>
     );
   }

--- a/src/components/ui/surfaces/notch/Notch.tsx
+++ b/src/components/ui/surfaces/notch/Notch.tsx
@@ -88,17 +88,31 @@ function buildPath(
   return d.join(" ");
 }
 
-function buildHeadPath(w: number, h: number, r: number) {
+// Hat shape: rounded top, flat bottom with inverse corners extending outward
+function buildHeadPath(w: number, h: number, r: number, ir: number) {
+  // Total width = ir + w + ir (inverse corners extend beyond the tab)
   return [
-    `M ${r},0`,
-    `H ${w - r}`,
-    `A ${r},${r} 0 0,1 ${w},${r}`,
-    `V ${h - r}`,
-    `A ${r},${r} 0 0,1 ${w - r},${h}`,
-    `H ${r}`,
-    `A ${r},${r} 0 0,1 0,${h - r}`,
+    // Start at bottom-left (below the inverse corner)
+    `M 0,${h}`,
+    // Up to inverse corner
+    `V ${h - ir}`,
+    // Inverse corner bottom-left (concave)
+    `A ${ir},${ir} 0 0,0 ${ir},${h}`,
+    // Flat bottom of tab (but we're going up into the tab)
+    // Actually: go up the left side of the tab
     `V ${r}`,
-    `A ${r},${r} 0 0,1 ${r},0`,
+    // Top-left corner
+    `A ${r},${r} 0 0,1 ${ir + r},0`,
+    // Top edge
+    `H ${ir + w - r}`,
+    // Top-right corner
+    `A ${r},${r} 0 0,1 ${ir + w},${r}`,
+    // Right side down
+    `V ${h}`,
+    // Inverse corner bottom-right (concave)
+    `A ${ir},${ir} 0 0,0 ${ir + w + ir},${h - ir}`,
+    // Down to bottom
+    `V ${h}`,
     `Z`,
   ].join(" ");
 }
@@ -126,15 +140,17 @@ export function Notch({
   const pad = strokeWidth / 2;
 
   if (headOnly) {
+    const ir = inverseRadius;
+    const totalW = notchWidth + ir * 2;
     return (
       <svg
-        width={notchWidth + strokeWidth}
+        width={totalW + strokeWidth}
         height={notchHeight + strokeWidth}
-        viewBox={`${-pad} ${-pad} ${notchWidth + strokeWidth} ${notchHeight + strokeWidth}`}
+        viewBox={`${-pad} ${-pad} ${totalW + strokeWidth} ${notchHeight + strokeWidth}`}
         className={cn("pointer-events-none", className)}
         style={style}
       >
-        <path d={buildHeadPath(notchWidth, notchHeight, radius)} fill={fill} stroke={stroke} strokeWidth={strokeWidth} />
+        <path d={buildHeadPath(notchWidth, notchHeight, radius, ir)} fill={fill} stroke={stroke} strokeWidth={strokeWidth} />
       </svg>
     );
   }

--- a/src/components/ui/surfaces/notch/Notch.tsx
+++ b/src/components/ui/surfaces/notch/Notch.tsx
@@ -106,7 +106,7 @@ function buildHeadPath(nw: number, nh: number, r: number, ir: number, atStart: b
   if (!atStart) {
     // Top-left inverse corner (body continues up)
     d.push(`V ${topIr}`);
-    d.push(`A ${ir},${ir} 0 0,1 ${ir},0`);
+    d.push(`A ${ir},${ir} 0 0,0 ${ir},0`);
   }
 
   // Top edge
@@ -122,7 +122,7 @@ function buildHeadPath(nw: number, nh: number, r: number, ir: number, atStart: b
 
   if (!atEnd) {
     // Bottom-left inverse corner (body continues down)
-    d.push(`A ${ir},${ir} 0 0,1 0,${h}`);
+    d.push(`A ${ir},${ir} 0 0,0 0,${h}`);
   }
 
   // Sharp cut left edge back to start

--- a/src/components/ui/surfaces/notch/Notch.tsx
+++ b/src/components/ui/surfaces/notch/Notch.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import { cn } from "@/utils/cn";
 import type { ComponentMeta } from "@/types/component-meta";
+import { isDev } from "@/utils/env";
 
 export const meta: ComponentMeta = {
   name: "Notch",
@@ -42,27 +43,49 @@ function buildPath(
 ) {
   const tw = w + nw;
   const nb = ny + nh;
+  const atStart = ny === 0;
+  const atEnd = nb >= h;
+  const d: string[] = [];
 
-  return [
-    `M ${r},0`,
-    `H ${w - r}`,
-    `A ${r},${r} 0 0,1 ${w},${r}`,
-    `V ${ny - ir}`,
-    `A ${ir},${ir} 0 0,0 ${w + ir},${ny}`,
-    `H ${tw - r}`,
-    `A ${r},${r} 0 0,1 ${tw},${ny + r}`,
-    `V ${nb - r}`,
-    `A ${r},${r} 0 0,1 ${tw - r},${nb}`,
-    `H ${w + ir}`,
-    `A ${ir},${ir} 0 0,0 ${w},${nb + ir}`,
-    `V ${h - r}`,
-    `A ${r},${r} 0 0,1 ${w - r},${h}`,
-    `H ${r}`,
-    `A ${r},${r} 0 0,1 0,${h - r}`,
-    `V ${r}`,
-    `A ${r},${r} 0 0,1 ${r},0`,
-    `Z`,
-  ].join(" ");
+  // Top-left corner
+  d.push(`M ${r},0`);
+
+  if (atStart) {
+    // Notch starts at top — no body corner on top-right, notch IS the top-right
+    d.push(`H ${tw - r}`);
+    d.push(`A ${r},${r} 0 0,1 ${tw},${r}`);
+  } else {
+    // Body top-right corner, then inverse corner down to notch
+    d.push(`H ${w - r}`);
+    d.push(`A ${r},${r} 0 0,1 ${w},${r}`);
+    d.push(`V ${ny - ir}`);
+    d.push(`A ${ir},${ir} 0 0,0 ${w + ir},${ny}`);
+    d.push(`H ${tw - r}`);
+    d.push(`A ${r},${r} 0 0,1 ${tw},${ny + r}`);
+  }
+
+  if (atEnd) {
+    // Notch ends at bottom — notch IS the bottom-right
+    d.push(`V ${h - r}`);
+    d.push(`A ${r},${r} 0 0,1 ${tw - r},${h}`);
+  } else {
+    // Notch bottom-right corner, inverse corner, then body bottom-right
+    d.push(`V ${nb - r}`);
+    d.push(`A ${r},${r} 0 0,1 ${tw - r},${nb}`);
+    d.push(`H ${w + ir}`);
+    d.push(`A ${ir},${ir} 0 0,0 ${w},${nb + ir}`);
+    d.push(`V ${h - r}`);
+    d.push(`A ${r},${r} 0 0,1 ${w - r},${h}`);
+  }
+
+  // Bottom-left and left edge
+  d.push(`H ${r}`);
+  d.push(`A ${r},${r} 0 0,1 0,${h - r}`);
+  d.push(`V ${r}`);
+  d.push(`A ${r},${r} 0 0,1 ${r},0`);
+  d.push(`Z`);
+
+  return d.join(" ");
 }
 
 function buildHeadPath(w: number, h: number, r: number) {
@@ -103,7 +126,7 @@ export function Notch({
   if (headOnly) {
     return (
       <svg width={notchWidth} height={notchHeight} className={cn("pointer-events-none", className)} style={style}>
-        <path d={buildHeadPath(notchWidth, notchHeight, radius)} fill={fill} stroke={stroke} strokeWidth={strokeWidth} />
+        <path d={buildHeadPath(notchWidth, notchHeight, radius)} fill={fill} stroke={stroke} strokeWidth={strokeWidth} vectorEffect="non-scaling-stroke" />
       </svg>
     );
   }
@@ -118,7 +141,28 @@ export function Notch({
   const bnh = horiz ? notchHeight : notchWidth;
   const edge = horiz ? height : width;
   const notchLen = horiz ? notchHeight : notchWidth;
-  const ny = resolveOffset(notchOffset, edge, notchLen);
+  const rawNy = resolveOffset(notchOffset, edge, notchLen);
+  const minGap = radius + inverseRadius;
+
+  // Offset must be 0 or >= minGap from either edge
+  let ny = rawNy;
+  if (ny > 0 && ny < minGap) {
+    if (isDev) {
+      console.warn(
+        `[Notch] notchOffset ${notchOffset} is too small — must be 0 or >= ${minGap} (radius + inverseRadius). Clamping to 0.`,
+      );
+    }
+    ny = 0;
+  }
+  const endGap = edge - notchLen - ny;
+  if (endGap > 0 && endGap < minGap) {
+    if (isDev) {
+      console.warn(
+        `[Notch] notch is too close to the far edge — gap ${endGap} < ${minGap}. Clamping to edge.`,
+      );
+    }
+    ny = edge - notchLen;
+  }
 
   const path = buildPath(bw, bh, bnw, bnh, ny, radius, inverseRadius);
 

--- a/src/components/ui/surfaces/notch/Notch.tsx
+++ b/src/components/ui/surfaces/notch/Notch.tsx
@@ -97,23 +97,26 @@ function buildHeadPath(nw: number, nh: number, r: number, ir: number) {
   const h = nh + ir * 2; // total height
 
   return [
-    // Top-left: sharp edge then inverse corner going right
+    // Start at top-left sharp corner
     `M 0,0`,
+    // Down to where inverse corner starts
     `V ${ir}`,
-    `A ${ir},${ir} 0 0,0 ${ir},0`,
+    // Inverse corner: curves outward (right and down) — from (0,ir) to (ir,0) but we're going clockwise
+    // Actually: from (0,ir) curving to (ir,0) going right — sweep=1
+    `A ${ir},${ir} 0 0,1 ${ir},0`,
     // Top edge of notch
     `H ${w - r}`,
-    // Top-right corner
+    // Top-right rounded corner
     `A ${r},${r} 0 0,1 ${w},${r}`,
     // Right edge down
     `V ${h - r}`,
-    // Bottom-right corner
+    // Bottom-right rounded corner
     `A ${r},${r} 0 0,1 ${w - r},${h}`,
-    // Bottom edge back to left
+    // Bottom edge back to inverse corner
     `H ${ir}`,
-    // Bottom-left inverse corner
-    `A ${ir},${ir} 0 0,0 0,${h - ir}`,
-    // Sharp edge down
+    // Inverse corner: curves outward (left and down) — from (ir,h) to (0,h-ir) — sweep=1
+    `A ${ir},${ir} 0 0,1 0,${h - ir}`,
+    // Down to bottom-left sharp corner
     `V ${h}`,
     `Z`,
   ].join(" ");

--- a/src/components/ui/surfaces/notch/Notch.tsx
+++ b/src/components/ui/surfaces/notch/Notch.tsx
@@ -97,23 +97,17 @@ function buildHeadPath(nw: number, nh: number, r: number, ir: number) {
   const h = nh + ir * 2; // total height
 
   return [
-    // Top-left: sharp edge then inverse corner going right
     `M 0,0`,
     `V ${ir}`,
-    `A ${ir},${ir} 0 0,0 ${ir},0`,
-    // Top edge of notch
+    // Top-left inverse corner — large-arc=1 to flip the curve direction
+    `A ${ir},${ir} 0 1,0 ${ir},0`,
     `H ${w - r}`,
-    // Top-right corner
     `A ${r},${r} 0 0,1 ${w},${r}`,
-    // Right edge down
     `V ${h - r}`,
-    // Bottom-right corner
     `A ${r},${r} 0 0,1 ${w - r},${h}`,
-    // Bottom edge back to left
     `H ${ir}`,
-    // Bottom-left inverse corner
-    `A ${ir},${ir} 0 0,0 0,${h - ir}`,
-    // Sharp edge down
+    // Bottom-left inverse corner — large-arc=1
+    `A ${ir},${ir} 0 1,0 0,${h - ir}`,
     `V ${h}`,
     `Z`,
   ].join(" ");

--- a/src/components/ui/surfaces/notch/Notch.tsx
+++ b/src/components/ui/surfaces/notch/Notch.tsx
@@ -97,17 +97,23 @@ function buildHeadPath(nw: number, nh: number, r: number, ir: number) {
   const h = nh + ir * 2; // total height
 
   return [
+    // Top-left: sharp edge then inverse corner going right
     `M 0,0`,
     `V ${ir}`,
-    // Top-left inverse corner — large-arc=1 to flip the curve direction
-    `A ${ir},${ir} 0 1,0 ${ir},0`,
+    `A ${ir},${ir} 0 0,0 ${ir},0`,
+    // Top edge of notch
     `H ${w - r}`,
+    // Top-right corner
     `A ${r},${r} 0 0,1 ${w},${r}`,
+    // Right edge down
     `V ${h - r}`,
+    // Bottom-right corner
     `A ${r},${r} 0 0,1 ${w - r},${h}`,
+    // Bottom edge back to left
     `H ${ir}`,
-    // Bottom-left inverse corner — large-arc=1
-    `A ${ir},${ir} 0 1,0 0,${h - ir}`,
+    // Bottom-left inverse corner
+    `A ${ir},${ir} 0 0,0 0,${h - ir}`,
+    // Sharp edge down
     `V ${h}`,
     `Z`,
   ].join(" ");

--- a/src/components/ui/surfaces/notch/Notch.tsx
+++ b/src/components/ui/surfaces/notch/Notch.tsx
@@ -88,36 +88,48 @@ function buildPath(
   return d.join(" ");
 }
 
-// Head only: the notch tab cut from the full shape at offset=0.
-// For a right-edge notch at offset=0:
-//   - Top edge is shared with body top → normal rounded corner on top-left and top-right
-//   - Bottom has inverse corner on left (where body would continue down)
-//   - Right side has normal rounded corners
-//   - Left side: straight down, then inverse corner, then sharp cut
-// Size: (nw + ir) wide, (nh + ir) tall
-function buildHeadPath(nw: number, nh: number, r: number, ir: number) {
-  const w = nw + ir; // total width (notch + inverse corner extends left)
-  const h = nh + ir; // total height (notch + inverse corner extends down)
+// Head only: the notch tab cut from the full shape.
+// atStart: notch at edge start → top-left is sharp, bottom-left has inverse corner
+// atEnd: notch at edge end → bottom-left is sharp, top-left has inverse corner
+// middle: both top-left and bottom-left have inverse corners
+function buildHeadPath(nw: number, nh: number, r: number, ir: number, atStart: boolean, atEnd: boolean) {
+  const w = nw + ir; // inverse corner extends left
+  const topIr = atStart ? 0 : ir;
+  const botIr = atEnd ? 0 : ir;
+  const h = nh + topIr + botIr;
 
-  return [
-    // Top-left corner (shared with body)
-    `M 0,0`,
-    // Top edge
-    `H ${w - r}`,
-    // Top-right rounded corner
-    `A ${r},${r} 0 0,1 ${w},${r}`,
-    // Right edge down
-    `V ${nh - r}`,
-    // Bottom-right rounded corner
-    `A ${r},${r} 0 0,1 ${w - r},${nh}`,
-    // Bottom edge to inverse corner
-    `H ${ir}`,
-    // Inverse corner (same as in full shape: concave, body continues down-left)
-    `A ${ir},${ir} 0 0,0 0,${h}`,
-    // Sharp cut at left edge
-    `V 0`,
-    `Z`,
-  ].join(" ");
+  const d: string[] = [];
+
+  // Start top-left
+  d.push(`M 0,0`);
+
+  if (!atStart) {
+    // Top-left inverse corner (body continues up)
+    d.push(`V ${topIr}`);
+    d.push(`A ${ir},${ir} 0 0,0 ${ir},0`);
+  }
+
+  // Top edge
+  d.push(`H ${w - r}`);
+  // Top-right rounded corner
+  d.push(`A ${r},${r} 0 0,1 ${w},${topIr + r}`);
+  // Right edge down
+  d.push(`V ${topIr + nh - r}`);
+  // Bottom-right rounded corner
+  d.push(`A ${r},${r} 0 0,1 ${w - r},${topIr + nh}`);
+  // Bottom edge to left
+  d.push(`H ${ir}`);
+
+  if (!atEnd) {
+    // Bottom-left inverse corner (body continues down)
+    d.push(`A ${ir},${ir} 0 0,0 0,${h}`);
+  }
+
+  // Sharp cut left edge back to start
+  d.push(`V 0`);
+  d.push(`Z`);
+
+  return d.join(" ");
 }
 
 function resolveOffset(offset: number, edge: number, notch: number) {
@@ -144,10 +156,19 @@ export function Notch({
 
   if (headOnly) {
     const ir = inverseRadius;
-    // Path is always drawn as a right-edge tab
+    const horiz = notchSide === "right" || notchSide === "left";
+    const edge = horiz ? height : width;
+    const notchLen = horiz ? notchHeight : notchWidth;
+    const resolvedOff = resolveOffset(notchOffset, edge, notchLen);
+    const minGap = radius + ir;
+    const atStart = resolvedOff === 0 || resolvedOff < minGap;
+    const atEnd = (edge - notchLen - resolvedOff) === 0 || (edge - notchLen - resolvedOff) < minGap;
+
+    const topIr = atStart ? 0 : ir;
+    const botIr = atEnd ? 0 : ir;
     const pathW = notchWidth + ir;
-    const pathH = notchHeight + ir;
-    const headPath = buildHeadPath(notchWidth, notchHeight, radius, ir);
+    const pathH = notchHeight + topIr + botIr;
+    const headPath = buildHeadPath(notchWidth, notchHeight, radius, ir, atStart, atEnd);
 
     // For other sides, transform the right-edge tab
     let svgW: number, svgH: number;

--- a/src/components/ui/surfaces/notch/Notch.tsx
+++ b/src/components/ui/surfaces/notch/Notch.tsx
@@ -97,26 +97,23 @@ function buildHeadPath(nw: number, nh: number, r: number, ir: number) {
   const h = nh + ir * 2; // total height
 
   return [
-    // Start at top-left sharp corner
+    // Top-left: sharp edge then inverse corner going right
     `M 0,0`,
-    // Down to where inverse corner starts
     `V ${ir}`,
-    // Inverse corner: curves outward (right and down) — from (0,ir) to (ir,0) but we're going clockwise
-    // Actually: from (0,ir) curving to (ir,0) going right — sweep=1
-    `A ${ir},${ir} 0 0,1 ${ir},0`,
+    `A ${ir},${ir} 0 0,0 ${ir},0`,
     // Top edge of notch
     `H ${w - r}`,
-    // Top-right rounded corner
+    // Top-right corner
     `A ${r},${r} 0 0,1 ${w},${r}`,
     // Right edge down
     `V ${h - r}`,
-    // Bottom-right rounded corner
+    // Bottom-right corner
     `A ${r},${r} 0 0,1 ${w - r},${h}`,
-    // Bottom edge back to inverse corner
+    // Bottom edge back to left
     `H ${ir}`,
-    // Inverse corner: curves outward (left and down) — from (ir,h) to (0,h-ir) — sweep=1
-    `A ${ir},${ir} 0 0,1 0,${h - ir}`,
-    // Down to bottom-left sharp corner
+    // Bottom-left inverse corner
+    `A ${ir},${ir} 0 0,0 0,${h - ir}`,
+    // Sharp edge down
     `V ${h}`,
     `Z`,
   ].join(" ");

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,3 +146,8 @@ export {
   type AppSwitcherProps,
   type AppLink,
 } from "./components/ui/navigation/app-switcher/AppSwitcher";
+export {
+  Notch,
+  type NotchProps,
+  type NotchSide,
+} from "./components/ui/surfaces/notch/Notch";


### PR DESCRIPTION
## Summary
- SVG shape with notch tab on any edge (`top`/`bottom`/`left`/`right`)
- `notchOffset`: positive = from top/left, negative = from bottom/right
- `radius` + `inverseRadius` for corners and concave joints
- `fill` / `stroke` / `strokeWidth` — no variant prop, set directly
- `headOnly` mode renders just the notch tab (no body)
- Path built for right edge, other sides via SVG transform
- Stories: Playground (all controls), AllSides, FillOnly, OutlineOnly, NegativeOffset, HeadOnly

Closes #112

## Test plan
- [x] `pnpm components validate` — 30 components pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 6 tests pass
- [ ] Visual review in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)