### PR TITLE
feat: add DropdownMenu component (#20)

### DIFF
--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.stories.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { DropdownMenu } from "./DropdownMenu";
+import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+
+const meta: Meta<typeof DropdownMenu> = {
+  title: "UI/Navigation/DropdownMenu",
+  component: DropdownMenu,
+  decorators: [
+    (Story) => (
+      <div className="p-8 min-h-[300px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof DropdownMenu>;
+
+export const Playground: Story = {
+  args: {
+    trigger: (
+      <IconButton icon="more_vert" aria-label="Open menu" variant="text" />
+    ),
+    items: [
+      { id: "edit", label: "Edit", icon: "edit" },
+      { id: "duplicate", label: "Duplicate", icon: "content_copy" },
+      { type: "separator" as const },
+      { id: "delete", label: "Delete", icon: "delete", variant: "danger" as const },
+    ],
+    onSelect: (item) => console.log("Selected:", item.id),
+  },
+};

--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.stories.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.stories.tsx
@@ -20,7 +20,7 @@ type Story = StoryObj<typeof DropdownMenu>;
 export const Playground: Story = {
   args: {
     trigger: (
-      <IconButton icon="more_vert" aria-label="Open menu" variant="text" />
+      <IconButton icon="more_vert" aria-label="Open menu" variant="filled" />
     ),
     items: [
       { id: "edit", label: "Edit", icon: "edit" },

--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.test.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, afterEach, vi } from "vitest";
+import { DropdownMenu } from "./DropdownMenu";
+import type { DropdownMenuEntry } from "./DropdownMenu";
+
+afterEach(cleanup);
+
+const items: DropdownMenuEntry[] = [
+  { id: "edit", label: "Edit", icon: "edit" },
+  { id: "duplicate", label: "Duplicate", icon: "content_copy" },
+  { type: "separator" },
+  { id: "disabled-item", label: "Locked", disabled: true },
+  { id: "delete", label: "Delete", icon: "delete", variant: "danger" },
+];
+
+const trigger = <button>Open</button>;
+
+describe("DropdownMenu", () => {
+  it("renders trigger", () => {
+    render(<DropdownMenu items={items} onSelect={() => {}} trigger={trigger} />);
+    expect(screen.getByText("Open")).toBeInTheDocument();
+  });
+
+  it("opens menu on click", () => {
+    render(<DropdownMenu items={items} onSelect={() => {}} trigger={trigger} />);
+    fireEvent.click(screen.getByText("Open"));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+
+  it("calls onSelect when item clicked", () => {
+    const onSelect = vi.fn();
+    render(<DropdownMenu items={items} onSelect={onSelect} trigger={trigger} />);
+    fireEvent.click(screen.getByText("Open"));
+    fireEvent.click(screen.getByText("Edit"));
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "edit", label: "Edit" }),
+    );
+  });
+
+  it("closes on Escape", () => {
+    render(<DropdownMenu items={items} onSelect={() => {}} trigger={trigger} />);
+    fireEvent.click(screen.getByText("Open"));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    fireEvent.keyDown(screen.getByRole("menu"), { key: "Escape" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
+
+  it("skips disabled items in keyboard nav", () => {
+    const onSelect = vi.fn();
+    render(<DropdownMenu items={items} onSelect={onSelect} trigger={trigger} />);
+    fireEvent.click(screen.getByText("Open"));
+    const menu = screen.getByRole("menu");
+
+    // ArrowDown from first item (Edit) -> Duplicate -> skip separator -> skip disabled -> Delete
+    fireEvent.keyDown(menu, { key: "ArrowDown" }); // Edit -> Duplicate
+    fireEvent.keyDown(menu, { key: "ArrowDown" }); // Duplicate -> Delete (skips separator + disabled)
+    fireEvent.keyDown(menu, { key: "Enter" });
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "delete" }),
+    );
+  });
+});

--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
@@ -13,7 +13,7 @@ import { Icon } from "@/components/ui/media/icon/Icon";
 import { Notch } from "@/components/ui/surfaces/notch/Notch";
 
 const DD_NOTCH_W = 40;
-const DD_NOTCH_H = 24;
+const DD_NOTCH_H = 40;
 const DD_R = 12;
 const DD_IR = 10;
 

--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
@@ -61,7 +61,7 @@ export function DropdownMenu({
   offset = 0,
   className,
 }: DropdownMenuProps) {
-  const fromEnd = offset < 0;
+  const fromEnd = offset < 0 || Object.is(offset, -0);
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -213,7 +213,7 @@ export function DropdownMenu({
           className="absolute z-50 overflow-visible outline-none"
           style={{
             top: -7,
-            [fromEnd ? "right" : "left"]: -7 - Math.abs(offset),
+            [fromEnd ? "right" : "left"]: (fromEnd? -5 : -7) - Math.abs(offset),
             filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))",
           }}
         >

--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
@@ -65,12 +65,10 @@ export function DropdownMenu({
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const [contentH, setContentH] = useState(0);
   const [menuW, setMenuW] = useState(0);
-  const [triggerW, setTriggerW] = useState(0);
   const menuId = useId();
 
   const actionableIndices = items
@@ -133,7 +131,6 @@ export function DropdownMenu({
     if (!open || !contentRef.current) return;
     setContentH(contentRef.current.offsetHeight);
     setMenuW(contentRef.current.offsetWidth);
-    if (triggerRef.current) setTriggerW(triggerRef.current.offsetWidth);
   }, [open, items.length]);
 
   const handleKeyDown = useCallback(
@@ -190,7 +187,6 @@ export function DropdownMenu({
   return (
     <div ref={containerRef} className={cn("relative inline-block", className)}>
       <div
-        ref={triggerRef}
         className="relative z-[51]"
         onClick={() => {
           if (open) {

--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
@@ -70,7 +70,7 @@ export function DropdownMenu({
   const contentRef = useRef<HTMLDivElement>(null);
   const [contentH, setContentH] = useState(0);
   const [menuW, setMenuW] = useState(0);
-  const [notchX, setNotchX] = useState(0);
+  const [triggerW, setTriggerW] = useState(0);
   const menuId = useId();
 
   const actionableIndices = items
@@ -133,13 +133,7 @@ export function DropdownMenu({
     if (!open || !contentRef.current) return;
     setContentH(contentRef.current.offsetHeight);
     setMenuW(contentRef.current.offsetWidth);
-    const btn = triggerRef.current;
-    const dd = menuRef.current;
-    if (btn && dd) {
-      const btnRect = btn.getBoundingClientRect();
-      const ddRect = dd.getBoundingClientRect();
-      setNotchX(btnRect.left - ddRect.left);
-    }
+    if (triggerRef.current) setTriggerW(triggerRef.current.offsetWidth);
   }, [open, items.length]);
 
   const handleKeyDown = useCallback(
@@ -219,7 +213,7 @@ export function DropdownMenu({
           className="absolute z-50 overflow-visible outline-none"
           style={{
             top: -7,
-            [fromEnd ? "right" : "left"]: -7,
+            [fromEnd ? "right" : "left"]: -7 - Math.abs(offset),
             filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))",
           }}
         >
@@ -230,7 +224,7 @@ export function DropdownMenu({
               notchWidth={DD_NOTCH_W}
               notchHeight={DD_NOTCH_H}
               notchSide="bottom"
-              notchOffset={notchX}
+              notchOffset={offset}
               radius={DD_R}
               inverseRadius={DD_IR}
               stroke="var(--color-primary)"

--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
@@ -65,11 +65,9 @@ export function DropdownMenu({
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const [contentH, setContentH] = useState(0);
-  const [notchX, setNotchX] = useState(0);
   const [menuW, setMenuW] = useState(0);
   const menuId = useId();
 
@@ -133,13 +131,6 @@ export function DropdownMenu({
     if (!open || !contentRef.current) return;
     setContentH(contentRef.current.offsetHeight);
     setMenuW(contentRef.current.offsetWidth);
-    const btn = triggerRef.current;
-    const dd = menuRef.current;
-    if (btn && dd) {
-      const btnRect = btn.getBoundingClientRect();
-      const ddRect = dd.getBoundingClientRect();
-      setNotchX(btnRect.left - ddRect.left);
-    }
   }, [open, items.length]);
 
   const handleKeyDown = useCallback(
@@ -196,7 +187,6 @@ export function DropdownMenu({
   return (
     <div ref={containerRef} className={cn("relative inline-block", className)}>
       <div
-        ref={triggerRef}
         className="relative z-[51]"
         onClick={() => {
           if (open) {
@@ -219,7 +209,7 @@ export function DropdownMenu({
           className="absolute z-50 overflow-visible outline-none"
           style={{
             top: -4,
-            [fromEnd ? "right" : "left"]: Math.abs(offset) - 4,
+            [fromEnd ? "right" : "left"]: -4,
             filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))",
           }}
         >
@@ -230,7 +220,7 @@ export function DropdownMenu({
               notchWidth={DD_NOTCH_W}
               notchHeight={DD_NOTCH_H}
               notchSide="bottom"
-              notchOffset={fromEnd ? -notchX : notchX}
+              notchOffset={offset}
               radius={DD_R}
               inverseRadius={DD_IR}
               stroke="var(--color-primary)"

--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
@@ -1,0 +1,248 @@
+import {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  useId,
+  type ReactNode,
+} from "react";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { Icon } from "@/components/ui/media/icon/Icon";
+
+export const meta: ComponentMeta = {
+  name: "DropdownMenu",
+  description:
+    "Action dropdown menu with keyboard navigation, icon support, and danger variant.",
+};
+
+export interface DropdownMenuItem {
+  id: string;
+  label: string;
+  icon?: string;
+  variant?: "default" | "danger";
+  disabled?: boolean;
+}
+
+export interface DropdownMenuSeparator {
+  type: "separator";
+}
+
+export type DropdownMenuEntry = DropdownMenuItem | DropdownMenuSeparator;
+
+export interface DropdownMenuProps {
+  items: DropdownMenuEntry[];
+  onSelect: (item: DropdownMenuItem) => void;
+  trigger: ReactNode;
+  align?: "start" | "end";
+  className?: string;
+}
+
+function isSeparator(entry: DropdownMenuEntry): entry is DropdownMenuSeparator {
+  return "type" in entry && entry.type === "separator";
+}
+
+function isActionable(entry: DropdownMenuEntry): entry is DropdownMenuItem {
+  return !isSeparator(entry) && !entry.disabled;
+}
+
+export function DropdownMenu({
+  items,
+  onSelect,
+  trigger,
+  align = "start",
+  className,
+}: DropdownMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const menuId = useId();
+
+  const actionableIndices = items
+    .map((entry, i) => (isActionable(entry) ? i : -1))
+    .filter((i) => i !== -1);
+
+  const findNext = useCallback(
+    (current: number) => {
+      const pos = actionableIndices.indexOf(current);
+      if (pos === -1) return actionableIndices[0] ?? -1;
+      return actionableIndices[(pos + 1) % actionableIndices.length] ?? -1;
+    },
+    [actionableIndices],
+  );
+
+  const findPrev = useCallback(
+    (current: number) => {
+      const pos = actionableIndices.indexOf(current);
+      if (pos === -1)
+        return actionableIndices[actionableIndices.length - 1] ?? -1;
+      return (
+        actionableIndices[
+          (pos - 1 + actionableIndices.length) % actionableIndices.length
+        ] ?? -1
+      );
+    },
+    [actionableIndices],
+  );
+
+  const openMenu = useCallback(() => {
+    setOpen(true);
+    setActiveIndex(actionableIndices[0] ?? -1);
+  }, [actionableIndices]);
+
+  const closeMenu = useCallback(() => {
+    setOpen(false);
+    setActiveIndex(-1);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const raf = requestAnimationFrame(() => {
+      menuRef.current?.focus();
+    });
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current?.contains(e.target as Node)) return;
+      closeMenu();
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      cancelAnimationFrame(raf);
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [open, closeMenu]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case "ArrowDown": {
+          e.preventDefault();
+          setActiveIndex((prev) => findNext(prev));
+          break;
+        }
+        case "ArrowUp": {
+          e.preventDefault();
+          setActiveIndex((prev) => findPrev(prev));
+          break;
+        }
+        case "Home": {
+          e.preventDefault();
+          setActiveIndex(actionableIndices[0] ?? -1);
+          break;
+        }
+        case "End": {
+          e.preventDefault();
+          setActiveIndex(
+            actionableIndices[actionableIndices.length - 1] ?? -1,
+          );
+          break;
+        }
+        case "Enter":
+        case " ": {
+          e.preventDefault();
+          if (activeIndex >= 0) {
+            const entry = items[activeIndex];
+            if (entry && isActionable(entry)) {
+              onSelect(entry);
+              closeMenu();
+            }
+          }
+          break;
+        }
+        case "Escape": {
+          e.preventDefault();
+          closeMenu();
+          break;
+        }
+        case "Tab": {
+          closeMenu();
+          break;
+        }
+      }
+    },
+    [findNext, findPrev, actionableIndices, activeIndex, items, onSelect, closeMenu],
+  );
+
+  return (
+    <div ref={containerRef} className={cn("relative inline-block", className)}>
+      <div
+        onClick={() => {
+          if (open) {
+            closeMenu();
+          } else {
+            openMenu();
+          }
+        }}
+      >
+        {trigger}
+      </div>
+
+      {open && (
+        <div
+          ref={menuRef}
+          id={menuId}
+          role="menu"
+          tabIndex={-1}
+          onKeyDown={handleKeyDown}
+          className={cn(
+            "absolute z-50 mt-1 min-w-[180px] rounded-xl bg-surface-container py-1 shadow-md outline-none",
+            align === "end" ? "right-0" : "left-0",
+          )}
+        >
+          {items.map((entry, index) => {
+            if (isSeparator(entry)) {
+              return (
+                <div
+                  key={`sep-${index}`}
+                  role="separator"
+                  className="my-1 h-px bg-outline-variant"
+                />
+              );
+            }
+
+            const item = entry;
+            const isActive = index === activeIndex;
+            const isDanger = item.variant === "danger";
+
+            return (
+              <div
+                key={item.id}
+                role="menuitem"
+                aria-disabled={item.disabled || undefined}
+                className={cn(
+                  "flex cursor-pointer items-center gap-3 px-3 py-2 text-sm transition-colors",
+                  item.disabled && "pointer-events-none opacity-38",
+                  isDanger ? "text-error" : "text-on-surface",
+                  isActive &&
+                    (isDanger
+                      ? "bg-error/8"
+                      : "bg-on-surface/8"),
+                )}
+                onClick={() => {
+                  if (item.disabled) return;
+                  onSelect(item);
+                  closeMenu();
+                }}
+                onMouseEnter={() => {
+                  if (!item.disabled) setActiveIndex(index);
+                }}
+              >
+                {item.icon && (
+                  <Icon
+                    name={item.icon}
+                    size={20}
+                    className={isDanger ? "text-error" : "text-on-surface-variant"}
+                  />
+                )}
+                {item.label}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
@@ -3,12 +3,19 @@ import {
   useRef,
   useEffect,
   useCallback,
+  useLayoutEffect,
   useId,
   type ReactNode,
 } from "react";
 import { cn } from "@/utils/cn";
 import type { ComponentMeta } from "@/types/component-meta";
 import { Icon } from "@/components/ui/media/icon/Icon";
+import { Notch } from "@/components/ui/surfaces/notch/Notch";
+
+const DD_NOTCH_W = 32;
+const DD_NOTCH_H = 24;
+const DD_R = 8;
+const DD_IR = 8;
 
 export const meta: ComponentMeta = {
   name: "DropdownMenu",
@@ -56,7 +63,12 @@ export function DropdownMenu({
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [contentH, setContentH] = useState(0);
+  const [notchX, setNotchX] = useState(0);
+  const [menuW, setMenuW] = useState(0);
   const menuId = useId();
 
   const actionableIndices = items
@@ -115,6 +127,19 @@ export function DropdownMenu({
     };
   }, [open, closeMenu]);
 
+  useLayoutEffect(() => {
+    if (!open || !contentRef.current) return;
+    setContentH(contentRef.current.offsetHeight);
+    setMenuW(contentRef.current.offsetWidth);
+    const btn = triggerRef.current;
+    const dd = menuRef.current;
+    if (btn && dd) {
+      const btnRect = btn.getBoundingClientRect();
+      const ddRect = dd.getBoundingClientRect();
+      setNotchX(btnRect.left - ddRect.left);
+    }
+  }, [open, items.length]);
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       switch (e.key) {
@@ -169,6 +194,8 @@ export function DropdownMenu({
   return (
     <div ref={containerRef} className={cn("relative inline-block", className)}>
       <div
+        ref={triggerRef}
+        className="relative z-[51]"
         onClick={() => {
           if (open) {
             closeMenu();
@@ -188,59 +215,81 @@ export function DropdownMenu({
           tabIndex={-1}
           onKeyDown={handleKeyDown}
           className={cn(
-            "absolute z-50 mt-1 min-w-[180px] rounded-xl bg-surface-container py-1 shadow-md outline-none",
+            "absolute z-50 overflow-visible outline-none",
             align === "end" ? "right-0" : "left-0",
           )}
+          style={{ top: 4, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
         >
-          {items.map((entry, index) => {
-            if (isSeparator(entry)) {
+          {contentH > 0 && menuW > 0 && (
+            <Notch
+              width={menuW}
+              height={contentH}
+              notchWidth={DD_NOTCH_W}
+              notchHeight={DD_NOTCH_H}
+              notchSide="bottom"
+              notchOffset={align === "end" ? -notchX : notchX}
+              radius={DD_R}
+              inverseRadius={DD_IR}
+              stroke="var(--color-primary)"
+              strokeWidth={1.5}
+              className="absolute top-0 left-0"
+            />
+          )}
+          <div
+            ref={contentRef}
+            className="relative z-10 min-w-[180px] py-1.5 px-1"
+            style={{ marginTop: DD_NOTCH_H }}
+          >
+            {items.map((entry, index) => {
+              if (isSeparator(entry)) {
+                return (
+                  <div
+                    key={`sep-${index}`}
+                    role="separator"
+                    className="my-1 h-px bg-outline-variant mx-1.5"
+                  />
+                );
+              }
+
+              const item = entry;
+              const isActive = index === activeIndex;
+              const isDanger = item.variant === "danger";
+
               return (
                 <div
-                  key={`sep-${index}`}
-                  role="separator"
-                  className="my-1 h-px bg-outline-variant"
-                />
+                  key={item.id}
+                  role="menuitem"
+                  aria-disabled={item.disabled || undefined}
+                  className={cn(
+                    "flex cursor-pointer items-center gap-3 px-3 py-2 text-sm transition-colors rounded-md",
+                    item.disabled && "pointer-events-none opacity-38",
+                    isDanger ? "text-error" : "text-on-surface",
+                    isActive &&
+                      (isDanger
+                        ? "bg-error/8"
+                        : "bg-on-surface/8"),
+                  )}
+                  onClick={() => {
+                    if (item.disabled) return;
+                    onSelect(item);
+                    closeMenu();
+                  }}
+                  onMouseEnter={() => {
+                    if (!item.disabled) setActiveIndex(index);
+                  }}
+                >
+                  {item.icon && (
+                    <Icon
+                      name={item.icon}
+                      size={20}
+                      className={isDanger ? "text-error" : "text-on-surface-variant"}
+                    />
+                  )}
+                  {item.label}
+                </div>
               );
-            }
-
-            const item = entry;
-            const isActive = index === activeIndex;
-            const isDanger = item.variant === "danger";
-
-            return (
-              <div
-                key={item.id}
-                role="menuitem"
-                aria-disabled={item.disabled || undefined}
-                className={cn(
-                  "flex cursor-pointer items-center gap-3 px-3 py-2 text-sm transition-colors",
-                  item.disabled && "pointer-events-none opacity-38",
-                  isDanger ? "text-error" : "text-on-surface",
-                  isActive &&
-                    (isDanger
-                      ? "bg-error/8"
-                      : "bg-on-surface/8"),
-                )}
-                onClick={() => {
-                  if (item.disabled) return;
-                  onSelect(item);
-                  closeMenu();
-                }}
-                onMouseEnter={() => {
-                  if (!item.disabled) setActiveIndex(index);
-                }}
-              >
-                {item.icon && (
-                  <Icon
-                    name={item.icon}
-                    size={20}
-                    className={isDanger ? "text-error" : "text-on-surface-variant"}
-                  />
-                )}
-                {item.label}
-              </div>
-            );
-          })}
+            })}
+          </div>
         </div>
       )}
     </div>

--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
@@ -12,10 +12,10 @@ import type { ComponentMeta } from "@/types/component-meta";
 import { Icon } from "@/components/ui/media/icon/Icon";
 import { Notch } from "@/components/ui/surfaces/notch/Notch";
 
-const DD_NOTCH_W = 32;
+const DD_NOTCH_W = 40;
 const DD_NOTCH_H = 24;
-const DD_R = 8;
-const DD_IR = 8;
+const DD_R = 12;
+const DD_IR = 10;
 
 export const meta: ComponentMeta = {
   name: "DropdownMenu",

--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
@@ -12,7 +12,7 @@ import type { ComponentMeta } from "@/types/component-meta";
 import { Icon } from "@/components/ui/media/icon/Icon";
 import { Notch } from "@/components/ui/surfaces/notch/Notch";
 
-const DD_NOTCH_W = 40;
+const DD_NOTCH_W = 48;
 const DD_NOTCH_H = 40;
 const DD_R = 12;
 const DD_IR = 10;
@@ -214,11 +214,12 @@ export function DropdownMenu({
           role="menu"
           tabIndex={-1}
           onKeyDown={handleKeyDown}
-          className={cn(
-            "absolute z-50 overflow-visible outline-none",
-            align === "end" ? "right-0" : "left-0",
-          )}
-          style={{ top: 4, filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))" }}
+          className="absolute z-50 overflow-visible outline-none"
+          style={{
+            top: -4,
+            [align === "end" ? "right" : "left"]: -4,
+            filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))",
+          }}
         >
           {contentH > 0 && menuW > 0 && (
             <Notch

--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
@@ -12,8 +12,8 @@ import type { ComponentMeta } from "@/types/component-meta";
 import { Icon } from "@/components/ui/media/icon/Icon";
 import { Notch } from "@/components/ui/surfaces/notch/Notch";
 
-const DD_NOTCH_W = 48;
-const DD_NOTCH_H = 40;
+const DD_NOTCH_W = 52;
+const DD_NOTCH_H = 46;
 const DD_R = 12;
 const DD_IR = 10;
 
@@ -41,7 +41,8 @@ export interface DropdownMenuProps {
   items: DropdownMenuEntry[];
   onSelect: (item: DropdownMenuItem) => void;
   trigger: ReactNode;
-  align?: "start" | "end";
+  /** Horizontal offset from trigger. Positive = from start (left), negative = from end (right) */
+  offset?: number;
   className?: string;
 }
 
@@ -57,9 +58,10 @@ export function DropdownMenu({
   items,
   onSelect,
   trigger,
-  align = "start",
+  offset = 0,
   className,
 }: DropdownMenuProps) {
+  const fromEnd = offset < 0;
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -217,7 +219,7 @@ export function DropdownMenu({
           className="absolute z-50 overflow-visible outline-none"
           style={{
             top: -4,
-            [align === "end" ? "right" : "left"]: -4,
+            [fromEnd ? "right" : "left"]: Math.abs(offset) - 4,
             filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))",
           }}
         >
@@ -228,7 +230,7 @@ export function DropdownMenu({
               notchWidth={DD_NOTCH_W}
               notchHeight={DD_NOTCH_H}
               notchSide="bottom"
-              notchOffset={align === "end" ? -notchX : notchX}
+              notchOffset={fromEnd ? -notchX : notchX}
               radius={DD_R}
               inverseRadius={DD_IR}
               stroke="var(--color-primary)"

--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
@@ -65,10 +65,12 @@ export function DropdownMenu({
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLDivElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const [contentH, setContentH] = useState(0);
   const [menuW, setMenuW] = useState(0);
+  const [notchX, setNotchX] = useState(0);
   const menuId = useId();
 
   const actionableIndices = items
@@ -131,6 +133,13 @@ export function DropdownMenu({
     if (!open || !contentRef.current) return;
     setContentH(contentRef.current.offsetHeight);
     setMenuW(contentRef.current.offsetWidth);
+    const btn = triggerRef.current;
+    const dd = menuRef.current;
+    if (btn && dd) {
+      const btnRect = btn.getBoundingClientRect();
+      const ddRect = dd.getBoundingClientRect();
+      setNotchX(btnRect.left - ddRect.left);
+    }
   }, [open, items.length]);
 
   const handleKeyDown = useCallback(
@@ -187,6 +196,7 @@ export function DropdownMenu({
   return (
     <div ref={containerRef} className={cn("relative inline-block", className)}>
       <div
+        ref={triggerRef}
         className="relative z-[51]"
         onClick={() => {
           if (open) {
@@ -208,8 +218,8 @@ export function DropdownMenu({
           onKeyDown={handleKeyDown}
           className="absolute z-50 overflow-visible outline-none"
           style={{
-            top: -4,
-            [fromEnd ? "right" : "left"]: -4,
+            top: -7,
+            [fromEnd ? "right" : "left"]: -7,
             filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))",
           }}
         >
@@ -220,7 +230,7 @@ export function DropdownMenu({
               notchWidth={DD_NOTCH_W}
               notchHeight={DD_NOTCH_H}
               notchSide="bottom"
-              notchOffset={offset}
+              notchOffset={notchX}
               radius={DD_R}
               inverseRadius={DD_IR}
               stroke="var(--color-primary)"

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,13 @@ export {
   type AppLink,
 } from "./components/ui/navigation/app-switcher/AppSwitcher";
 export {
+  DropdownMenu,
+  type DropdownMenuProps,
+  type DropdownMenuItem,
+  type DropdownMenuEntry,
+  type DropdownMenuSeparator,
+} from "./components/ui/navigation/dropdown-menu/DropdownMenu";
+export {
   Notch,
   type NotchProps,
   type NotchSide,


### PR DESCRIPTION
## Summary
- Add `DropdownMenu` component with full keyboard navigation (ArrowUp/Down, Home/End, Enter/Space, Escape, Tab)
- Supports icon items, danger variant, disabled item skipping, separator entries, and outside-click dismissal
- Includes Storybook story with IconButton trigger and Vitest tests for core behaviors

Closes #20

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test -- --run` passes (262 tests, 30 files)
- [x] `pnpm components validate` passes (33 components)
- [ ] Visual review in Storybook (`pnpm storybook`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)