### PR TITLE
feat: formatDate and formatRelativeDate utilities (#151)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { cn } from "./utils/cn";
+export { formatDate, formatRelativeDate } from "./utils/date";
 export { Icon, type IconProps } from "./components/ui/media/icon/Icon";
 export { isDev, isProd, isStorybook } from "./utils/env";
 export { Button, type ButtonProps } from "./components/ui/actions/button/Button";

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { formatDate, formatRelativeDate } from "./date";
+
+describe("formatDate", () => {
+  it("formats a date string", () => {
+    const result = formatDate("2026-04-29");
+    expect(result).toContain("Apr");
+    expect(result).toContain("29");
+    expect(result).toContain("2026");
+  });
+
+  it("formats an ISO datetime string", () => {
+    const result = formatDate("2025-12-25T10:00:00Z");
+    expect(result).toContain("Dec");
+    expect(result).toContain("25");
+    expect(result).toContain("2025");
+  });
+});
+
+describe("formatRelativeDate", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function setNow(dateStr: string) {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(dateStr));
+  }
+
+  it("returns 'Today' for the current date", () => {
+    setNow("2026-04-28T12:00:00Z");
+    expect(formatRelativeDate("2026-04-28T08:00:00Z")).toBe("Today");
+  });
+
+  it("returns 'Yesterday' for one day ago", () => {
+    setNow("2026-04-28T12:00:00Z");
+    expect(formatRelativeDate("2026-04-27T12:00:00Z")).toBe("Yesterday");
+  });
+
+  it("returns days ago for 2-6 days", () => {
+    setNow("2026-04-28T12:00:00Z");
+    expect(formatRelativeDate("2026-04-25T12:00:00Z")).toBe("3d ago");
+    expect(formatRelativeDate("2026-04-22T12:00:00Z")).toBe("6d ago");
+  });
+
+  it("returns weeks ago for 7-29 days", () => {
+    setNow("2026-04-28T12:00:00Z");
+    expect(formatRelativeDate("2026-04-20T12:00:00Z")).toBe("1w ago");
+    expect(formatRelativeDate("2026-04-14T12:00:00Z")).toBe("2w ago");
+  });
+
+  it("returns formatted date for 30+ days ago", () => {
+    setNow("2026-04-28T12:00:00Z");
+    const result = formatRelativeDate("2026-03-14T12:00:00Z");
+    expect(result).toContain("Mar");
+    expect(result).toContain("14");
+  });
+
+  it("handles boundary at exactly 7 days", () => {
+    setNow("2026-04-28T12:00:00Z");
+    expect(formatRelativeDate("2026-04-21T12:00:00Z")).toBe("1w ago");
+  });
+
+  it("handles boundary at exactly 30 days", () => {
+    setNow("2026-04-28T12:00:00Z");
+    const result = formatRelativeDate("2026-03-29T12:00:00Z");
+    expect(result).toContain("Mar");
+    expect(result).toContain("29");
+  });
+});

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,24 @@
+export function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export function formatRelativeDate(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return `${diffDays}d ago`;
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
+
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}


### PR DESCRIPTION
## Summary
- Add `formatDate` utility: locale-aware date formatting (e.g. "Apr 29, 2026")
- Add `formatRelativeDate` utility: human-friendly relative dates (Today, Yesterday, 3d ago, 2w ago, or formatted date for older)
- Export both functions from `src/index.ts`
- Full test coverage with edge cases at day/week/month boundaries (9 tests)

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — all 9 date utility tests pass
- [x] Boundary tests: today, yesterday, 2-6 days, exactly 7 days, 8-29 days, exactly 30 days, 30+ days

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)