### PR TITLE
feat: add size and hideLabel to Combobox

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/inputs/combobox/Combobox.stories.tsx
+++ b/src/components/ui/inputs/combobox/Combobox.stories.tsx
@@ -105,3 +105,48 @@ export const Disabled: Story = {
     </div>
   ),
 };
+
+export const Small: Story = {
+  render: () => {
+    const [value, setValue] = useState("");
+    return (
+      <div className="max-w-sm">
+        <Combobox
+          label="Pronouns"
+          value={value}
+          onChange={setValue}
+          size="sm"
+          options={[
+            { value: "", label: "Prefer not to say" },
+            { value: "he/him", label: "he/him" },
+            { value: "she/her", label: "she/her" },
+            { value: "they/them", label: "they/them" },
+          ]}
+        />
+      </div>
+    );
+  },
+};
+
+export const SmallHiddenLabel: Story = {
+  render: () => {
+    const [value, setValue] = useState("");
+    return (
+      <div className="max-w-sm">
+        <Combobox
+          label="Pronouns"
+          value={value}
+          onChange={setValue}
+          size="sm"
+          hideLabel
+          options={[
+            { value: "", label: "Prefer not to say" },
+            { value: "he/him", label: "he/him" },
+            { value: "she/her", label: "she/her" },
+            { value: "they/them", label: "they/them" },
+          ]}
+        />
+      </div>
+    );
+  },
+};

--- a/src/components/ui/inputs/combobox/Combobox.tsx
+++ b/src/components/ui/inputs/combobox/Combobox.tsx
@@ -14,6 +14,8 @@ export interface ComboboxOption {
   label: string;
 }
 
+export type ComboboxSize = "sm" | "md";
+
 export interface ComboboxProps {
   label: string;
   value: string;
@@ -25,6 +27,8 @@ export interface ComboboxProps {
   error?: boolean;
   helperText?: string;
   className?: string;
+  size?: ComboboxSize;
+  hideLabel?: boolean;
 }
 
 function normalizeOption(opt: string | ComboboxOption): ComboboxOption {
@@ -42,6 +46,8 @@ export function Combobox({
   error = false,
   helperText,
   className,
+  size = "md",
+  hideLabel = false,
 }: ComboboxProps) {
   const options = useMemo(() => rawOptions.map(normalizeOption), [rawOptions]);
 
@@ -192,9 +198,11 @@ export function Combobox({
           onFocus={handleFocus}
           onKeyDown={handleKeyDown}
           disabled={disabled}
-          placeholder=" "
+          placeholder={hideLabel ? label : " "}
+          aria-label={hideLabel ? label : undefined}
           className={cn(
-            "peer w-full rounded-lg px-4 py-4 bg-transparent border-0 outline-none text-on-surface transition-colors disabled:cursor-not-allowed",
+            "peer w-full rounded-lg bg-transparent border-0 outline-none text-on-surface transition-colors disabled:cursor-not-allowed",
+            size === "sm" ? "px-3 py-2.5 text-sm" : "px-4 py-4",
             error ? "focus:text-error" : "focus:text-primary",
           )}
           autoComplete="off"
@@ -204,19 +212,22 @@ export function Combobox({
           aria-controls={listboxId}
           aria-activedescendant={activeOptionId}
         />
-        <label
-          htmlFor={inputId}
-          className={cn(
-            "absolute text-base z-10 font-normal left-4 top-4 px-1 bg-surface-container-low rounded-md transition-all duration-200 ease-in-out origin-top-left pointer-events-none",
-            "peer-focus:scale-75 peer-focus:top-0 peer-focus:-translate-y-1/2 peer-focus:left-3",
-            "peer-[:not(:placeholder-shown)]:scale-75 peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:-translate-y-1/2 peer-[:not(:placeholder-shown)]:left-3",
-            error
-              ? "text-error peer-focus:text-error"
-              : "text-on-surface-variant peer-focus:text-primary",
-          )}
-        >
-          {label}
-        </label>
+        {!hideLabel && (
+          <label
+            htmlFor={inputId}
+            className={cn(
+              "absolute z-10 font-normal px-1 bg-surface-container-low rounded-md transition-all duration-200 ease-in-out origin-top-left pointer-events-none",
+              size === "sm"
+                ? "text-sm left-3 top-2.5 peer-focus:scale-75 peer-focus:top-0 peer-focus:-translate-y-1/2 peer-focus:left-2.5 peer-[:not(:placeholder-shown)]:scale-75 peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:-translate-y-1/2 peer-[:not(:placeholder-shown)]:left-2.5"
+                : "text-base left-4 top-4 peer-focus:scale-75 peer-focus:top-0 peer-focus:-translate-y-1/2 peer-focus:left-3 peer-[:not(:placeholder-shown)]:scale-75 peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:-translate-y-1/2 peer-[:not(:placeholder-shown)]:left-3",
+              error
+                ? "text-error peer-focus:text-error"
+                : "text-on-surface-variant peer-focus:text-primary",
+            )}
+          >
+            {label}
+          </label>
+        )}
         <button
           type="button"
           tabIndex={-1}

--- a/src/components/ui/inputs/floating-label-input/FloatingLabelInput.tsx
+++ b/src/components/ui/inputs/floating-label-input/FloatingLabelInput.tsx
@@ -122,14 +122,13 @@ export function FloatingLabelInput(props: FloatingLabelInputProps) {
     disabled && "opacity-50 cursor-not-allowed hover:border-outline-variant",
   );
 
-  const labelLeft = isSmall ? "left-2.5" : "left-3";
   const labelClassName = cn(
     "absolute z-10 font-normal px-1",
     "bg-surface-container-low rounded-md transition-all duration-200 ease-in-out",
     "origin-top-left pointer-events-none",
-    isSmall ? "text-sm left-3 top-2.5" : "text-base left-4 top-4",
-    `peer-focus:scale-75 peer-focus:top-0 peer-focus:-translate-y-1/2 peer-focus:${labelLeft}`,
-    `peer-[:not(:placeholder-shown)]:scale-75 peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:-translate-y-1/2 peer-[:not(:placeholder-shown)]:${labelLeft}`,
+    isSmall
+      ? "text-sm left-3 top-2.5 peer-focus:scale-75 peer-focus:top-0 peer-focus:-translate-y-1/2 peer-focus:left-2.5 peer-[:not(:placeholder-shown)]:scale-75 peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:-translate-y-1/2 peer-[:not(:placeholder-shown)]:left-2.5"
+      : "text-base left-4 top-4 peer-focus:scale-75 peer-focus:top-0 peer-focus:-translate-y-1/2 peer-focus:left-3 peer-[:not(:placeholder-shown)]:scale-75 peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:-translate-y-1/2 peer-[:not(:placeholder-shown)]:left-3",
     error
       ? "text-error peer-focus:text-error"
       : "text-on-surface-variant peer-focus:text-primary",


### PR DESCRIPTION
## Summary
- `size`: `"sm" | "md"` (default `"md"`) — compact padding and text for inline use
- `hideLabel`: shows placeholder instead of floating label, adds `aria-label`
- Matches FloatingLabelInput API (`size` + `hideLabel`)
- Updated stories: Small, SmallHiddenLabel
- Bumps to v0.1.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)