### PR TITLE
feat: SnackbarProvider + useSnackbar with AppShell-integrated outlet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/app-shell/AppShell.stories.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.stories.tsx
@@ -7,6 +7,8 @@ import { AppSwitcher } from "@/components/ui/navigation/app-switcher/AppSwitcher
 import { Logo } from "@/components/ui/media/logo-mirrorstack/LogoMirrorStack";
 import { NavDrawer, type NavDrawerItem } from "@/components/ui/navigation/nav-drawer/NavDrawer";
 import { Avatar } from "@/components/ui/media/avatar/Avatar";
+import { Button } from "@/components/ui/actions/button/Button";
+import { useSnackbar } from "@/context/snackbar/SnackbarProvider";
 
 const meta: Meta<typeof AppShell> = {
   title: "Layout/AppShell",
@@ -171,6 +173,92 @@ export const WithNavDrawer: Story = {
         onAgentSend={(msg) => console.log("Send:", msg)}
       >
         <DemoContent />
+      </AppShell>
+    );
+  },
+};
+
+function SnackbarDemoContent() {
+  const { showSnackbar } = useSnackbar();
+  return (
+    <div className="max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold text-on-surface mb-4">Dashboard</h1>
+      <p className="text-on-surface-variant mb-6">
+        The snackbar outlet centers over the content area, not the full viewport. Click the button to see it.
+      </p>
+      <div className="flex gap-3">
+        <Button
+          onClick={() =>
+            showSnackbar({ message: "Saved", variant: "success" })
+          }
+        >
+          Show Snackbar
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() =>
+            showSnackbar({
+              message: "Failed to save",
+              variant: "error",
+              action: { label: "Retry", onClick: () => {} },
+            })
+          }
+        >
+          Show with Action
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export const WithSnackbar: Story = {
+  render: () => {
+    const [selected, setSelected] = useState("apps");
+    return (
+      <AppShell
+        navigation={
+          <NavigationRail
+            logo={
+              <NavigationButton
+                customIcon={
+                  <div className="w-full h-full bg-primary/20 flex items-center justify-center">
+                    <span className="text-primary font-semibold text-lg">M</span>
+                  </div>
+                }
+                label="My App"
+                variant="secondary"
+                disableHoverExpand
+                className="border border-primary"
+              />
+            }
+          >
+            <div className="w-full gap-2 flex flex-col">
+              <NavigationButton
+                icon="space_dashboard"
+                label="Dashboard"
+                variant="primary"
+                selected={selected === "dashboard"}
+                onClick={() => setSelected("dashboard")}
+              />
+              <NavigationButton
+                icon="data_table"
+                label="Your Apps"
+                selected={selected === "apps"}
+                onClick={() => setSelected("apps")}
+              />
+            </div>
+          </NavigationRail>
+        }
+        appSwitcher={
+          <AppSwitcher
+            currentApp="Account"
+            logo={<div className="w-8 h-8"><Logo /></div>}
+            apps={apps}
+            activeAppId="account"
+          />
+        }
+      >
+        <SnackbarDemoContent />
       </AppShell>
     );
   },

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/utils/cn";
 import type { ComponentMeta } from "@/types/component-meta";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 import { SidebarProvider, useSidebarWidth } from "@/context/sidebar/SidebarProvider";
+import { SnackbarProvider, SnackbarOutlet } from "@/context/snackbar/SnackbarProvider";
 import { AgentSidebarHeader } from "@/components/ui/surfaces/agent-sidebar/AgentSidebarHeader";
 import { AgentSidebarInput } from "@/components/ui/surfaces/agent-sidebar/AgentSidebarInput";
 
@@ -39,7 +40,9 @@ export interface AppShellProps {
 export function AppShell(props: AppShellProps) {
   return (
     <SidebarProvider defaultWidth={0}>
-      <AppShellInner {...props} />
+      <SnackbarProvider>
+        <AppShellInner {...props} />
+      </SnackbarProvider>
     </SidebarProvider>
   );
 }
@@ -164,6 +167,7 @@ function AppShellInner({
                 >
                   {children}
                 </div>
+                <SnackbarOutlet />
               </main>
             </div>
           </div>

--- a/src/context/snackbar/SnackbarProvider.test.tsx
+++ b/src/context/snackbar/SnackbarProvider.test.tsx
@@ -1,0 +1,211 @@
+import { useState } from "react";
+import { cleanup, render, screen, fireEvent, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import {
+  SnackbarOutlet,
+  SnackbarProvider,
+  useSnackbar,
+  useUnsavedSnackbar,
+} from "./SnackbarProvider";
+import { SNACKBAR_EXIT_MS } from "@/components/ui/feedback/snackbar/Snackbar";
+
+afterEach(cleanup);
+
+describe("SnackbarProvider", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("throws when useSnackbar is used outside provider", () => {
+    function Consumer() {
+      useSnackbar();
+      return null;
+    }
+    expect(() => render(<Consumer />)).toThrow(
+      "useSnackbar must be used within a SnackbarProvider",
+    );
+  });
+
+  it("shows a snackbar message via showSnackbar", () => {
+    function Trigger() {
+      const { showSnackbar } = useSnackbar();
+      return (
+        <button onClick={() => showSnackbar({ message: "Saved" })}>
+          show
+        </button>
+      );
+    }
+    render(
+      <SnackbarProvider>
+        <Trigger />
+      </SnackbarProvider>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText("show"));
+    });
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+  });
+
+  it("dismisses the snackbar after exit timer", () => {
+    function Trigger() {
+      const { showSnackbar, dismissSnackbar } = useSnackbar();
+      return (
+        <>
+          <button onClick={() => showSnackbar({ message: "Saved" })}>show</button>
+          <button onClick={() => dismissSnackbar()}>dismiss</button>
+        </>
+      );
+    }
+    render(
+      <SnackbarProvider>
+        <Trigger />
+      </SnackbarProvider>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText("show"));
+    });
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByText("dismiss"));
+    });
+    act(() => {
+      vi.advanceTimersByTime(SNACKBAR_EXIT_MS + 50);
+    });
+    expect(screen.queryByText("Saved")).not.toBeInTheDocument();
+  });
+
+  it("patches in-flight options via updateSnackbar", () => {
+    function Trigger() {
+      const { showSnackbar, updateSnackbar } = useSnackbar();
+      return (
+        <>
+          <button
+            onClick={() =>
+              showSnackbar({
+                message: "Saving",
+                loading: true,
+                action: { label: "Save", onClick: () => {} },
+              })
+            }
+          >
+            show
+          </button>
+          <button onClick={() => updateSnackbar({ loading: false })}>
+            patch
+          </button>
+        </>
+      );
+    }
+    const { container } = render(
+      <SnackbarProvider>
+        <Trigger />
+      </SnackbarProvider>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText("show"));
+    });
+    expect(container.querySelector("[role='status']")).toHaveAttribute(
+      "aria-busy",
+      "true",
+    );
+    act(() => {
+      fireEvent.click(screen.getByText("patch"));
+    });
+    expect(container.querySelector("[role='status']")).toHaveAttribute(
+      "aria-busy",
+      "false",
+    );
+  });
+
+  it("suppresses the provider's fallback render when an outlet is mounted", () => {
+    function Trigger() {
+      const { showSnackbar } = useSnackbar();
+      return (
+        <button onClick={() => showSnackbar({ message: "Saved" })}>show</button>
+      );
+    }
+    const { container } = render(
+      <SnackbarProvider>
+        <Trigger />
+        <SnackbarOutlet />
+      </SnackbarProvider>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText("show"));
+    });
+    const matches = container.querySelectorAll("[role='status']");
+    expect(matches.length).toBe(1);
+    expect(matches[0].getAttribute("class")).toContain("absolute");
+  });
+});
+
+describe("useUnsavedSnackbar", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function UnsavedHarness({
+    onSave,
+    onReset,
+  }: {
+    onSave: () => void;
+    onReset: () => void;
+  }) {
+    const [value, setValue] = useState("a");
+    useUnsavedSnackbar({
+      snapshot: value,
+      onSave: () => {
+        onSave();
+        setValue("a");
+      },
+      onReset: () => {
+        onReset();
+        setValue("a");
+      },
+    });
+    return (
+      <button onClick={() => setValue("b")}>change</button>
+    );
+  }
+
+  it("shows when snapshot differs and dismisses on save", () => {
+    const onSave = vi.fn();
+    const onReset = vi.fn();
+    const { container } = render(
+      <SnackbarProvider>
+        <UnsavedHarness onSave={onSave} onReset={onReset} />
+      </SnackbarProvider>,
+    );
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByText("change"));
+    });
+    expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
+
+    const saveBtn = Array.from(
+      container.querySelectorAll("button"),
+    ).find((b) => b.textContent === "Save") as HTMLButtonElement;
+    expect(saveBtn).toBeInTheDocument();
+    act(() => {
+      fireEvent.click(saveBtn);
+    });
+    expect(onSave).toHaveBeenCalledOnce();
+
+    act(() => {
+      vi.advanceTimersByTime(SNACKBAR_EXIT_MS + 100);
+    });
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+  });
+});

