### PR TITLE
fix: AppShell SnackbarOutlet pinning and restore pt-20 padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/app-shell/AppShell.stories.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.stories.tsx
@@ -264,6 +264,103 @@ export const WithSnackbar: Story = {
   },
 };
 
+function SnackbarScrollableDemoContent() {
+  const { showSnackbar } = useSnackbar();
+  return (
+    <div className="max-w-4xl mx-auto">
+      <h1 className="text-2xl font-bold text-on-surface mb-4">Long Page</h1>
+      <p className="text-on-surface-variant mb-6">
+        Scroll the content area down. The "Show snackbar" button at the top will
+        move out of view, but the snackbar must stay pinned to the bottom of the
+        visible content area.
+      </p>
+      <div className="mb-6">
+        <Button
+          onClick={() =>
+            showSnackbar({
+              message: "Snackbar stays pinned while content scrolls",
+              variant: "success",
+            })
+          }
+        >
+          Show snackbar
+        </Button>
+      </div>
+      <div className="flex flex-col gap-3">
+        {Array.from({ length: 30 }, (_, i) => (
+          <div
+            key={i}
+            className="h-24 rounded-xl bg-surface-container flex items-center justify-center text-on-surface-variant"
+          >
+            Card {i + 1}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export const SnackbarWithScrollableContent: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Demonstrates that the SnackbarOutlet stays pinned to the bottom of the visible content area while the inner content scrolls. Scroll the content — the snackbar must remain visible even after the trigger button leaves the viewport.",
+      },
+    },
+  },
+  render: () => {
+    const [selected, setSelected] = useState("apps");
+    return (
+      <AppShell
+        navigation={
+          <NavigationRail
+            logo={
+              <NavigationButton
+                customIcon={
+                  <div className="w-full h-full bg-primary/20 flex items-center justify-center">
+                    <span className="text-primary font-semibold text-lg">M</span>
+                  </div>
+                }
+                label="My App"
+                variant="secondary"
+                disableHoverExpand
+                className="border border-primary"
+              />
+            }
+          >
+            <div className="w-full gap-2 flex flex-col">
+              <NavigationButton
+                icon="space_dashboard"
+                label="Dashboard"
+                variant="primary"
+                selected={selected === "dashboard"}
+                onClick={() => setSelected("dashboard")}
+              />
+              <NavigationButton
+                icon="data_table"
+                label="Your Apps"
+                selected={selected === "apps"}
+                onClick={() => setSelected("apps")}
+              />
+            </div>
+          </NavigationRail>
+        }
+        appSwitcher={
+          <AppSwitcher
+            currentApp="Account"
+            logo={<div className="w-8 h-8"><Logo /></div>}
+            apps={apps}
+            activeAppId="account"
+          />
+        }
+      >
+        <SnackbarScrollableDemoContent />
+      </AppShell>
+    );
+  },
+};
+
 export const Playground: Story = {
   render: () => {
     const [selected, setSelected] = useState("apps");

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -161,14 +161,14 @@ function AppShellInner({
                 <div
                   className={cn(
                     "mx-auto w-full px-6 pb-8",
-                    appSwitcher ? "pt-8" : "pt-6",
+                    appSwitcher ? "pt-20" : "pt-6",
                     contentClassName,
                   )}
                 >
                   {children}
                 </div>
-                <SnackbarOutlet />
               </main>
+              <SnackbarOutlet />
             </div>
           </div>
         </div>


### PR DESCRIPTION
Closes #135

## Summary
- Move `<SnackbarOutlet />` out of the scrollable `<main>` and into its sibling parent (which is `relative` + `overflow-hidden`) so the outlet's `absolute bottom-4 inset-x-0` pins to the visible content bottom instead of floating in the middle of scrolled content.
- Restore `pt-20` content padding when `appSwitcher` is provided (was incorrectly tightened to `pt-8`, causing content to collide with the absolute-positioned app switcher pill at the top).
- Bump version to `v0.1.8`.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (278 tests)
- [x] `pnpm components validate` passes
- [ ] Visual: scroll content in AppShell — Snackbar stays pinned to visible bottom, not buried in scrolled content
- [ ] Visual: AppShell with `appSwitcher` — content is no longer hugging the top pill

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>