### PR TITLE
feat: add navClassName to AppShell

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -27,6 +27,8 @@ export interface AppShellProps {
   appSwitcherClassName?: string;
   /** Class for the content area */
   contentClassName?: string;
+  /** Class for the navigation wrapper (override responsive visibility) */
+  navClassName?: string;
   /** Agent sidebar chat content */
   agentSidebarContent?: ReactNode;
   onAgentSend?: (message: string) => void;
@@ -49,6 +51,7 @@ function AppShellInner({
   className,
   appSwitcherClassName = "max-w-7xl",
   contentClassName,
+  navClassName,
   agentSidebarContent,
   onAgentSend,
   onAgentAttachFile,
@@ -145,7 +148,7 @@ function AppShellInner({
 
           <div className="h-full flex">
             {navigation && (
-              <div className="hidden lg:flex h-full shrink-0 items-center [&>*]:h-auto">
+              <div className={cn("hidden lg:flex h-full shrink-0 items-center [&>*]:h-auto", navClassName)}>
                 {navigation}
               </div>
             )}


### PR DESCRIPTION
## Summary
- Adds `navClassName` prop to AppShell for overriding navigation wrapper classes
- Use case: `navClassName="flex!"` to always show nav, or `navClassName="hidden md:flex"` for earlier breakpoint
- Bumps to v0.1.5

## Usage
```tsx
<AppShell navClassName="hidden md:flex" navigation={<NavDrawer ... />}>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)