### PR TITLE
feat: themed scrollbar styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/theme.css
+++ b/src/theme.css
@@ -246,6 +246,42 @@ body {
   50% { transform: scaleY(1); }
 }
 
+/* Scrollbar — themed to match design tokens.
+   Chromium 121+: when `scrollbar-color` is set, it overrides
+   ::-webkit-scrollbar* rules entirely (so border-padding tricks fail).
+   Gate the modern API to Firefox only; let Chromium use the webkit
+   pseudo-elements below. */
+@supports not selector(::-webkit-scrollbar-thumb) {
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-outline-variant) transparent;
+  }
+}
+
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: var(--color-outline-variant);
+  border: 2px solid transparent;
+  background-clip: padding-box;
+  border-radius: 9999px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: var(--color-outline);
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
 /* Material Symbols Rounded */
 .material-symbols-rounded {
   font-family: "Material Symbols Rounded";


### PR DESCRIPTION
## Summary
- Themed scrollbar that auto-flips for light/dark mode using design tokens
- Rounded pill thumb (border-radius: 9999px), 10px wide, hover-brightens
- Gates modern \`scrollbar-color\` / \`scrollbar-width\` behind \`@supports not selector(::-webkit-scrollbar-thumb)\` so Chromium 121+ falls through to webkit pseudo-elements (the modern API silently overrides them otherwise)
- Bumps version 0.2.2 → 0.2.3

## Test plan
- [x] \`pnpm typecheck\` passes
- [x] Pre-existing ThemeProvider test failures unrelated to this change (verified on main)
- [ ] Visual check after publish in web-account / web-applications

🤖 Generated with [Claude Code](https://claude.com/claude-code)