### PR TITLE
feat: add interactive prop to Surface (#152)

### DIFF
--- a/src/components/ui/surfaces/surface/Surface.stories.tsx
+++ b/src/components/ui/surfaces/surface/Surface.stories.tsx
@@ -41,6 +41,29 @@ export const CardExample: Story = {
   ),
 };
 
+export const Interactive: Story = {
+  args: {
+    interactive: true,
+    children: "Hover over me — interactive surface with hover styles",
+  },
+};
+
+export const InteractiveCard: Story = {
+  render: () => (
+    <Surface interactive className="p-0 max-w-sm overflow-hidden">
+      <div className="aspect-video bg-surface-container" />
+      <div className="p-4">
+        <h3 className="text-base font-semibold text-on-surface">
+          Clickable Card
+        </h3>
+        <p className="text-sm text-on-surface-variant mt-1">
+          An interactive surface that responds to hover.
+        </p>
+      </div>
+    </Surface>
+  ),
+};
+
 export const Nested: Story = {
   render: () => (
     <Surface className="p-6">

--- a/src/components/ui/surfaces/surface/Surface.test.tsx
+++ b/src/components/ui/surfaces/surface/Surface.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render } from "@testing-library/react";
+import { describe, expect, it, afterEach } from "vitest";
+import { Surface } from "./Surface";
+
+afterEach(cleanup);
+
+describe("Surface", () => {
+  it("renders children", () => {
+    const { getByText } = render(<Surface>Hello</Surface>);
+    expect(getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("applies default classes", () => {
+    const { container } = render(<Surface>Content</Surface>);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain("rounded-2xl");
+    expect(div.className).toContain("bg-surface-container-low");
+    expect(div.className).toContain("border-outline-variant");
+  });
+
+  it("merges custom className", () => {
+    const { container } = render(<Surface className="p-4">Content</Surface>);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain("p-4");
+    expect(div.className).toContain("rounded-2xl");
+  });
+
+  it("does not apply interactive classes by default", () => {
+    const { container } = render(<Surface>Content</Surface>);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).not.toContain("hover:bg-surface-container");
+    expect(div.className).not.toContain("cursor-pointer");
+    expect(div.className).not.toContain("transition-colors");
+  });
+
+  it("applies interactive classes when interactive is true", () => {
+    const { container } = render(<Surface interactive>Content</Surface>);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain("hover:bg-surface-container");
+    expect(div.className).toContain("cursor-pointer");
+    expect(div.className).toContain("transition-colors");
+  });
+
+  it("passes through HTML attributes", () => {
+    const { container } = render(
+      <Surface data-testid="surface" role="button">
+        Content
+      </Surface>,
+    );
+    const div = container.firstChild as HTMLElement;
+    expect(div).toHaveAttribute("data-testid", "surface");
+    expect(div).toHaveAttribute("role", "button");
+  });
+});

--- a/src/components/ui/surfaces/surface/Surface.tsx
+++ b/src/components/ui/surfaces/surface/Surface.tsx
@@ -10,13 +10,22 @@ export const meta: ComponentMeta = {
 
 export interface SurfaceProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
+  /** Adds hover background, transition, and pointer cursor. */
+  interactive?: boolean;
 }
 
-export function Surface({ children, className, ...props }: SurfaceProps) {
+export function Surface({
+  children,
+  className,
+  interactive,
+  ...props
+}: SurfaceProps) {
   return (
     <div
       className={cn(
         "rounded-2xl bg-surface-container-low border border-outline-variant",
+        interactive &&
+          "hover:bg-surface-container transition-colors cursor-pointer",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Adds `interactive?: boolean` prop to `Surface` component
- When true, applies `hover:bg-surface-container`, `transition-colors`, and `cursor-pointer`
- Eliminates the need for web-applications to wrap Surface as "Card" just for hover styles

## Changes
- `Surface.tsx` — new `interactive` prop with conditional hover classes via `cn()`
- `Surface.stories.tsx` — `Interactive` and `InteractiveCard` story variants
- `Surface.test.tsx` — new test file covering default rendering, class merging, interactive classes, and HTML passthrough

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (all 6 Surface tests green)
- [ ] Visual check in Storybook: Interactive and InteractiveCard stories show hover effect

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)