### PR TITLE
feat: SettingRow + Tone (0.2.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/data/setting-row/SettingRow.stories.tsx
+++ b/src/components/ui/data/setting-row/SettingRow.stories.tsx
@@ -23,7 +23,7 @@ const meta: Meta<typeof SettingRow> = {
 export default meta;
 type Story = StoryObj<typeof SettingRow>;
 
-export const Default: Story = {};
+export const Playground: Story = {};
 
 export const Warning: Story = {
   args: { tone: "warning" },

--- a/src/components/ui/data/setting-row/SettingRow.stories.tsx
+++ b/src/components/ui/data/setting-row/SettingRow.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SettingRow } from "./SettingRow";
+import { Switch } from "@/components/ui/inputs/switch/Switch";
+import { Button } from "@/components/ui/actions/button/Button";
+
+const meta: Meta<typeof SettingRow> = {
+  title: "UI/Data/SettingRow",
+  component: SettingRow,
+  args: {
+    title: "Developer mode",
+    description:
+      "Show the developer rail with module scaffolding, dev tunnel, and federation overrides.",
+    control: <Switch checked={false} onChange={() => {}} aria-label="Developer mode" />,
+  },
+  argTypes: {
+    tone: {
+      control: "select",
+      options: [undefined, "primary", "secondary", "tertiary", "error", "warning", "success", "info"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SettingRow>;
+
+export const Default: Story = {};
+
+export const Warning: Story = {
+  args: { tone: "warning" },
+};
+
+export const Error: Story = {
+  args: {
+    title: "Disable account",
+    description:
+      "Sign out and put your account in a suspended state. Use the email link to restore later.",
+    tone: "error",
+    control: (
+      <Button variant="filled" color="error" size="sm" onClick={() => {}}>
+        Disable
+      </Button>
+    ),
+  },
+};
+
+export const Success: Story = {
+  args: { tone: "success", title: "Two-factor authentication", description: "Enabled with an authenticator app." },
+};
+
+export const NoDescription: Story = {
+  args: { description: undefined },
+};

--- a/src/components/ui/data/setting-row/SettingRow.test.tsx
+++ b/src/components/ui/data/setting-row/SettingRow.test.tsx
@@ -1,0 +1,65 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SettingRow } from "./SettingRow";
+
+afterEach(cleanup);
+
+describe("SettingRow", () => {
+  it("renders title and description", () => {
+    render(
+      <SettingRow
+        title="Developer mode"
+        description="Show the developer rail."
+        control={<button>toggle</button>}
+      />,
+    );
+    expect(screen.getByText("Developer mode")).toBeInTheDocument();
+    expect(screen.getByText("Show the developer rail.")).toBeInTheDocument();
+  });
+
+  it("renders the control slot", () => {
+    render(
+      <SettingRow
+        title="Beta program"
+        control={<button>my-control</button>}
+      />,
+    );
+    expect(screen.getByText("my-control")).toBeInTheDocument();
+  });
+
+  it("omits the description block when not provided", () => {
+    const { container } = render(
+      <SettingRow title="Title only" control={<span>x</span>} />,
+    );
+    expect(container.querySelectorAll("p").length).toBe(1);
+  });
+
+  it("applies the neutral border by default", () => {
+    const { container } = render(
+      <SettingRow title="X" control={<span />} />,
+    );
+    expect(container.firstChild).toHaveClass("border-outline-variant");
+  });
+
+  it.each([
+    ["primary", "border-primary/40"],
+    ["secondary", "border-secondary/40"],
+    ["tertiary", "border-tertiary/40"],
+    ["error", "border-error/40"],
+    ["warning", "border-warning/40"],
+    ["success", "border-success/40"],
+    ["info", "border-info/40"],
+  ] as const)("applies the %s tone border", (tone, expected) => {
+    const { container } = render(
+      <SettingRow title="X" control={<span />} tone={tone} />,
+    );
+    expect(container.firstChild).toHaveClass(expected);
+  });
+
+  it("forwards the className prop", () => {
+    const { container } = render(
+      <SettingRow title="X" control={<span />} className="custom-class" />,
+    );
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+});

--- a/src/components/ui/data/setting-row/SettingRow.tsx
+++ b/src/components/ui/data/setting-row/SettingRow.tsx
@@ -1,0 +1,53 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { toneBorderClass, type Tone } from "@/types/tone";
+
+export const meta: ComponentMeta = {
+  name: "SettingRow",
+  description:
+    "Title + optional description on the left, control slot on the right. Used to compose settings forms; supports an optional tone for warning/error/success/info accents.",
+};
+
+export interface SettingRowProps {
+  /** Primary heading for the row. */
+  title: string;
+  /** Optional supporting copy, rendered below the title. */
+  description?: string;
+  /** Right-aligned control — typically a Switch, Button, or status pill. */
+  control: ReactNode;
+  /**
+   * When set, applies a colored border accent matching the tone. Default
+   * (omitted) renders with the neutral outline-variant border.
+   */
+  tone?: Tone;
+  className?: string;
+}
+
+export function SettingRow({
+  title,
+  description,
+  control,
+  tone,
+  className,
+}: SettingRowProps) {
+  const border = tone ? toneBorderClass[tone] : "border-outline-variant";
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-4 px-3.5 py-3 rounded-xl border bg-surface-container",
+        border,
+        className,
+      )}
+    >
+      <div className="min-w-0 flex-1 space-y-1.5">
+        <p className="text-sm font-medium text-on-surface">{title}</p>
+        {description && (
+          <p className="text-xs text-on-surface-variant">{description}</p>
+        )}
+      </div>
+      <div className="shrink-0">{control}</div>
+    </div>
+  );
+}

--- a/src/components/ui/data/setting-row/SettingRow.tsx
+++ b/src/components/ui/data/setting-row/SettingRow.tsx
@@ -47,7 +47,7 @@ export function SettingRow({
           <p className="text-xs text-on-surface-variant">{description}</p>
         )}
       </div>
-      <div className="shrink-0">{control}</div>
+      <div className="shrink-0 flex items-center">{control}</div>
     </div>
   );
 }

--- a/src/components/ui/inputs/combobox/Combobox.tsx
+++ b/src/components/ui/inputs/combobox/Combobox.tsx
@@ -242,7 +242,7 @@ export function Combobox({
               inputRef.current?.focus();
             }
           }}
-          className="absolute right-3 p-1 text-on-surface-variant hover:text-primary transition-colors"
+          className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-on-surface-variant hover:text-primary transition-colors"
         >
           <Icon
             name="expand_more"

--- a/src/components/ui/inputs/combobox/Combobox.tsx
+++ b/src/components/ui/inputs/combobox/Combobox.tsx
@@ -242,7 +242,7 @@ export function Combobox({
               inputRef.current?.focus();
             }
           }}
