### PR TITLE
chore: add npm publish to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://npm.pkg.github.com
+
+      - run: pnpm install --frozen-lockfile
 
       - name: Get version from package.json
         id: version
@@ -44,3 +54,8 @@ jobs:
             --prerelease=${{ steps.pre.outputs.prerelease }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish to GitHub Packages
+        run: pnpm publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds npm publish step to the release workflow
- Publishes to GitHub Packages when a PR with `release` label is merged
- Triggers v0.1.2 release and first npm publish

## Test plan
- [ ] Merge this PR → release workflow creates v0.1.2 tag + GitHub Release + publishes to GitHub Packages
- [ ] Verify package visible at https://github.com/mirrorstack-ai/web-ui-kit/packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)