### PR TITLE
feat: ReauthDialog passkey setup recommendation variant

### DIFF
--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.stories.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.stories.tsx
@@ -89,3 +89,33 @@ export const PasskeyOnly: Story = {
     );
   },
 };
+
+export const PasskeySetupRecommendation: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Sensitive Action</Button>
+        <ReauthDialog
+          open={open}
+          onClose={() => setOpen(false)}
+          onSuccess={() => setOpen(false)}
+          methods={["email"]}
+          onEmailSendCode={async () => {
+            await new Promise((r) => setTimeout(r, 500));
+            return "challenge-789";
+          }}
+          onEmailVerifyCode={async (_id, code) => {
+            await new Promise((r) => setTimeout(r, 500));
+            if (code === "123456") return "token";
+            throw new Error("Invalid code");
+          }}
+          onPasskeySetup={() => {
+            console.log("navigate to /me/security");
+            setOpen(false);
+          }}
+        />
+      </>
+    );
+  },
+};

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.test.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.test.tsx
@@ -68,7 +68,7 @@ describe("ReauthDialog", () => {
         onPasskeySetup={onPasskeySetup}
       />,
     );
-    const cta = screen.getByText("Set up passkey");
+    const cta = screen.getByText("Set up a passkey for faster verification next time");
     expect(cta).toBeInTheDocument();
     fireEvent.click(cta);
     expect(onPasskeySetup).toHaveBeenCalledTimes(1);
@@ -83,11 +83,15 @@ describe("ReauthDialog", () => {
       />,
     );
     fireEvent.click(screen.getByText("Use email verification instead"));
-    expect(screen.queryByText("Set up passkey")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Set up a passkey for faster verification next time"),
+    ).not.toBeInTheDocument();
   });
 
   it("does not show passkey setup recommendation when callback omitted", () => {
     render(<ReauthDialog {...defaultProps} methods={["email"]} />);
-    expect(screen.queryByText("Set up passkey")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Set up a passkey for faster verification next time"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.test.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.test.tsx
@@ -68,10 +68,26 @@ describe("ReauthDialog", () => {
         onPasskeySetup={onPasskeySetup}
       />,
     );
-    const cta = screen.getByText("Set up a passkey for faster verification next time");
-    expect(cta).toBeInTheDocument();
-    fireEvent.click(cta);
+    const link = screen.getByRole("button", { name: "Set up a passkey" });
+    expect(link).toBeInTheDocument();
+    expect(screen.getByText(/for faster verification next time/)).toBeInTheDocument();
+    fireEvent.click(link);
     expect(onPasskeySetup).toHaveBeenCalledTimes(1);
+  });
+
+  it("only the 'Set up a passkey' phrase is interactive in the setup banner", () => {
+    const onPasskeySetup = vi.fn();
+    render(
+      <ReauthDialog
+        {...defaultProps}
+        methods={["email"]}
+        onPasskeySetup={onPasskeySetup}
+      />,
+    );
+    const trailingText = screen.getByText(/for faster verification next time/);
+    fireEvent.click(trailingText);
+    expect(onPasskeySetup).not.toHaveBeenCalled();
+    expect(trailingText.closest("button")).toBeNull();
   });
 
   it("does not show passkey setup recommendation when methods includes passkey", () => {
@@ -84,14 +100,14 @@ describe("ReauthDialog", () => {
     );
     fireEvent.click(screen.getByText("Use email verification instead"));
     expect(
-      screen.queryByText("Set up a passkey for faster verification next time"),
+      screen.queryByRole("button", { name: "Set up a passkey" }),
     ).not.toBeInTheDocument();
   });
 
   it("does not show passkey setup recommendation when callback omitted", () => {
     render(<ReauthDialog {...defaultProps} methods={["email"]} />);
     expect(
-      screen.queryByText("Set up a passkey for faster verification next time"),
+      screen.queryByRole("button", { name: "Set up a passkey" }),
     ).not.toBeInTheDocument();
   });
 });

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.test.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.test.tsx
@@ -58,4 +58,36 @@ describe("ReauthDialog", () => {
       expect(screen.getByLabelText("Digit 1")).toBeInTheDocument();
     });
   });
