### PR TITLE
refactor: use Alert for ReauthDialog passkey setup banner

### DIFF
--- a/src/components/ui/feedback/alert/Alert.stories.tsx
+++ b/src/components/ui/feedback/alert/Alert.stories.tsx
@@ -49,3 +49,12 @@ export const Dismissible: Story = {
     onDismiss: () => {},
   },
 };
+
+export const WithCustomIcon: Story = {
+  args: {
+    variant: "info",
+    icon: "passkey",
+    iconSize: 28,
+    children: "Set up a passkey for faster verification next time.",
+  },
+};

--- a/src/components/ui/feedback/alert/Alert.test.tsx
+++ b/src/components/ui/feedback/alert/Alert.test.tsx
@@ -50,4 +50,28 @@ describe("Alert", () => {
     );
     expect(screen.getByRole("alert")).toHaveClass("mt-4");
   });
+
+  it("renders override icon when icon prop is provided", () => {
+    render(
+      <Alert variant="info" icon="passkey">
+        Set up a passkey
+      </Alert>,
+    );
+    expect(screen.getByText("passkey")).toBeInTheDocument();
+    expect(screen.queryByText("info")).not.toBeInTheDocument();
+  });
+
+  it("respects iconSize override", () => {
+    render(
+      <Alert variant="info" icon="passkey" iconSize={28}>
+        Big icon
+      </Alert>,
+    );
+    expect(screen.getByText("passkey")).toHaveStyle({ fontSize: "28px" });
+  });
+
+  it("uses default icon size of 20 when iconSize not provided", () => {
+    render(<Alert variant="info">Default size</Alert>);
+    expect(screen.getByText("info")).toHaveStyle({ fontSize: "20px" });
+  });
 });

--- a/src/components/ui/feedback/alert/Alert.tsx
+++ b/src/components/ui/feedback/alert/Alert.tsx
@@ -18,6 +18,10 @@ export interface AlertProps {
   children: ReactNode;
   className?: string;
   onDismiss?: () => void;
+  /** Override the default icon for this variant. */
+  icon?: string;
+  /** Override the default icon size (default: 20). */
+  iconSize?: number;
 }
 
 const variantStyles: Record<AlertVariant, string> = {
@@ -40,6 +44,8 @@ export function Alert({
   children,
   className,
   onDismiss,
+  icon,
+  iconSize,
 }: AlertProps) {
   return (
     <div
@@ -52,8 +58,8 @@ export function Alert({
     >
       <div className="flex items-center">
         <Icon
-          name={variantIcons[variant]}
-          size={20}
+          name={icon ?? variantIcons[variant]}
+          size={iconSize ?? 20}
           className="shrink-0"
         />
         <div className="ml-3 flex-1">

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -248,19 +248,16 @@ export function ReauthDialog({
       )}
 
       {showingEmail && showPasskeySetup && (
-        <div className="mt-4 flex items-center gap-3 rounded-md border border-outline-variant bg-surface-variant/40 p-3">
-          <Icon name="passkey" size={20} className="text-primary shrink-0" />
-          <p className="text-sm text-on-surface">
-            <button
-              type="button"
-              onClick={onPasskeySetup}
-              className="text-primary underline underline-offset-2 hover:text-primary/80"
-            >
-              Set up a passkey
-            </button>
-            {" for faster verification next time"}
-          </p>
-        </div>
+        <Alert variant="info" icon="passkey" iconSize={28} className="mt-4">
+          <button
+            type="button"
+            onClick={onPasskeySetup}
+            className="text-primary underline underline-offset-2 hover:text-primary/80"
+          >
+            Set up a passkey
+          </button>
+          {" for faster verification next time"}
+        </Alert>
       )}
 
     </Dialog>


### PR DESCRIPTION
## Summary
- Extends `Alert` with optional `icon` and `iconSize` props so the variant's default icon and size (20px) can be overridden without breaking existing callers.
- Refactors the ReauthDialog passkey setup banner to use `<Alert variant="info" icon="passkey" iconSize={28}>` instead of a hand-rolled bordered div + Icon + p block, dropping ~13 lines of duplicated styling.
- Adds an `Alert.WithCustomIcon` Storybook story plus three tests covering icon override, iconSize override, and the 20px default.

Closes #130

> Stacks on #129 — base branch is `feat/128-reauth-banner-polish` so the diff stays focused on this refactor.

## Test plan
- [x] `pnpm test` — 272/272 passing
- [x] `pnpm typecheck` — clean
- [x] `pnpm components validate` — all 34 components valid
- [ ] Eyeball Storybook: `Alert > WithCustomIcon` shows passkey glyph at 28px
- [ ] Eyeball Storybook: `ReauthDialog` email-only flow with `onPasskeySetup` set — banner now renders inside the info-variant Alert with a visibly larger icon (~1.4x body text)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>