### PR TITLE
feat(media): add AvatarCropper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "clsx": "^2.0.0",
+    "react-easy-crop": "^5.5.7",
     "tailwind-merge": "^2.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       clsx:
         specifier: ^2.0.0
         version: 2.1.1
+      react-easy-crop:
+        specifier: ^5.5.7
+        version: 5.5.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^2.0.0
         version: 2.6.1
@@ -1330,6 +1333,9 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-wheel@1.0.1:
+    resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
+
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
@@ -1405,6 +1411,12 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-easy-crop@5.5.7:
+    resolution: {integrity: sha512-kYo4NtMeXFQB7h1U+h5yhUkE46WQbQdq7if54uDlbMdZHdRgNehfvaFrXnFw5NR1PNoUOJIfTwLnWmEx/MaZnA==}
+    peerDependencies:
+      react: '>=16.4.0'
+      react-dom: '>=16.4.0'
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -2851,6 +2863,8 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  normalize-wheel@1.0.1: {}
+
   nwsapi@2.2.23: {}
 
   open@10.2.0:
@@ -2928,6 +2942,13 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-easy-crop@5.5.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      normalize-wheel: 1.0.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
 
   react-is@17.0.2: {}
 

--- a/src/components/ui/media/avatar-cropper/AvatarCropper.stories.tsx
+++ b/src/components/ui/media/avatar-cropper/AvatarCropper.stories.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { AvatarCropper } from "./AvatarCropper";
+import { Button } from "@/components/ui/actions/button/Button";
+
+const meta: Meta<typeof AvatarCropper> = {
+  title: "UI/Media/AvatarCropper",
+  component: AvatarCropper,
+};
+
+export default meta;
+type Story = StoryObj<typeof AvatarCropper>;
+
+export const Playground: Story = {
+  render: () => {
+    const [file, setFile] = useState<File | null>(null);
+    const [saving, setSaving] = useState(false);
+
+    return (
+      <div className="space-y-4">
+        <p className="text-sm text-on-surface-variant">
+          Pick an image to open the cropper. Save logs the cropped Blob to the console.
+        </p>
+        <input
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+        />
+        <Button variant="outline" onClick={() => setFile(null)}>
+          Reset
+        </Button>
+        <AvatarCropper
+          file={file}
+          saving={saving}
+          onCancel={() => setFile(null)}
+          onSave={async (blob) => {
+            setSaving(true);
+            // Simulate an upload roundtrip so the loading state is visible.
+            await new Promise((r) => setTimeout(r, 800));
+            // eslint-disable-next-line no-console
+            console.log("cropped blob", blob);
+            setSaving(false);
+            setFile(null);
+          }}
+        />
+      </div>
+    );
+  },
+};