--- a/src/context/snackbar/SnackbarProvider.tsx
+++ b/src/context/snackbar/SnackbarProvider.tsx
@@ -1,0 +1,222 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import {
+  Snackbar,
+  SNACKBAR_EXIT_MS,
+  type SnackbarAction,
+  type SnackbarVariant,
+} from "@/components/ui/feedback/snackbar/Snackbar";
+
+export interface SnackbarOptions {
+  message: string;
+  variant?: SnackbarVariant;
+  action?: SnackbarAction;
+  secondaryAction?: SnackbarAction;
+  loading?: boolean;
+  duration?: number;
+}
+
+interface SnackbarContextType {
+  showSnackbar: (options: SnackbarOptions) => void;
+  updateSnackbar: (options: Partial<SnackbarOptions>) => void;
+  dismissSnackbar: () => void;
+  /** Internal — used by SnackbarOutlet */
+  _internal: {
+    current: SnackbarOptions | null;
+    open: boolean;
+    registerOutlet: () => () => void;
+  };
+}
+
+const SnackbarContext = createContext<SnackbarContextType | undefined>(undefined);
+
+export interface SnackbarProviderProps {
+  children: ReactNode;
+}
+
+export function SnackbarProvider({ children }: SnackbarProviderProps) {
+  const [current, setCurrent] = useState<SnackbarOptions | null>(null);
+  const [open, setOpen] = useState(false);
+  const [outletCount, setOutletCount] = useState(0);
+  const cleanupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const dismissSnackbar = useCallback(() => {
+    setOpen(false);
+    cleanupTimerRef.current = setTimeout(() => {
+      setCurrent(null);
+      cleanupTimerRef.current = null;
+    }, SNACKBAR_EXIT_MS);
+  }, []);
+
+  const showSnackbar = useCallback((options: SnackbarOptions) => {
+    if (cleanupTimerRef.current) {
+      clearTimeout(cleanupTimerRef.current);
+      cleanupTimerRef.current = null;
+    }
+    setCurrent(options);
+    setOpen(true);
+  }, []);
+
+  const updateSnackbar = useCallback((partial: Partial<SnackbarOptions>) => {
+    setCurrent((prev) => (prev ? { ...prev, ...partial } : prev));
+  }, []);
+
+  const registerOutlet = useCallback(() => {
+    setOutletCount((c) => c + 1);
+    return () => setOutletCount((c) => c - 1);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (cleanupTimerRef.current) {
+        clearTimeout(cleanupTimerRef.current);
+      }
+    };
+  }, []);
+
+  const hasOutlet = outletCount > 0;
+
+  const contextValue = useMemo(
+    () => ({
+      showSnackbar,
+      updateSnackbar,
+      dismissSnackbar,
+      _internal: { current, open, registerOutlet },
+    }),
+    [showSnackbar, updateSnackbar, dismissSnackbar, current, open, registerOutlet],
+  );
+
+  return (
+    <SnackbarContext.Provider value={contextValue}>
+      {children}
+      {!hasOutlet && current && (
+        <Snackbar
+          message={current.message}
+          variant={current.variant}
+          action={current.action}
+          secondaryAction={current.secondaryAction}
+          loading={current.loading}
+          duration={current.duration}
+          onDismiss={dismissSnackbar}
+          open={open}
+        />
+      )}
+    </SnackbarContext.Provider>
+  );
+}
+
+export function useSnackbar() {
+  const context = useContext(SnackbarContext);
+  if (context === undefined) {
+    throw new Error("useSnackbar must be used within a SnackbarProvider");
+  }
+  return {
+    showSnackbar: context.showSnackbar,
+    updateSnackbar: context.updateSnackbar,
+    dismissSnackbar: context.dismissSnackbar,
+  };
+}
+
+export interface UseUnsavedSnackbarOptions {
+  snapshot: string;
+  message?: string;
+  onSave: () => void;
+  onReset: () => void;
+}
+
+export function useUnsavedSnackbar(options: UseUnsavedSnackbarOptions) {
+  const { showSnackbar, dismissSnackbar } = useSnackbar();
+  const savedRef = useRef(options.snapshot);
+  const isDirty = options.snapshot !== savedRef.current;
+  const prevDirty = useRef(false);
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      savedRef.current = options.snapshot;
+      isFirstRender.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isDirty && !prevDirty.current) {
+      showSnackbar({
+        message: options.message ?? "Unsaved changes",
+        variant: "unsave",
+        duration: 0,
+        action: {
+          label: "Save",
+          onClick: () => {
+            savedRef.current = options.snapshot;
+            prevDirty.current = false;
+            options.onSave();
+            dismissSnackbar();
+            setTimeout(() => {
+              showSnackbar({ message: "Saved", variant: "success" });
+            }, 50);
+          },
+        },
+        secondaryAction: {
+          label: "Reset",
+          onClick: () => {
+            prevDirty.current = false;
+            options.onReset();
+            dismissSnackbar();
+          },
+        },
+      });
+    } else if (!isDirty && prevDirty.current) {
+      dismissSnackbar();
+    }
+    prevDirty.current = isDirty;
+  }, [isDirty, options.snapshot]);
+
+  return { isDirty, savedRef };
+}
+
+export interface SnackbarOutletProps {
+  className?: string;
+}
+
+/**
+ * Place inside a content area to center the snackbar over that area.
+ * Pass a className to offset for sidebars (e.g. "lg:left-72").
+ */
+export function SnackbarOutlet({ className }: SnackbarOutletProps) {
+  const context = useContext(SnackbarContext);
+  const registerOutlet = context?._internal.registerOutlet;
+
+  useEffect(() => {
+    return registerOutlet?.();
+  }, [registerOutlet]);
+
+  if (!context) return null;
+
+  const { _internal, dismissSnackbar } = context;
+  const { current, open } = _internal;
+
+  if (!current && !open) return null;
+
+  return (
+    <Snackbar
+      message={current?.message ?? ""}
+      variant={current?.variant}
+      action={current?.action}
+      secondaryAction={current?.secondaryAction}
+      loading={current?.loading}
+      duration={current?.duration}
+      onDismiss={dismissSnackbar}
+      open={open}
+      inline
+      className={className}
+    />
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,16 @@ export {
   type SidebarContextType,
 } from "./context/sidebar/SidebarProvider";
 export {
+  SnackbarProvider,
+  SnackbarOutlet,
+  useSnackbar,
+  useUnsavedSnackbar,
+  type SnackbarProviderProps,
+  type SnackbarOptions,
+  type SnackbarOutletProps,
+  type UseUnsavedSnackbarOptions,
+} from "./context/snackbar/SnackbarProvider";
+export {
   ActivityList,
   type ActivityListProps,
   type ActivityItem,


### PR DESCRIPTION
## Summary

- Adds `SnackbarProvider` + `useSnackbar` hook with `showSnackbar` / `updateSnackbar` / `dismissSnackbar` API.
- Adds `useUnsavedSnackbar` hook for detecting dirty state with Save/Reset actions and a transient "Saved" success follow-up.
- Adds `SnackbarOutlet` and mounts it inside `AppShell`'s `<main>` element so the snackbar is centered over the content area, not the entire viewport (nav rail excluded).
- One snackbar at a time; new `showSnackbar` replaces the current; `dismissSnackbar` plays exit animation via `SNACKBAR_EXIT_MS`.
- Provider's fallback render is suppressed when an outlet is mounted (single instance).
- Exports added in `src/index.ts`.

Closes #132

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (278 tests, 6 new for SnackbarProvider)
- [x] `pnpm components validate` passes
- [ ] Open Storybook → `Layout/AppShell` → `WithSnackbar`: confirm snackbar centers over the content column with the nav rail visible
- [ ] Confirm `useUnsavedSnackbar` shows when snapshot changes; Save dismisses it then flashes "Saved"
- [ ] Confirm provider fallback renders only when no outlet is mounted

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>