### PR TITLE
feat: Card component (#159)

### DIFF
--- a/src/components/ui/surfaces/card/Card.stories.tsx
+++ b/src/components/ui/surfaces/card/Card.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Card } from "./Card";
+import { Button } from "@/components/ui/actions/button/Button";
+
+const meta: Meta<typeof Card> = {
+  title: "UI/Surfaces/Card",
+  component: Card,
+  args: {
+    children: (
+      <>
+        <h3 className="text-base font-semibold text-on-surface">Card Title</h3>
+        <p className="text-sm text-on-surface-variant mt-1">
+          A brief description of the card content.
+        </p>
+      </>
+    ),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Card>;
+
+export const Playground: Story = {
+  args: {
+    className: "max-w-sm",
+    media: <div className="aspect-video bg-surface-container" />,
+    actions: (
+      <>
+        <Button variant="text" size="sm">
+          Cancel
+        </Button>
+        <Button variant="filled" size="sm">
+          Action
+        </Button>
+      </>
+    ),
+  },
+};
+
+export const Default: Story = {
+  args: {
+    className: "max-w-sm",
+    media: <div className="aspect-video bg-surface-container" />,
+    actions: (
+      <>
+        <Button variant="text" size="sm">
+          Cancel
+        </Button>
+        <Button variant="filled" size="sm">
+          Action
+        </Button>
+      </>
+    ),
+  },
+};
+
+export const Interactive: Story = {
+  args: {
+    className: "max-w-sm",
+    interactive: true,
+    media: <div className="aspect-video bg-surface-container" />,
+  },
+};
+
+export const MediaOnly: Story = {
+  args: {
+    className: "max-w-sm",
+    media: <div className="aspect-video bg-surface-container" />,
+  },
+};
+
+export const NoActions: Story = {
+  args: {
+    className: "max-w-sm",
+    media: <div className="aspect-video bg-surface-container" />,
+  },
+};
+
+export const ContentOnly: Story = {
+  args: {
+    className: "max-w-sm",
+  },
+};

--- a/src/components/ui/surfaces/card/Card.test.tsx
+++ b/src/components/ui/surfaces/card/Card.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render } from "@testing-library/react";
+import { describe, expect, it, afterEach } from "vitest";
+import { Card } from "./Card";
+
+afterEach(cleanup);
+
+describe("Card", () => {
+  it("renders children", () => {
+    const { getByText } = render(<Card>Card content</Card>);
+    expect(getByText("Card content")).toBeInTheDocument();
+  });
+
+  it("renders media slot when provided", () => {
+    const { getByTestId } = render(
+      <Card media={<div data-testid="media">Media</div>}>Content</Card>,
+    );
+    expect(getByTestId("media")).toBeInTheDocument();
+  });
+
+  it("does not render media wrapper when media is not provided", () => {
+    const { container } = render(<Card>Content</Card>);
+    // Only the content div should be inside the Surface
+    const surface = container.firstChild as HTMLElement;
+    expect(surface.children).toHaveLength(1);
+  });
+
+  it("renders actions slot when provided", () => {
+    const { getByText } = render(
+      <Card actions={<button>Save</button>}>Content</Card>,
+    );
+    expect(getByText("Save")).toBeInTheDocument();
+  });
+
+  it("does not render actions wrapper when actions is not provided", () => {
+    const { container } = render(<Card>Content</Card>);
+    const surface = container.firstChild as HTMLElement;
+    // Only the content div, no actions div
+    expect(surface.children).toHaveLength(1);
+  });
+
+  it("applies interactive prop to Surface", () => {
+    const { container } = render(<Card interactive>Content</Card>);
+    const surface = container.firstChild as HTMLElement;
+    expect(surface.className).toContain("cursor-pointer");
+    expect(surface.className).toContain("hover:bg-surface-container");
+  });
+
+  it("does not apply interactive classes by default", () => {
+    const { container } = render(<Card>Content</Card>);
+    const surface = container.firstChild as HTMLElement;
+    expect(surface.className).not.toContain("cursor-pointer");
+  });
+
+  it("merges custom className onto Surface", () => {
+    const { container } = render(<Card className="max-w-sm">Content</Card>);
+    const surface = container.firstChild as HTMLElement;
+    expect(surface.className).toContain("max-w-sm");
+    expect(surface.className).toContain("overflow-hidden");
+  });
+
+  it("renders all slots together", () => {
+    const { getByTestId, getByText } = render(
+      <Card
+        media={<div data-testid="media">Image</div>}
+        actions={<button>Action</button>}
+      >
+        Body text
+      </Card>,
+    );
+    expect(getByTestId("media")).toBeInTheDocument();
+    expect(getByText("Body text")).toBeInTheDocument();
+    expect(getByText("Action")).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/surfaces/card/Card.tsx
+++ b/src/components/ui/surfaces/card/Card.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import { Surface } from "@/components/ui/surfaces/surface/Surface";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "Card",
+  description:
+    "Card layout with optional media area, content, and action buttons built on Surface",
+};
+
+export interface CardProps {
+  /** Content area — title, description, etc. */
+  children: ReactNode;
+  /** Optional top area for images, video, or color blocks. */
+  media?: ReactNode;
+  /** Optional bottom area with action buttons. */
+  actions?: ReactNode;
+  /** Delegates to Surface's interactive prop for hover styles. */
+  interactive?: boolean;
+  /** Applied to the outer Surface. */
+  className?: string;
+}
+
+export function Card({
+  children,
+  media,
+  actions,
+  interactive,
+  className,
+}: CardProps) {
+  return (
+    <Surface
+      interactive={interactive}
+      className={cn("p-0 overflow-hidden", className)}
+    >
+      {media}
+      <div className="p-4">{children}</div>
+      {actions && (
+        <div className="flex justify-end gap-2 px-4 pb-4">{actions}</div>
+      )}
+    </Surface>
+  );
+}

--- a/src/components/ui/surfaces/surface/Surface.stories.tsx
+++ b/src/components/ui/surfaces/surface/Surface.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Surface } from "./Surface";
-import { Button } from "@/components/ui/actions/button/Button";
 
 const meta: Meta<typeof Surface> = {
   title: "UI/Surfaces/Surface",
@@ -19,49 +18,11 @@ export const Playground: Story = {
   },
 };
 
-export const CardExample: Story = {
-  render: () => (
-    <Surface className="p-0 max-w-sm overflow-hidden">
-      <div className="aspect-video bg-surface-container" />
-      <div className="p-4">
-        <h3 className="text-base font-semibold text-on-surface">Card Title</h3>
-        <p className="text-sm text-on-surface-variant mt-1">
-          A brief description of the card content.
-        </p>
-        <div className="flex justify-end gap-2 mt-4">
-          <Button variant="text" size="sm">
-            Cancel
-          </Button>
-          <Button variant="filled" size="sm">
-            Action
-          </Button>
-        </div>
-      </div>
-    </Surface>
-  ),
-};
-
 export const Interactive: Story = {
   args: {
     interactive: true,
     children: "Hover over me — interactive surface with hover styles",
   },
-};
-
-export const InteractiveCard: Story = {
-  render: () => (
-    <Surface interactive className="p-0 max-w-sm overflow-hidden">
-      <div className="aspect-video bg-surface-container" />
-      <div className="p-4">
-        <h3 className="text-base font-semibold text-on-surface">
-          Clickable Card
-        </h3>
-        <p className="text-sm text-on-surface-variant mt-1">
-          An interactive surface that responds to hover.
-        </p>
-      </div>
-    </Surface>
-  ),
 };
 
 export const Nested: Story = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,10 @@ export {
   type SurfaceProps,
 } from "./components/ui/surfaces/surface/Surface";
 export {
+  Card,
+  type CardProps,
+} from "./components/ui/surfaces/card/Card";
+export {
   Avatar,
   type AvatarProps,
   type AvatarSize,


### PR DESCRIPTION
## Summary
- Extract the card layout pattern from Surface's `CardExample`/`InteractiveCard` stories into a reusable `Card` component
- Supports `media`, `children` (content), and `actions` slots with optional `interactive` and `className` props
- Composes `Surface` internally with `p-0 overflow-hidden` defaults

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 9 new tests covering children, media slot, actions slot, interactive prop, className merge, and all-slots-together
- [x] `pnpm components validate` — all 37 components valid
- [ ] Storybook: verify Playground, Default, Interactive, MediaOnly, NoActions, ContentOnly stories render correctly

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)