### PR TITLE
fix: NavDrawer h-full prevents vertical centering in AppShell

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/navigation/nav-drawer/NavDrawer.tsx
+++ b/src/components/ui/navigation/nav-drawer/NavDrawer.tsx
@@ -45,7 +45,7 @@ export function NavDrawer({
   return (
     <aside
       className={cn(
-        "w-72 shrink-0 h-full flex flex-col p-4 overflow-hidden",
+        "w-72 shrink-0 max-h-full flex flex-col p-4 overflow-hidden",
         className,
       )}
     >


### PR DESCRIPTION
## Summary
- Changed NavDrawer from `h-full` to `max-h-full`
- `h-full` filled the AppShell nav wrapper, making `justify-center` ineffective
- `max-h-full` lets NavDrawer take natural height (centerable) while still scrolling when tall

## Test plan
- [ ] Open Storybook → Layout/AppShell → WithNavDrawer — NavDrawer should be vertically centered
- [ ] web-account /me page — sidebar centered in viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)