+
+  it("shows passkey setup recommendation in email-only flow when callback provided", () => {
+    const onPasskeySetup = vi.fn();
+    render(
+      <ReauthDialog
+        {...defaultProps}
+        methods={["email"]}
+        onPasskeySetup={onPasskeySetup}
+      />,
+    );
+    const cta = screen.getByText("Set up passkey");
+    expect(cta).toBeInTheDocument();
+    fireEvent.click(cta);
+    expect(onPasskeySetup).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show passkey setup recommendation when methods includes passkey", () => {
+    render(
+      <ReauthDialog
+        {...defaultProps}
+        methods={["passkey", "email"]}
+        onPasskeySetup={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByText("Use email verification instead"));
+    expect(screen.queryByText("Set up passkey")).not.toBeInTheDocument();
+  });
+
+  it("does not show passkey setup recommendation when callback omitted", () => {
+    render(<ReauthDialog {...defaultProps} methods={["email"]} />);
+    expect(screen.queryByText("Set up passkey")).not.toBeInTheDocument();
+  });
 });

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -248,17 +248,26 @@ export function ReauthDialog({
       )}
 
       {showingEmail && showPasskeySetup && (
-        <button
-          type="button"
-          onClick={onPasskeySetup}
-          className={cn(
-            "mt-4 inline-flex items-center gap-2 text-sm text-primary underline underline-offset-2",
-            "hover:text-primary/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
-          )}
-        >
-          <Icon name="passkey" size={16} className="text-primary shrink-0" />
-          <span>Set up a passkey for faster verification next time</span>
-        </button>
+        <div className="mt-4 inline-flex items-center gap-2 text-sm text-on-surface-variant">
+          <Icon
+            name="passkey"
+            size={16}
+            className="text-on-surface-variant shrink-0 self-center"
+          />
+          <span>
+            <button
+              type="button"
+              onClick={onPasskeySetup}
+              className={cn(
+                "text-primary underline underline-offset-2",
+                "hover:text-primary/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+              )}
+            >
+              Set up a passkey
+            </button>
+            {" for faster verification next time"}
+          </span>
+        </div>
       )}
 
     </Dialog>

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -30,6 +30,8 @@ export interface ReauthDialogProps {
   onEmailVerifyCode?: (challengeId: string, code: string) => Promise<string>;
   /** Run WebAuthn ceremony, returns reauth token. */
   onPasskeyVerify?: () => Promise<string>;
+  /** Optional. When provided and the user has no passkey, surfaces a setup recommendation in the email flow. */
+  onPasskeySetup?: () => void;
   className?: string;
 }
 
@@ -43,10 +45,12 @@ export function ReauthDialog({
   onEmailSendCode,
   onEmailVerifyCode,
   onPasskeyVerify,
+  onPasskeySetup,
   className,
 }: ReauthDialogProps) {
   const hasPasskey = methods.includes("passkey");
   const hasEmail = methods.includes("email");
+  const showPasskeySetup = !hasPasskey && !!onPasskeySetup;
 
   const [code, setCode] = useState("");
   const [challengeId, setChallengeId] = useState<string | null>(null);
@@ -240,6 +244,24 @@ export function ReauthDialog({
               Use passkey instead
             </button>
           )}
+        </div>
+      )}
+
+      {showingEmail && showPasskeySetup && (
+        <div className="mt-4 flex items-start gap-3 rounded-md border border-outline-variant bg-surface-variant/40 p-3">
+          <Icon name="passkey" size={20} className="text-primary mt-0.5 shrink-0" />
+          <div>
+            <p className="text-sm text-on-surface">
+              Set up a passkey for faster verification next time
+            </p>
+            <button
+              type="button"
+              onClick={onPasskeySetup}
+              className={cn(linkCls, "mt-1")}
+            >
+              Set up passkey
+            </button>
+          </div>
         </div>
       )}
 

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -248,21 +248,19 @@ export function ReauthDialog({
       )}
 
       {showingEmail && showPasskeySetup && (
-        <div className="mt-4 flex items-start gap-3 rounded-md border border-outline-variant bg-surface-variant/40 p-3">
-          <Icon name="passkey" size={20} className="text-primary mt-0.5 shrink-0" />
-          <div>
-            <p className="text-sm text-on-surface">
-              Set up a passkey for faster verification next time
-            </p>
-            <button
-              type="button"
-              onClick={onPasskeySetup}
-              className={cn(linkCls, "mt-1")}
-            >
-              Set up passkey
-            </button>
-          </div>
-        </div>
+        <button
+          type="button"
+          onClick={onPasskeySetup}
+          className={cn(
+            "mt-4 flex w-full items-center gap-3 rounded-md border border-outline-variant bg-surface-variant/40 p-3 text-left",
+            "hover:bg-surface-variant/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+          )}
+        >
+          <Icon name="passkey" size={20} className="text-primary shrink-0" />
+          <span className="text-sm text-on-surface">
+            Set up a passkey for faster verification next time
+          </span>
+        </button>
       )}
 
     </Dialog>

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -252,14 +252,12 @@ export function ReauthDialog({
           type="button"
           onClick={onPasskeySetup}
           className={cn(
-            "mt-4 flex w-full items-center gap-3 rounded-md border border-outline-variant bg-surface-variant/40 p-3 text-left",
-            "hover:bg-surface-variant/60 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+            "mt-4 inline-flex items-center gap-2 text-sm text-primary underline underline-offset-2",
+            "hover:text-primary/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
           )}
         >
-          <Icon name="passkey" size={20} className="text-primary shrink-0" />
-          <span className="text-sm text-on-surface">
-            Set up a passkey for faster verification next time
-          </span>
+          <Icon name="passkey" size={16} className="text-primary shrink-0" />
+          <span>Set up a passkey for faster verification next time</span>
         </button>
       )}
 


### PR DESCRIPTION
## Summary
- Adds optional `onPasskeySetup` prop to `ReauthDialog`. When provided AND `methods` does not include `"passkey"`, an inline recommendation banner renders inside the email flow inviting the user to set up a passkey for faster verification next time.
- The dialog hardcodes no URL — the consumer owns navigation when the CTA fires.
- New Storybook story `PasskeySetupRecommendation` and three new tests covering visibility branches.

Closes #122
Closes #125
Closes #126
Closes #127

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes for `ReauthDialog.test.tsx` (10/10)
- [x] `pnpm components validate` passes
- [ ] Visual check in Storybook: `PasskeySetupRecommendation` shows the banner; `EmailOnly` does not (no callback); `Playground` does not (passkey already in methods)

🤖 Generated with [Claude Code](https://claude.com/claude-code)