### PR TITLE
fix: remove max-w-lg from inline snackbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/feedback/snackbar/Snackbar.tsx
+++ b/src/components/ui/feedback/snackbar/Snackbar.tsx
@@ -117,7 +117,8 @@ export function Snackbar({
     >
       <div
         className={cn(
-          "w-full max-w-lg bg-surface-container-high border rounded-2xl shadow-md",
+          "w-full bg-surface-container-high border rounded-2xl shadow-md",
+          !inline && "max-w-lg",
           variantBorder[variant],
         )}
       >


### PR DESCRIPTION
## Summary
- Removes `max-w-lg` from snackbar inner div in inline mode
- Inline snackbar fills its container width (controlled by `snackbarClassName` on AppShell)
- Fixed mode keeps `max-w-lg`
- Bumps to v0.1.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)