--- a/src/components/ui/media/avatar-cropper/AvatarCropper.stories.tsx
+++ b/src/components/ui/media/avatar-cropper/AvatarCropper.stories.tsx
@@ -84,11 +84,14 @@ export const Playground: Story = {
           onCancel={() => setPendingFile(null)}
           onSave={async (blob) => {
             setSaving(true);
-            // Simulate an upload roundtrip so the loading state is visible.
-            await new Promise((r) => setTimeout(r, 600));
-            setResultUrl(URL.createObjectURL(blob));
-            setSaving(false);
-            setPendingFile(null);
+            try {
+              // Simulate an upload roundtrip so the loading state is visible.
+              await new Promise((r) => setTimeout(r, 600));
+              setResultUrl(URL.createObjectURL(blob));
+              setPendingFile(null);
+            } finally {
+              setSaving(false);
+            }
           }}
         />
       </div>

--- a/src/components/ui/media/avatar-cropper/AvatarCropper.stories.tsx
+++ b/src/components/ui/media/avatar-cropper/AvatarCropper.stories.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { AvatarCropper } from "./AvatarCropper";
+import { Avatar } from "@/components/ui/media/avatar/Avatar";
 import { Button } from "@/components/ui/actions/button/Button";
 
 const meta: Meta<typeof AvatarCropper> = {
@@ -13,34 +14,81 @@ type Story = StoryObj<typeof AvatarCropper>;
 
 export const Playground: Story = {
   render: () => {
-    const [file, setFile] = useState<File | null>(null);
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [pendingFile, setPendingFile] = useState<File | null>(null);
     const [saving, setSaving] = useState(false);
+    const [resultUrl, setResultUrl] = useState<string | null>(null);
+
+    // Object URL for the result preview — revoke on replacement / unmount
+    // so we don't leak Blob references in long-running dev sessions.
+    useEffect(() => {
+      if (!resultUrl) return;
+      return () => URL.revokeObjectURL(resultUrl);
+    }, [resultUrl]);
+
+    const onPick = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) setPendingFile(file);
+      e.target.value = "";
+    };
 
     return (
-      <div className="space-y-4">
+      <div className="space-y-6">
         <p className="text-sm text-on-surface-variant">
-          Pick an image to open the cropper. Save logs the cropped Blob to the console.
+          Pick a photo, drag/zoom to crop, then Save. The cropped result renders
+          below — same flow a consuming app would wire to an upload endpoint.
         </p>
+
+        <div className="flex items-center gap-4">
+          <Avatar
+            src={resultUrl ?? undefined}
+            fallback="A"
+            size="xl"
+          />
+          <div className="flex flex-col gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => inputRef.current?.click()}
+              loading={saving}
+            >
+              {resultUrl ? "Replace photo" : "Choose photo"}
+            </Button>
+            {resultUrl && (
+              <Button
+                variant="text"
+                size="sm"
+                onClick={() => setResultUrl(null)}
+                disabled={saving}
+              >
+                Reset
+              </Button>
+            )}
+            <p className="text-xs text-on-surface-variant">
+              JPEG, PNG, or WebP · Max 5 MB
+            </p>
+          </div>
+        </div>
+
         <input
+          ref={inputRef}
           type="file"
           accept="image/jpeg,image/png,image/webp"
-          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+          onChange={onPick}
+          className="hidden"
         />
-        <Button variant="outline" onClick={() => setFile(null)}>
-          Reset
-        </Button>
+
         <AvatarCropper
-          file={file}
+          file={pendingFile}
           saving={saving}
-          onCancel={() => setFile(null)}
+          onCancel={() => setPendingFile(null)}
           onSave={async (blob) => {
             setSaving(true);
             // Simulate an upload roundtrip so the loading state is visible.
-            await new Promise((r) => setTimeout(r, 800));
-            // eslint-disable-next-line no-console
-            console.log("cropped blob", blob);
+            await new Promise((r) => setTimeout(r, 600));
+            setResultUrl(URL.createObjectURL(blob));
             setSaving(false);
-            setFile(null);
+            setPendingFile(null);
           }}
         />
       </div>

--- a/src/components/ui/media/avatar-cropper/AvatarCropper.test.tsx
+++ b/src/components/ui/media/avatar-cropper/AvatarCropper.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { AvatarCropper, meta } from "./AvatarCropper";
+
+// jsdom doesn't implement URL.createObjectURL/revokeObjectURL — stub them
+// so the lifecycle effect runs without throwing.
+beforeAll(() => {
+  if (!URL.createObjectURL) {
+    URL.createObjectURL = vi.fn(() => "blob:mock");
+  }
+  if (!URL.revokeObjectURL) {
+    URL.revokeObjectURL = vi.fn();
+  }
+});
+
+afterEach(cleanup);
+
+// react-easy-crop renders a Cropper component that needs a layout-aware
+// environment; jsdom doesn't supply that, but we can still verify the
+// surface contract: open/closed states, action handlers, and the meta
+// export. The Cropper internals are exercised end-to-end in the
+// consuming app's manual smoke tests.
+vi.mock("react-easy-crop", () => ({
+  default: () => <div data-testid="cropper-mock" />,
+}));
+
+describe("AvatarCropper", () => {
+  it("exports a ComponentMeta", () => {
+    expect(meta.name).toBe("AvatarCropper");
+    expect(typeof meta.description).toBe("string");
+  });
+
+  it("renders nothing when file is null", () => {
+    render(<AvatarCropper file={null} onCancel={() => {}} onSave={() => {}} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders dialog when file is provided", () => {
+    const file = new File([new Uint8Array(64)], "x.jpg", { type: "image/jpeg" });
+    render(<AvatarCropper file={file} onCancel={() => {}} onSave={() => {}} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Adjust avatar")).toBeInTheDocument();
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
+    expect(screen.getByText("Save")).toBeInTheDocument();
+  });
+
+  it("respects custom title prop", () => {
+    const file = new File([new Uint8Array(64)], "x.jpg", { type: "image/jpeg" });
+    render(
+      <AvatarCropper file={file} onCancel={() => {}} onSave={() => {}} title="Pick crop" />,
+    );
+    expect(screen.getByText("Pick crop")).toBeInTheDocument();
+  });
+
+  it("Save button starts disabled (image not yet decoded in jsdom)", () => {
+    const file = new File([new Uint8Array(64)], "x.jpg", { type: "image/jpeg" });
+    render(<AvatarCropper file={file} onCancel={() => {}} onSave={() => {}} />);
+    // jsdom doesn't fire <img> onload, so imageReady stays false.
+    const save = screen.getByRole("button", { name: "Save" });
+    expect(save).toBeDisabled();
+  });
+
+  it("Cancel button reflects saving prop", () => {
+    const file = new File([new Uint8Array(64)], "x.jpg", { type: "image/jpeg" });
+    render(<AvatarCropper file={file} saving onCancel={() => {}} onSave={() => {}} />);
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    expect(cancel).toBeDisabled();
+  });
+});

--- a/src/components/ui/media/avatar-cropper/AvatarCropper.tsx
+++ b/src/components/ui/media/avatar-cropper/AvatarCropper.tsx
@@ -1,0 +1,185 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import Cropper from "react-easy-crop";
+import type { Area, Point } from "react-easy-crop";
+import { Dialog } from "@/components/ui/surfaces/dialog/Dialog";
+import { isDev } from "@/utils/env";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "AvatarCropper",
+  description:
+    "Modal dialog for cropping a picked image to a circular avatar. Drag to reposition, scroll/pinch to zoom. Outputs a cropped Blob via the onSave callback.",
+};
+
+export interface AvatarCropperProps {
+  /**
+   * The picked file. The dialog is open when this is non-null and closed
+   * when null. Passing a new File resets the crop offset and re-decodes.
+   */
+  file: File | null;
+  onCancel: () => void;
+  onSave: (cropped: Blob) => void | Promise<void>;
+  /**
+   * When true, the dialog stays open and Save is disabled — useful while
+   * the parent runs an async upload. Cancel is also disabled to avoid
+   * dropping the source file mid-upload.
+   */
+  saving?: boolean;
+  /**
+   * Output dimensions in pixels (square). Defaults to 512, the standard
+   * profile-photo ceiling — large enough to downscale for any UI surface,
+   * small enough that JPEG @ 0.9 quality is well under typical upload caps.
+   */
+  outputSize?: number;
+  /**
+   * JPEG/WebP encoding quality (0–1). Ignored for PNG. Defaults to 0.9.
+   */
+  quality?: number;
+  /** Optional title override. Defaults to "Adjust avatar". */
+  title?: string;
+}
+
+export function AvatarCropper({
+  file,
+  onCancel,
+  onSave,
+  saving,
+  outputSize = 512,
+  quality = 0.9,
+  title = "Adjust avatar",
+}: AvatarCropperProps) {
+  const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [croppedArea, setCroppedArea] = useState<Area | null>(null);
+
+  // Object URL + decoded image lifecycle.
+  //
+  // Both URL creation and image decode live in a single effect so the
+  // cleanup closure captures the exact URL that was created (useMemo +
+  // separate cleanup can leak under StrictMode's double-invoke). The
+  // decoded HTMLImageElement is cached in a ref so produceCroppedBlob
+  // doesn't re-decode on every Save click.
+  const [imageUrl, setImageUrl] = useState("");
+  const [imageReady, setImageReady] = useState(false);
+  const imageElementRef = useRef<HTMLImageElement | null>(null);
+
+  useEffect(() => {
+    if (!file) {
+      setImageUrl("");
+      setImageReady(false);
+      imageElementRef.current = null;
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    setImageUrl(url);
+    setImageReady(false);
+
+    const img = new Image();
+    img.onload = () => {
+      imageElementRef.current = img;
+      setImageReady(true);
+    };
+    img.onerror = () => {
+      // Save stays disabled (imageReady false). Cancel still works.
+      // Surfacing here would mean a callback prop the consumer didn't
+      // ask for; staying quiet is more in line with the dialog's
+      // input-only contract.
+      imageElementRef.current = null;
+      if (isDev) {
+        console.warn("[AvatarCropper] failed to decode image; Save is disabled");
+      }
+    };
+    img.src = url;
+
+    return () => {
+      URL.revokeObjectURL(url);
+      imageElementRef.current = null;
+    };
+  }, [file]);
+
+  // Reset crop/zoom when a new file arrives — without this, opening for
+  // a second file inherits the prior offset.
+  useEffect(() => {
+    setCrop({ x: 0, y: 0 });
+    setZoom(1);
+    setCroppedArea(null);
+  }, [file]);
+
+  const onCropComplete = useCallback((_: Area, areaPixels: Area) => {
+    setCroppedArea(areaPixels);
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    const img = imageElementRef.current;
+    if (!file || !croppedArea || !img) return;
+    const blob = await produceCroppedBlob(img, croppedArea, file.type, outputSize, quality);
+    if (blob) await onSave(blob);
+  }, [file, croppedArea, onSave, outputSize, quality]);
+
+  const saveDisabled = !!saving || !imageReady;
+
+  return (
+    <Dialog
+      open={file !== null}
+      onClose={saving ? undefined : onCancel}
+      title={title}
+      actions={[
+        { label: "Cancel", variant: "text", onClick: onCancel, disabled: saving },
+        {
+          label: "Save",
+          variant: "filled",
+          onClick: handleSave,
+          loading: saving,
+          disabled: saveDisabled,
+        },
+      ]}
+    >
+      <div className="relative w-full h-80 bg-surface-container">
+        {imageUrl && (
+          <Cropper
+            image={imageUrl}
+            crop={crop}
+            zoom={zoom}
+            aspect={1}
+            cropShape="round"
+            showGrid={false}
+            onCropChange={setCrop}
+            onZoomChange={setZoom}
+            onCropComplete={onCropComplete}
+          />
+        )}
+      </div>
+      <p className="text-xs text-on-surface-variant mt-3">
+        Drag to reposition, scroll or pinch to zoom.
+      </p>
+    </Dialog>
+  );
+}
+
+async function produceCroppedBlob(
+  img: HTMLImageElement,
+  area: Area,
+  mimeType: string,
+  outputSize: number,
+  quality: number,
+): Promise<Blob | null> {
+  const canvas = document.createElement("canvas");
+  canvas.width = outputSize;
+  canvas.height = outputSize;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  ctx.drawImage(
+    img,
+    area.x,
+    area.y,
+    area.width,
+    area.height,
+    0,
+    0,
+    outputSize,
+    outputSize,
+  );
+  return new Promise((resolve) => {
+    canvas.toBlob((b) => resolve(b), mimeType, quality);
+  });
+}

--- a/src/components/ui/media/avatar-cropper/AvatarCropper.tsx
+++ b/src/components/ui/media/avatar-cropper/AvatarCropper.tsx
@@ -70,20 +70,24 @@ export function AvatarCropper({
       imageElementRef.current = null;
       return;
     }
+    // aborted gates the load callbacks against rapid file change.
+    // Without it, an in-flight onload from a previous file can fire
+    // after this effect's cleanup ran, restoring a stale (revoked-URL)
+    // image element and re-enabling Save against broken bytes.
+    let aborted = false;
     const url = URL.createObjectURL(file);
     setImageUrl(url);
     setImageReady(false);
 
     const img = new Image();
     img.onload = () => {
+      if (aborted) return;
       imageElementRef.current = img;
       setImageReady(true);
     };
     img.onerror = () => {
+      if (aborted) return;
       // Save stays disabled (imageReady false). Cancel still works.
-      // Surfacing here would mean a callback prop the consumer didn't
-      // ask for; staying quiet is more in line with the dialog's
-      // input-only contract.
       imageElementRef.current = null;
       if (isDev) {
         console.warn("[AvatarCropper] failed to decode image; Save is disabled");
@@ -92,6 +96,7 @@ export function AvatarCropper({
     img.src = url;
 
     return () => {
+      aborted = true;
       URL.revokeObjectURL(url);
       imageElementRef.current = null;
     };
@@ -112,8 +117,18 @@ export function AvatarCropper({
   const handleSave = useCallback(async () => {
     const img = imageElementRef.current;
     if (!file || !croppedArea || !img) return;
-    const blob = await produceCroppedBlob(img, croppedArea, file.type, outputSize, quality);
-    if (blob) await onSave(blob);
+    try {
+      const blob = await produceCroppedBlob(img, croppedArea, file.type, outputSize, quality);
+      if (blob) await onSave(blob);
+    } catch (err) {
+      // onSave's lifecycle (saving prop, error UI) is the consumer's
+      // contract — we catch here to keep an async rejection from
+      // bubbling out of Dialog's sync onClick as an unhandled
+      // rejection.
+      if (isDev) {
+        console.warn("[AvatarCropper] onSave threw; consumer should handle:", err);
+      }
+    }
   }, [file, croppedArea, onSave, outputSize, quality]);
 
   const saveDisabled = !!saving || !imageReady;

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,10 @@ export {
   type AvatarProps,
   type AvatarSize,
 } from "./components/ui/media/avatar/Avatar";
+export {
+  AvatarCropper,
+  type AvatarCropperProps,
+} from "./components/ui/media/avatar-cropper/AvatarCropper";
 export { Logo, type LogoProps } from "./components/ui/media/logo-mirrorstack/LogoMirrorStack";
 export {
   Combobox,


### PR DESCRIPTION
## Summary

Adds \`AvatarCropper\` to the media category — a modal dialog that wraps `react-easy-crop` and produces a cropped Blob via callback. Extracted from web-account where it was prototyped locally; lifting to the kit so other apps (web-applications, future modules) can reuse the same UX.

## API

```tsx
<AvatarCropper
  file={pickedFile}              // null = closed; File = open
  onCancel={() => setFile(null)}
  onSave={async (blob) => upload(blob)}
  saving={uploading}             // optional — blocks Cancel + disables Save
  outputSize={512}               // optional override (default 512)
  quality={0.9}                  // optional JPEG/WebP quality
  title="Adjust avatar"          // optional override
/>
```

## Implementation notes

- **Object URL + decoded image** live in a single `useEffect` so the cleanup closure captures the exact URL that was created. `useMemo` + separate cleanup can leak under StrictMode's double-invoke.
- **Decoded `HTMLImageElement` is cached** in a ref; `Save` uses it directly instead of re-decoding on every click.
- **Save is disabled until `imageReady`** AND while `saving` — prevents click-before-ready and rapid double-click.
- **Output MIME matches input** (jpeg/png/webp) so we don't force a transcode.
- Adds `react-easy-crop` (~10KB gzipped) to runtime deps.

## Tests

6 unit tests via vitest + jsdom:
- `meta` export shape
- Closed when `file === null`
- Open + renders Cancel/Save when file provided
- Custom title prop works
- Save starts disabled (image hasn't decoded in jsdom)
- `saving` prop disables Cancel

`react-easy-crop` is mocked because its `Cropper` needs a layout-aware environment jsdom doesn't supply. End-to-end exercise happens in the consuming app's smoke tests.

## Component validation

- \`pnpm typecheck\` clean
- \`pnpm test\` — 322/322 passing
- \`pnpm build\` clean
- \`pnpm components validate\` — all 38 components have valid metadata (incl. AvatarCropper)

## Migration plan

After this merges + a new web-ui-kit version is published:
1. \`web-account\` PR: bump kit version, swap local \`AvatarCropper\` → kit import, remove local copy
2. (Future) \`web-applications\` and modules can adopt the same import