### PR TITLE
feat: add snackbarClassName to AppShell

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -30,6 +30,8 @@ export interface AppShellProps {
   contentClassName?: string;
   /** Class for the navigation wrapper (override responsive visibility) */
   navClassName?: string;
+  /** Class for the snackbar container (e.g. max-w-2xl mx-auto) */
+  snackbarClassName?: string;
   /** Agent sidebar chat content */
   agentSidebarContent?: ReactNode;
   onAgentSend?: (message: string) => void;
@@ -55,6 +57,7 @@ function AppShellInner({
   appSwitcherClassName = "max-w-7xl",
   contentClassName,
   navClassName,
+  snackbarClassName,
   agentSidebarContent,
   onAgentSend,
   onAgentAttachFile,
@@ -168,7 +171,7 @@ function AppShellInner({
                   {children}
                 </div>
               </main>
-              <SnackbarOutlet />
+              <SnackbarOutlet className={snackbarClassName} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Adds `snackbarClassName` prop to AppShell
- Passed to `SnackbarOutlet` as `className`
- Consumer sets max-width to match content: `snackbarClassName="max-w-2xl mx-auto px-6"`
- Bumps to v0.1.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)