### PR TITLE
fix: type-safe SocialProvider and remove redundant webkit prefixes

### DIFF
--- a/src/components/ui/actions/social-button/SocialButton.test.tsx
+++ b/src/components/ui/actions/social-button/SocialButton.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, afterEach } from "vitest";
-import { SocialButton, SocialIcon } from "./SocialButton";
+import { SocialButton, SocialIcon, type SocialProvider } from "./SocialButton";
 
 afterEach(cleanup);
 
@@ -41,7 +41,7 @@ describe("SocialIcon", () => {
   });
 
   it("returns null for unknown provider", () => {
-    const { container } = render(<SocialIcon provider="unknown" />);
+    const { container } = render(<SocialIcon provider={"unknown" as SocialProvider} />);
     expect(container.querySelector("svg")).not.toBeInTheDocument();
   });
 });

--- a/src/components/ui/actions/social-button/SocialButton.tsx
+++ b/src/components/ui/actions/social-button/SocialButton.tsx
@@ -9,17 +9,17 @@ export const meta: ComponentMeta = {
     "Social-login button with built-in brand icon for Google, Discord, OpenID, or LINE",
 };
 
-const providerIcons: Record<string, typeof GoogleIcon> = {
+export type SocialProvider = "google" | "discord" | "openid" | "line";
+
+const providerIcons: Record<SocialProvider, typeof GoogleIcon> = {
   google: GoogleIcon,
   discord: DiscordIcon,
   openid: OpenIdIcon,
   line: LineIcon,
 };
 
-export type SocialProvider = keyof typeof providerIcons;
-
 export interface SocialIconProps {
-  provider: string;
+  provider: SocialProvider;
   size?: number;
   className?: string;
 }

--- a/src/components/ui/media/logo-mirrorstack/LogoMirrorStack.tsx
+++ b/src/components/ui/media/logo-mirrorstack/LogoMirrorStack.tsx
@@ -13,13 +13,9 @@ export interface LogoProps {
 
 const maskStyle: React.CSSProperties = {
   maskImage: `url(${logoDataUrl})`,
-  WebkitMaskImage: `url(${logoDataUrl})`,
   maskSize: "contain",
-  WebkitMaskSize: "contain",
   maskRepeat: "no-repeat",
-  WebkitMaskRepeat: "no-repeat",
   maskPosition: "center",
-  WebkitMaskPosition: "center",
 };
 
 export function Logo({ className }: LogoProps) {


### PR DESCRIPTION
## Summary
- `SocialProvider` is now `"google" | "discord" | "openid" | "line"` instead of erased `string`
- Remove redundant `-webkit-` mask prefixes in LogoMirrorStack (unprefixed works in all supported browsers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)