### PR TITLE
fix: snackbar takes full content width in AppShell

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -168,7 +168,7 @@ function AppShellInner({
                   {children}
                 </div>
               </main>
-              <SnackbarOutlet />
+              <SnackbarOutlet className={cn("mx-auto w-full px-6", contentClassName)} />
             </div>
           </div>
         </div>

--- a/src/components/ui/feedback/snackbar/Snackbar.tsx
+++ b/src/components/ui/feedback/snackbar/Snackbar.tsx
@@ -103,9 +103,9 @@ export function Snackbar({
   return (
     <div
       className={cn(
-        "z-50 flex justify-center px-4",
+        "z-50 flex justify-center",
         "transition-all duration-300 ease-out",
-        inline ? "absolute bottom-4 inset-x-0" : "fixed bottom-4 inset-x-0",
+        inline ? "absolute bottom-4 inset-x-0" : "fixed bottom-4 inset-x-0 px-4",
         visible && open
           ? "translate-y-0 opacity-100"
           : "translate-y-8 opacity-0 pointer-events-none",
@@ -117,7 +117,8 @@ export function Snackbar({
     >
       <div
         className={cn(
-          "w-full max-w-lg bg-surface-container-high border rounded-2xl shadow-md",
+          "w-full bg-surface-container-high border rounded-2xl shadow-md",
+          !inline && "max-w-lg",
           variantBorder[variant],
         )}
       >


### PR DESCRIPTION
## Summary
- `SnackbarOutlet` in AppShell gets `contentClassName` so it matches content max-width
- Snackbar inline mode: removes `max-w-lg` and `px-4` so it fills its container
- Non-inline (fixed) mode unchanged — keeps `max-w-lg` and `px-4`
- Bumps to v0.1.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)