### PR TITLE
fix: reduce AppShell content padding to pt-8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -158,7 +158,7 @@ function AppShellInner({
                 <div
                   className={cn(
                     "mx-auto w-full px-6 pb-8",
-                    appSwitcher ? "pt-20" : "pt-6",
+                    appSwitcher ? "pt-8" : "pt-6",
                     contentClassName,
                   )}
                 >


### PR DESCRIPTION
## Summary
- Reduces content top padding from `pt-20` to `pt-8` when appSwitcher is present
- Bumps to v0.1.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)