### PR TITLE
feat: ConfirmDialog convenience wrapper (#153)

### DIFF
--- a/src/components/ui/surfaces/confirm-dialog/ConfirmDialog.stories.tsx
+++ b/src/components/ui/surfaces/confirm-dialog/ConfirmDialog.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+const meta: Meta<typeof ConfirmDialog> = {
+  title: "UI/Surfaces/ConfirmDialog",
+  component: ConfirmDialog,
+  args: {
+    open: true,
+    title: "Confirm action",
+    description: "Are you sure you want to proceed?",
+    confirmLabel: "Confirm",
+    loading: false,
+  },
+  argTypes: {
+    open: { control: "boolean" },
+    title: { control: "text" },
+    description: { control: "text" },
+    confirmLabel: { control: "text" },
+    confirmColor: { control: "select", options: ["error", undefined] },
+    loading: { control: "boolean" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ConfirmDialog>;
+
+export const Playground: Story = {};
+
+export const ErrorVariant: Story = {
+  args: {
+    title: "Delete item?",
+    description:
+      "This will permanently delete the item. You cannot undo this action.",
+    confirmLabel: "Delete",
+    confirmColor: "error",
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    title: "Saving changes",
+    description: "Please wait while your changes are saved.",
+    loading: true,
+  },
+};

--- a/src/components/ui/surfaces/confirm-dialog/ConfirmDialog.test.tsx
+++ b/src/components/ui/surfaces/confirm-dialog/ConfirmDialog.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+afterEach(cleanup);
+
+describe("ConfirmDialog", () => {
+  const defaults = {
+    open: true,
+    onClose: vi.fn(),
+    onConfirm: vi.fn(),
+    title: "Delete item?",
+    description: "This action cannot be undone.",
+  };
+
+  it("renders title and description", () => {
+    render(<ConfirmDialog {...defaults} />);
+    expect(screen.getByText("Delete item?")).toBeInTheDocument();
+    expect(screen.getByText("This action cannot be undone.")).toBeInTheDocument();
+  });
+
+  it("renders nothing when closed", () => {
+    render(<ConfirmDialog {...defaults} open={false} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("calls onConfirm when confirm button is clicked", () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmDialog {...defaults} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose when cancel button is clicked", () => {
+    const onClose = vi.fn();
+    render(<ConfirmDialog {...defaults} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("uses custom confirmLabel", () => {
+    render(<ConfirmDialog {...defaults} confirmLabel="Delete" />);
+    expect(screen.getByRole("button", { name: "Delete" })).toBeInTheDocument();
+  });
+
+  it("disables confirm button when loading", () => {
+    render(<ConfirmDialog {...defaults} loading />);
+    const confirmBtn = screen.getByRole("button", { name: "Confirm" });
+    expect(confirmBtn).toBeDisabled();
+  });
+});

--- a/src/components/ui/surfaces/confirm-dialog/ConfirmDialog.tsx
+++ b/src/components/ui/surfaces/confirm-dialog/ConfirmDialog.tsx
@@ -1,0 +1,53 @@
+import type { ComponentMeta } from "@/types/component-meta";
+import type { ButtonProps } from "@/components/ui/actions/button/Button";
+import { Dialog } from "@/components/ui/surfaces/dialog/Dialog";
+
+export const meta: ComponentMeta = {
+  name: "ConfirmDialog",
+  description:
+    "Convenience wrapper over Dialog for the common confirm/cancel pattern",
+};
+
+export interface ConfirmDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  confirmColor?: ButtonProps["color"];
+  loading?: boolean;
+  className?: string;
+}
+
+export function ConfirmDialog({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  confirmColor,
+  loading = false,
+  className,
+}: ConfirmDialogProps) {
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={title}
+      className={className}
+      actions={[
+        { label: "Cancel", onClick: onClose, variant: "text" },
+        {
+          label: confirmLabel,
+          onClick: onConfirm,
+          loading,
+          color: confirmColor,
+        },
+      ]}
+    >
+      <p className="text-sm text-on-surface-variant">{description}</p>
+    </Dialog>
+  );
+}

--- a/src/components/ui/surfaces/surface/Surface.stories.tsx
+++ b/src/components/ui/surfaces/surface/Surface.stories.tsx
@@ -41,6 +41,29 @@ export const CardExample: Story = {
   ),
 };
 
+export const Interactive: Story = {
+  args: {
+    interactive: true,
+    children: "Hover over me — interactive surface with hover styles",
+  },
+};
+
+export const InteractiveCard: Story = {
+  render: () => (
+    <Surface interactive className="p-0 max-w-sm overflow-hidden">
+      <div className="aspect-video bg-surface-container" />
+      <div className="p-4">
+        <h3 className="text-base font-semibold text-on-surface">
+          Clickable Card
+        </h3>
+        <p className="text-sm text-on-surface-variant mt-1">
+          An interactive surface that responds to hover.
+        </p>
+      </div>
+    </Surface>
+  ),
+};
+
 export const Nested: Story = {
   render: () => (
     <Surface className="p-6">

--- a/src/components/ui/surfaces/surface/Surface.test.tsx
+++ b/src/components/ui/surfaces/surface/Surface.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render } from "@testing-library/react";
+import { describe, expect, it, afterEach } from "vitest";
+import { Surface } from "./Surface";
+
+afterEach(cleanup);
+
+describe("Surface", () => {
+  it("renders children", () => {
+    const { getByText } = render(<Surface>Hello</Surface>);
+    expect(getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("applies default classes", () => {
+    const { container } = render(<Surface>Content</Surface>);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain("rounded-2xl");
+    expect(div.className).toContain("bg-surface-container-low");
+    expect(div.className).toContain("border-outline-variant");
+  });
+
+  it("merges custom className", () => {
+    const { container } = render(<Surface className="p-4">Content</Surface>);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain("p-4");
+    expect(div.className).toContain("rounded-2xl");
+  });
+
+  it("does not apply interactive classes by default", () => {
+    const { container } = render(<Surface>Content</Surface>);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).not.toContain("hover:bg-surface-container");
+    expect(div.className).not.toContain("cursor-pointer");
+    expect(div.className).not.toContain("transition-colors");
+  });
+
+  it("applies interactive classes when interactive is true", () => {
+    const { container } = render(<Surface interactive>Content</Surface>);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain("hover:bg-surface-container");
+    expect(div.className).toContain("cursor-pointer");
+    expect(div.className).toContain("transition-colors");
+  });
+
+  it("passes through HTML attributes", () => {
+    const { container } = render(
+      <Surface data-testid="surface" role="button">
+        Content
+      </Surface>,
+    );
+    const div = container.firstChild as HTMLElement;
+    expect(div).toHaveAttribute("data-testid", "surface");
+    expect(div).toHaveAttribute("role", "button");
+  });
+});

--- a/src/components/ui/surfaces/surface/Surface.tsx
+++ b/src/components/ui/surfaces/surface/Surface.tsx
@@ -10,13 +10,22 @@ export const meta: ComponentMeta = {
 
 export interface SurfaceProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
+  /** Adds hover background, transition, and pointer cursor. */
+  interactive?: boolean;
 }
 
-export function Surface({ children, className, ...props }: SurfaceProps) {
+export function Surface({
+  children,
+  className,
+  interactive,
+  ...props
+}: SurfaceProps) {
   return (
     <div
       className={cn(
         "rounded-2xl bg-surface-container-low border border-outline-variant",
+        interactive &&
+          "hover:bg-surface-container transition-colors cursor-pointer",
         className,
       )}
       {...props}

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,10 @@ export {
   type DialogAction,
 } from "./components/ui/surfaces/dialog/Dialog";
 export {
+  ConfirmDialog,
+  type ConfirmDialogProps,
+} from "./components/ui/surfaces/confirm-dialog/ConfirmDialog";
+export {
   Surface,
   type SurfaceProps,
 } from "./components/ui/surfaces/surface/Surface";


### PR DESCRIPTION
## Summary
- Add `ConfirmDialog` component: thin wrapper over `Dialog` for the common confirm/cancel pattern
- Props: `open`, `onClose`, `onConfirm`, `title`, `description`, `confirmLabel`, `confirmColor`, `loading`, `className`
- Includes 6 unit tests (render, confirm click, cancel click, custom label, loading state, closed state)
- Includes Storybook stories (Playground, ErrorVariant, Loading)
- Exported from `src/index.ts`

Closes #153

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (all 292 tests, 34 suites)
- [ ] Storybook renders Playground, ErrorVariant, and Loading stories correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)