### PR TITLE
feat: Skeleton component (#148)

### DIFF
--- a/src/components/ui/feedback/skeleton/Skeleton.stories.tsx
+++ b/src/components/ui/feedback/skeleton/Skeleton.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Skeleton } from "./Skeleton";
+
+const meta: Meta<typeof Skeleton> = {
+  title: "UI/Feedback/Skeleton",
+  component: Skeleton,
+  args: {
+    width: "w-full",
+    height: "h-4",
+    lines: 1,
+  },
+  argTypes: {
+    width: { control: "text" },
+    height: { control: "text" },
+    lines: { control: { type: "number", min: 1 } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Skeleton>;
+
+export const Playground: Story = {};
+
+export const MultiLine: Story = {
+  args: {
+    lines: 4,
+  },
+};
+
+export const CustomSizes: Story = {
+  render: () => (
+    <div className="space-y-4">
+      <Skeleton width="w-3/4" height="h-6" />
+      <Skeleton width="w-1/2" height="h-4" />
+      <Skeleton width="w-48" height="h-4" />
+      <Skeleton width="w-24" height="h-3" />
+    </div>
+  ),
+};
+
+export const CardPlaceholder: Story = {
+  render: () => (
+    <div className="w-80 space-y-3 rounded-lg border border-outline-variant p-4">
+      <Skeleton width="w-10" height="h-10" className="rounded-full" />
+      <Skeleton width="w-3/4" height="h-5" />
+      <Skeleton lines={3} />
+    </div>
+  ),
+};

--- a/src/components/ui/feedback/skeleton/Skeleton.test.tsx
+++ b/src/components/ui/feedback/skeleton/Skeleton.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, render } from "@testing-library/react";
+import { describe, expect, it, afterEach } from "vitest";
+import { Skeleton } from "./Skeleton";
+
+afterEach(cleanup);
+
+describe("Skeleton", () => {
+  it("renders a single skeleton bar by default", () => {
+    const { container } = render(<Skeleton />);
+    const bars = container.querySelectorAll(".animate-pulse");
+    expect(bars).toHaveLength(1);
+  });
+
+  it("applies default width and height classes", () => {
+    const { container } = render(<Skeleton />);
+    const bar = container.firstElementChild!;
+    expect(bar).toHaveClass("w-full");
+    expect(bar).toHaveClass("h-4");
+  });
+
+  it("applies custom width and height", () => {
+    const { container } = render(<Skeleton width="w-48" height="h-8" />);
+    const bar = container.firstElementChild!;
+    expect(bar).toHaveClass("w-48");
+    expect(bar).toHaveClass("h-8");
+  });
+
+  it("renders multiple lines when lines > 1", () => {
+    const { container } = render(<Skeleton lines={3} />);
+    const bars = container.querySelectorAll(".animate-pulse");
+    expect(bars).toHaveLength(3);
+  });
+
+  it("wraps multiple lines in a container with spacing", () => {
+    const { container } = render(<Skeleton lines={2} />);
+    const wrapper = container.firstElementChild!;
+    expect(wrapper).toHaveClass("space-y-2");
+  });
+
+  it("applies className to the single-line bar", () => {
+    const { container } = render(<Skeleton className="mt-4" />);
+    const bar = container.firstElementChild!;
+    expect(bar).toHaveClass("mt-4");
+  });
+
+  it("applies className to the multi-line wrapper", () => {
+    const { container } = render(<Skeleton lines={2} className="mt-4" />);
+    const wrapper = container.firstElementChild!;
+    expect(wrapper).toHaveClass("mt-4");
+  });
+
+  it("clamps lines < 1 to 1", () => {
+    const { container } = render(<Skeleton lines={0} />);
+    const bars = container.querySelectorAll(".animate-pulse");
+    expect(bars).toHaveLength(1);
+  });
+});

--- a/src/components/ui/feedback/skeleton/Skeleton.tsx
+++ b/src/components/ui/feedback/skeleton/Skeleton.tsx
@@ -1,0 +1,60 @@
+import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "Skeleton",
+  description: "Loading placeholder with configurable dimensions and multi-line support",
+};
+
+export interface SkeletonProps {
+  /** Tailwind width class (e.g. "w-full", "w-48") */
+  width?: string;
+  /** Tailwind height class (e.g. "h-4", "h-8") */
+  height?: string;
+  /** Additional classes */
+  className?: string;
+  /** Renders multiple skeleton bars with vertical spacing */
+  lines?: number;
+}
+
+export function Skeleton({
+  width = "w-full",
+  height = "h-4",
+  className = "",
+  lines = 1,
+}: SkeletonProps) {
+  if (isDev && lines < 1) {
+    console.warn("[Skeleton] lines must be at least 1, received:", lines);
+  }
+
+  const count = Math.max(1, Math.round(lines));
+
+  if (count > 1) {
+    return (
+      <div className={cn("space-y-2", className)}>
+        {Array.from({ length: count }, (_, i) => (
+          <div
+            key={i}
+            className={cn(
+              width,
+              height,
+              "bg-surface-container-highest rounded animate-pulse",
+            )}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        width,
+        height,
+        "bg-surface-container-highest rounded animate-pulse",
+        className,
+      )}
+    />
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,6 +81,10 @@ export {
   type BadgeSize,
 } from "./components/ui/feedback/badge/Badge";
 export {
+  Skeleton,
+  type SkeletonProps,
+} from "./components/ui/feedback/skeleton/Skeleton";
+export {
   ThemeToggle,
   type ThemeToggleProps,
   type Theme,


### PR DESCRIPTION
## Summary
- Add `Skeleton` component to `ui/feedback/skeleton/` -- a loading placeholder with configurable width, height, className, and multi-line support
- Includes `isDev` warning when `lines < 1` and clamps invalid values to 1
- Exports `Skeleton` and `SkeletonProps` from package index

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` -- all 286 tests pass (8 new Skeleton tests)
- [x] `pnpm components validate` -- all 35 components valid
- [x] Tests cover: single bar default, custom width/height, multi-line rendering, className passthrough (single + multi), lines clamping

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)