### PR TITLE
feat: EmptyState component (#149)

### DIFF
--- a/src/components/ui/feedback/empty-state/EmptyState.stories.tsx
+++ b/src/components/ui/feedback/empty-state/EmptyState.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { EmptyState } from "./EmptyState";
+import { Button } from "@/components/ui/actions/button/Button";
+
+const meta: Meta<typeof EmptyState> = {
+  title: "UI/Feedback/EmptyState",
+  component: EmptyState,
+  args: {
+    icon: "folder_open",
+    title: "No items yet",
+  },
+  argTypes: {
+    icon: { control: "text" },
+    title: { control: "text" },
+    description: { control: "text" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof EmptyState>;
+
+export const Playground: Story = {};
+
+export const WithDescription: Story = {
+  args: {
+    icon: "search_off",
+    title: "No results found",
+    description: "Try adjusting your search or filters to find what you need.",
+  },
+};
+
+export const WithAction: Story = {
+  args: {
+    icon: "add_circle",
+    title: "No projects yet",
+    description: "Get started by creating your first project.",
+    action: <Button variant="filled">Create project</Button>,
+  },
+};
+
+export const NoDescription: Story = {
+  args: {
+    icon: "inbox",
+    title: "Your inbox is empty",
+  },
+};

--- a/src/components/ui/feedback/empty-state/EmptyState.test.tsx
+++ b/src/components/ui/feedback/empty-state/EmptyState.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { describe, expect, it, afterEach } from "vitest";
+import { EmptyState } from "./EmptyState";
+
+afterEach(cleanup);
+
+describe("EmptyState", () => {
+  it("renders icon, title", () => {
+    render(<EmptyState icon="folder_open" title="No items" />);
+    expect(screen.getByText("folder_open")).toBeInTheDocument();
+    expect(screen.getByText("No items")).toBeInTheDocument();
+  });
+
+  it("renders description when provided", () => {
+    render(
+      <EmptyState
+        icon="search_off"
+        title="No results"
+        description="Try a different search term."
+      />,
+    );
+    expect(screen.getByText("Try a different search term.")).toBeInTheDocument();
+  });
+
+  it("does not render description when omitted", () => {
+    const { container } = render(
+      <EmptyState icon="folder_open" title="No items" />,
+    );
+    expect(container.querySelector("p")).not.toBeInTheDocument();
+  });
+
+  it("renders action slot when provided", () => {
+    render(
+      <EmptyState
+        icon="add"
+        title="Nothing here"
+        action={<button>Create one</button>}
+      />,
+    );
+    expect(screen.getByText("Create one")).toBeInTheDocument();
+  });
+
+  it("does not render action when omitted", () => {
+    render(<EmptyState icon="folder_open" title="No items" />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <EmptyState icon="folder_open" title="No items" className="mt-8" />,
+    );
+    expect(container.firstChild).toHaveClass("mt-8");
+  });
+});

--- a/src/components/ui/feedback/empty-state/EmptyState.tsx
+++ b/src/components/ui/feedback/empty-state/EmptyState.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { Icon } from "@/components/ui/media/icon/Icon";
+
+export const meta: ComponentMeta = {
+  name: "EmptyState",
+  description:
+    "Centered empty state display with icon, title, description, and action slot",
+};
+
+export interface EmptyStateProps {
+  /** Material Symbols Rounded icon name (e.g. "folder_open", "search_off") */
+  icon: string;
+  /** Primary heading text */
+  title: string;
+  /** Optional supporting text below the title */
+  description?: string;
+  /** Optional action slot (e.g. a Button) */
+  action?: ReactNode;
+  className?: string;
+}
+
+export function EmptyState({
+  icon,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center py-16 text-center",
+        className,
+      )}
+    >
+      <Icon
+        name={icon}
+        size={48}
+        className="text-on-surface-variant mb-4"
+      />
+      <h3 className="text-lg font-medium text-on-surface mb-1">{title}</h3>
+      {description && (
+        <p className="text-sm text-on-surface-variant max-w-sm mb-4">
+          {description}
+        </p>
+      )}
+      {action}
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,10 @@ export {
   type DropZoneProps,
 } from "./components/ui/files/drop-zone/DropZone";
 export {
+  EmptyState,
+  type EmptyStateProps,
+} from "./components/ui/feedback/empty-state/EmptyState";
+export {
   AppShell,
   type AppShellProps,
 } from "./components/layout/app-shell/app-shell/AppShell";


### PR DESCRIPTION
## Summary
- Add `EmptyState` component to `src/components/ui/feedback/empty-state/`
- Centered layout with `Icon`, title, optional description, and action slot
- Includes test file (6 tests: rendering, optional description, action slot, className)
- Includes Storybook stories (Playground, WithDescription, WithAction, NoDescription)
- Exported from `src/index.ts`

Closes #149

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (292/292, including 6 EmptyState tests)
- [x] `pnpm components validate` passes (36/36)

🤖 Generated with [Claude Code](https://claude.com/claude-code)