### PR TITLE
fix: useUnsavedSnackbar stale callback and snapshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/context/snackbar/SnackbarProvider.tsx
+++ b/src/context/snackbar/SnackbarProvider.tsx
@@ -139,6 +139,10 @@ export function useUnsavedSnackbar(options: UseUnsavedSnackbarOptions) {
   const prevDirty = useRef(false);
   const isFirstRender = useRef(true);
 
+  // Keep latest callbacks/snapshot in refs so snackbar onClick always uses current values
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
   useEffect(() => {
     if (isFirstRender.current) {
       savedRef.current = options.snapshot;
@@ -155,9 +159,9 @@ export function useUnsavedSnackbar(options: UseUnsavedSnackbarOptions) {
         action: {
           label: "Save",
           onClick: () => {
-            savedRef.current = options.snapshot;
+            savedRef.current = optionsRef.current.snapshot;
             prevDirty.current = false;
-            options.onSave();
+            optionsRef.current.onSave();
             dismissSnackbar();
             setTimeout(() => {
               showSnackbar({ message: "Saved", variant: "success" });
@@ -168,7 +172,7 @@ export function useUnsavedSnackbar(options: UseUnsavedSnackbarOptions) {
           label: "Reset",
           onClick: () => {
             prevDirty.current = false;
-            options.onReset();
+            optionsRef.current.onReset();
             dismissSnackbar();
           },
         },


### PR DESCRIPTION
## Summary
- Uses `optionsRef` to always call the latest `onSave`/`onReset` and capture the current `snapshot`
- Fixes: editing multiple fields then clicking Save would save stale values from when the snackbar first appeared
- Fixes: second save after re-editing wouldn't work because savedRef had wrong snapshot
- Bumps to v0.1.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)