### PR TITLE
fix: AppShell content bottom padding so snackbar doesn't overlap content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -160,7 +160,7 @@ function AppShellInner({
               <main className="relative flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
                 <div
                   className={cn(
-                    "mx-auto w-full px-6 pb-8",
+                    "mx-auto w-full px-6 pb-24",
                     appSwitcher ? "pt-20" : "pt-6",
                     contentClassName,
                   )}


### PR DESCRIPTION
Closes #137

## Summary
- Increase the AppShell content wrapper bottom padding from `pb-8` to `pb-24` so the snackbar (rendered via `SnackbarOutlet` at the bottom of the content area) does not overlap the last content elements when scrolled to the end.
- Bump package version to `0.1.9`.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (278 tests)
- [x] `pnpm components validate` passes (34 components)
- [ ] Visual check in Storybook: snackbar no longer overlaps content at scroll bottom