### PR TITLE
feat: Card component (#159)

### DIFF
--- a/src/components/ui/surfaces/card/Card.stories.tsx
+++ b/src/components/ui/surfaces/card/Card.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Card } from "./Card";
+
+const meta: Meta<typeof Card> = {
+  title: "UI/Surfaces/Card",
+  component: Card,
+  args: {
+    className: "p-5",
+  },
+  argTypes: {
+    interactive: { control: "boolean" },
+    loading: { control: "boolean" },
+    className: { control: "text" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Card>;
+
+export const Playground: Story = {
+  args: {
+    children: "A simple card with default styling",
+  },
+};
+
+export const Interactive: Story = {
+  args: {
+    interactive: true,
+    children: "Hover over me — interactive card",
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+    children: "This content is hidden while loading",
+  },
+};
+
+export const InteractiveWithContent: Story = {
+  render: (args) => (
+    <Card {...args} interactive className="p-5 max-w-sm">
+      <h3 className="text-base font-semibold text-on-surface">App Name</h3>
+      <p className="text-sm text-on-surface-variant mt-1">
+        A brief description of the application and what it does.
+      </p>
+    </Card>
+  ),
+};

--- a/src/components/ui/surfaces/card/Card.test.tsx
+++ b/src/components/ui/surfaces/card/Card.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, render } from "@testing-library/react";
+import { describe, expect, it, afterEach } from "vitest";
+import { Card } from "./Card";
+
+afterEach(cleanup);
+
+describe("Card", () => {
+  it("renders children", () => {
+    const { getByText } = render(<Card>Hello Card</Card>);
+    expect(getByText("Hello Card")).toBeInTheDocument();
+  });
+
+  it("passes className through to Surface", () => {
+    const { container } = render(<Card className="p-5">Content</Card>);
+    const surface = container.firstChild as HTMLElement;
+    expect(surface.className).toContain("p-5");
+    expect(surface.className).toContain("rounded-2xl");
+  });
+
+  it("delegates interactive prop to Surface", () => {
+    const { container } = render(<Card interactive>Content</Card>);
+    const surface = container.firstChild as HTMLElement;
+    expect(surface.className).toContain("hover:bg-surface-container");
+    expect(surface.className).toContain("cursor-pointer");
+  });
+
+  it("does not apply interactive classes by default", () => {
+    const { container } = render(<Card>Content</Card>);
+    const surface = container.firstChild as HTMLElement;
+    expect(surface.className).not.toContain("hover:bg-surface-container");
+    expect(surface.className).not.toContain("cursor-pointer");
+  });
+
+  it("renders Skeleton lines when loading is true", () => {
+    const { container, queryByText } = render(
+      <Card loading>
+        <p>Should not appear</p>
+      </Card>,
+    );
+    expect(queryByText("Should not appear")).not.toBeInTheDocument();
+    const skeletonBars = container.querySelectorAll(".animate-pulse");
+    expect(skeletonBars.length).toBe(3);
+  });
+
+  it("renders children when loading is false", () => {
+    const { getByText, container } = render(
+      <Card loading={false}>
+        <p>Visible</p>
+      </Card>,
+    );
+    expect(getByText("Visible")).toBeInTheDocument();
+    const skeletonBars = container.querySelectorAll(".animate-pulse");
+    expect(skeletonBars.length).toBe(0);
+  });
+});

--- a/src/components/ui/surfaces/card/Card.tsx
+++ b/src/components/ui/surfaces/card/Card.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+import type { ComponentMeta } from "@/types/component-meta";
+import { Surface } from "@/components/ui/surfaces/surface/Surface";
+import { Skeleton } from "@/components/ui/feedback/skeleton/Skeleton";
+
+export const meta: ComponentMeta = {
+  name: "Card",
+  description: "Surface wrapper with common card patterns including loading state",
+};
+
+export interface CardProps {
+  children: ReactNode;
+  /** Adds hover background, transition, and pointer cursor (delegates to Surface). */
+  interactive?: boolean;
+  /** When true, renders Skeleton placeholders instead of children. */
+  loading?: boolean;
+  /** Additional classes passed through to Surface. */
+  className?: string;
+}
+
+export function Card({ children, interactive, loading, className }: CardProps) {
+  return (
+    <Surface interactive={interactive} className={className}>
+      {loading ? (
+        <Skeleton lines={3} />
+      ) : (
+        children
+      )}
+    </Surface>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,10 @@ export {
   type SurfaceProps,
 } from "./components/ui/surfaces/surface/Surface";
 export {
+  Card,
+  type CardProps,
+} from "./components/ui/surfaces/card/Card";
+export {
   Avatar,
   type AvatarProps,
   type AvatarSize,


### PR DESCRIPTION
## Summary
- Add `Card` component that wraps `Surface` with common card patterns
- Supports `interactive` prop (delegated to Surface's hover state)
- Supports `loading` prop (renders 3 Skeleton lines instead of children)
- Includes test file (6 tests), story file (4 stories), and index export

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (591/591 tests)
- [x] `pnpm components validate` passes (37/37 components)
- [x] Verified children rendering, className passthrough, interactive delegation, and loading skeleton state

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)