-          className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-on-surface-variant hover:text-primary transition-colors"
+          className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center justify-center p-1 text-on-surface-variant hover:text-primary transition-colors"
         >
           <Icon
             name="expand_more"

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,11 @@ export {
   type ReadOnlyFieldProps,
 } from "./components/ui/data/read-only-field/ReadOnlyField";
 export {
+  SettingRow,
+  type SettingRowProps,
+} from "./components/ui/data/setting-row/SettingRow";
+export { type Tone, toneBorderClass, toneTextClass } from "./types/tone";
+export {
   ThemeProvider,
   useTheme,
   type ThemeProviderProps,

--- a/src/types/tone.ts
+++ b/src/types/tone.ts
@@ -1,0 +1,40 @@
+// Tone is the shared severity/emphasis vocabulary across components
+// that change border / text / background color to convey state. Each
+// value maps to a corresponding theme token (e.g. `primary` →
+// `--color-primary`).
+//
+// Component-specific color props (SwitchColor, ButtonColor) stay
+// separate when they carry different valid sets — Tone is the
+// superset useful for surfaces that don't have role-specific
+// constraints.
+export type Tone =
+  | "primary"
+  | "secondary"
+  | "tertiary"
+  | "error"
+  | "warning"
+  | "success"
+  | "info";
+
+// Each map uses Tailwind's `<color>/40` opacity for borders so the
+// accent stays subtle against the surface background; text maps keep
+// full opacity for readability.
+export const toneBorderClass: Record<Tone, string> = {
+  primary: "border-primary/40",
+  secondary: "border-secondary/40",
+  tertiary: "border-tertiary/40",
+  error: "border-error/40",
+  warning: "border-warning/40",
+  success: "border-success/40",
+  info: "border-info/40",
+};
+
+export const toneTextClass: Record<Tone, string> = {
+  primary: "text-primary",
+  secondary: "text-secondary",
+  tertiary: "text-tertiary",
+  error: "text-error",
+  warning: "text-warning",
+  success: "text-success",
+  info: "text-info",
+};


### PR DESCRIPTION
Promotes the danger-zone row pattern from web-account#30 into a generic primitive, and adds a shared Tone vocabulary so other components/consumers can use the same severity classes.

## What's new

### \`<SettingRow>\`
Title + optional description on the left, control slot on the right, optional tone for warning/error/success/etc. border accent. Matches the row used today in \`web-account/me/security\` (developer mode, beta program, disable account).

\`\`\`tsx
<SettingRow
  title="Developer mode"
  description="Show the dev rail in apps.mirrorstack.ai…"
  control={<Switch checked={developerMode} onChange={setDeveloperMode} color="warning" aria-label="Developer mode" />}
  tone="warning"
/>
\`\`\`

### \`Tone\` type
\`\`\`ts
type Tone = "primary" | "secondary" | "tertiary" | "error" | "warning" | "success" | "info";
\`\`\`
Plus exported helper records — \`toneBorderClass\` and \`toneTextClass\` — for non-kit consumers composing tone-aware surfaces.

## Tests
\`SettingRow.test.tsx\` (8 cases): renders title + description, renders control slot, omits description block when undefined, neutral border default, all 7 tones map to the correct border class, className forwarding.

## Bump
\`0.2.3 → 0.2.4\`. Patch per the pre-1.0 versioning convention (bump even for new components).

## Out of scope (follow-ups)
- web-account refactor: replace local \`DangerRow\` with \`SettingRow\` + drop the local tone union (separate PR).
- \`SectionLabel\` could gain a \`tone?: Tone\` prop next to drop \`className="text-warning"\` ergonomics — not blocking.
- \`ConfirmDialog\` wrapper — defer until a 3rd usage materializes.

## Note on local test failures
\`ThemeProvider.test.tsx\` 4 cases fail locally with \`localStorage.clear is not a function\` — pre-existing on \`origin/main\`, reproduces with no code from this branch checked out. It's a Node 25 + jsdom 25.0.1 env mismatch. CI on Node 20/22 is green. Not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)