### PR TITLE
feat: Alert hideIcon + bump Dialog above docked sidebar (0.2.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -159,7 +159,7 @@ function AppShellInner({
               </div>
             )}
 
-            <div className="flex-1 min-w-0 flex flex-col h-full overflow-hidden relative">
+            <div className="flex-1 min-w-0 flex flex-col h-full overflow-hidden relative py-4">
               <main className="relative flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
                 <div
                   className={cn(

--- a/src/components/ui/feedback/alert/Alert.stories.tsx
+++ b/src/components/ui/feedback/alert/Alert.stories.tsx
@@ -58,3 +58,13 @@ export const WithCustomIcon: Story = {
     children: "Set up a passkey for faster verification next time.",
   },
 };
+
+export const HideIcon: Story = {
+  args: {
+    variant: "error",
+    title: "Before you continue",
+    hideIcon: true,
+    children:
+      "Useful when the surrounding container (like a destructive Dialog) already conveys severity and a leading icon would crowd the title.",
+  },
+};

--- a/src/components/ui/feedback/alert/Alert.test.tsx
+++ b/src/components/ui/feedback/alert/Alert.test.tsx
@@ -74,4 +74,15 @@ describe("Alert", () => {
     render(<Alert variant="info">Default size</Alert>);
     expect(screen.getByText("info")).toHaveStyle({ fontSize: "20px" });
   });
+
+  it("hides leading icon when hideIcon is set", () => {
+    render(
+      <Alert variant="error" hideIcon>
+        Hidden icon
+      </Alert>,
+    );
+    // The variant-default icon name "error" should not render as a child.
+    expect(screen.queryByText("error")).not.toBeInTheDocument();
+    expect(screen.getByText("Hidden icon")).toBeInTheDocument();
+  });
 });

--- a/src/components/ui/feedback/alert/Alert.test.tsx
+++ b/src/components/ui/feedback/alert/Alert.test.tsx
@@ -75,7 +75,7 @@ describe("Alert", () => {
     expect(screen.getByText("info")).toHaveStyle({ fontSize: "20px" });
   });
 
-  it("hides leading icon when hideIcon is set", () => {
+  it("hides leading icon and drops content margin when hideIcon is set", () => {
     render(
       <Alert variant="error" hideIcon>
         Hidden icon
@@ -83,6 +83,9 @@ describe("Alert", () => {
     );
     // The variant-default icon name "error" should not render as a child.
     expect(screen.queryByText("error")).not.toBeInTheDocument();
-    expect(screen.getByText("Hidden icon")).toBeInTheDocument();
+    const text = screen.getByText("Hidden icon");
+    // Without an icon there's nothing to offset, so the content container
+    // must drop its ml-3 — otherwise the alert sits with phantom left padding.
+    expect(text.parentElement).not.toHaveClass("ml-3");
   });
 });

--- a/src/components/ui/feedback/alert/Alert.tsx
+++ b/src/components/ui/feedback/alert/Alert.tsx
@@ -22,6 +22,9 @@ export interface AlertProps {
   icon?: string;
   /** Override the default icon size (default: 20). */
   iconSize?: number;
+  /** Hide the leading icon entirely. Useful when the alert sits inside a
+   * dialog or section that already conveys severity. */
+  hideIcon?: boolean;
 }
 
 const variantStyles: Record<AlertVariant, string> = {
@@ -46,6 +49,7 @@ export function Alert({
   onDismiss,
   icon,
   iconSize,
+  hideIcon,
 }: AlertProps) {
   return (
     <div
@@ -57,12 +61,14 @@ export function Alert({
       role="alert"
     >
       <div className="flex items-center">
-        <Icon
-          name={icon ?? variantIcons[variant]}
-          size={iconSize ?? 20}
-          className="shrink-0"
-        />
-        <div className="ml-3 flex-1">
+        {!hideIcon && (
+          <Icon
+            name={icon ?? variantIcons[variant]}
+            size={iconSize ?? 20}
+            className="shrink-0"
+          />
+        )}
+        <div className={cn("flex-1", !hideIcon && "ml-3")}>
           {title && <h3 className="text-sm font-medium">{title}</h3>}
           <div className={cn("text-sm", title && "mt-1")}>{children}</div>
         </div>

--- a/src/components/ui/feedback/alert/Alert.tsx
+++ b/src/components/ui/feedback/alert/Alert.tsx
@@ -70,7 +70,7 @@ export function Alert({
         )}
         <div className={cn("flex-1", !hideIcon && "ml-3")}>
           {title && <h3 className="text-sm font-medium">{title}</h3>}
-          <div className={cn("text-sm", title && "mt-1")}>{children}</div>
+          <div className={cn("text-sm", title && "mt-1.5")}>{children}</div>
         </div>
         {onDismiss && (
           <IconButton

--- a/src/components/ui/feedback/consequences-notice/ConsequencesNotice.stories.tsx
+++ b/src/components/ui/feedback/consequences-notice/ConsequencesNotice.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ConsequencesNotice } from "./ConsequencesNotice";
+
+const meta: Meta<typeof ConsequencesNotice> = {
+  title: "UI/Feedback/ConsequencesNotice",
+  component: ConsequencesNotice,
+  args: {
+    title: "Before you continue",
+    items: [
+      "You'll be signed out of every device immediately.",
+      "API tokens and modules linked to this account stop working.",
+      <>
+        You can restore the account within <strong>90 days</strong> via the
+        email link we send.
+      </>,
+      "After 90 days, the account and its data are permanently deleted.",
+    ],
+  },
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["error", "warning", "info", "success"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ConsequencesNotice>;
+
+export const Playground: Story = {};
+
+export const Warning: Story = {
+  args: {
+    variant: "warning",
+    title: "Heads up",
+    items: [
+      "This rotation invalidates all existing tokens.",
+      "Any module currently authenticating with the old token will fail until redeployed.",
+    ],
+  },
+};
+
+export const AppDeletion: Story = {
+  args: {
+    title: "Deleting this app will:",
+    items: [
+      "Stop all running modules associated with the app.",
+      "Revoke API tokens scoped to this app.",
+      <>
+        Schedule the app's data for deletion in <strong>30 days</strong>.
+      </>,
+      "Cancel any active subscriptions.",
+    ],
+  },
+};

--- a/src/components/ui/feedback/consequences-notice/ConsequencesNotice.test.tsx
+++ b/src/components/ui/feedback/consequences-notice/ConsequencesNotice.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ConsequencesNotice } from "./ConsequencesNotice";
+
+afterEach(cleanup);
+
+describe("ConsequencesNotice", () => {
+  it("renders the title and a bullet per item", () => {
+    render(
+      <ConsequencesNotice
+        title="Before you continue"
+        items={["First consequence", "Second consequence"]}
+      />,
+    );
+    expect(screen.getByText("Before you continue")).toBeInTheDocument();
+    expect(screen.getByText("First consequence")).toBeInTheDocument();
+    expect(screen.getByText("Second consequence")).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+  });
+
+  it("accepts ReactNode items so callers can embed strong/links", () => {
+    render(
+      <ConsequencesNotice
+        title="t"
+        items={[
+          <>
+            You can restore within <strong>90 days</strong>.
+          </>,
+        ]}
+      />,
+    );
+    expect(screen.getByText("90 days").tagName).toBe("STRONG");
+  });
+
+  it("hides the leading variant icon (delegates to Alert hideIcon)", () => {
+    render(<ConsequencesNotice title="t" items={["x"]} />);
+    // The error variant's default icon is "error" — should not appear.
+    expect(screen.queryByText("error")).not.toBeInTheDocument();
+  });
+
+  it("uses error variant by default and accepts an override", () => {
+    const { rerender } = render(<ConsequencesNotice title="t" items={["x"]} />);
+    expect(screen.getByRole("alert")).toHaveClass("text-error");
+    rerender(
+      <ConsequencesNotice title="t" items={["x"]} variant="warning" />,
+    );
+    expect(screen.getByRole("alert")).toHaveClass("text-warning");
+  });
+});

--- a/src/components/ui/feedback/consequences-notice/ConsequencesNotice.tsx
+++ b/src/components/ui/feedback/consequences-notice/ConsequencesNotice.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+
+import { Alert, type AlertVariant } from "@/components/ui/feedback/alert/Alert";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "ConsequencesNotice",
+  description:
+    "Bulleted Alert used inside destructive confirm dialogs and danger-zone surfaces. Wraps Alert with hideIcon so the surrounding container's title carries the severity.",
+};
+
+export interface ConsequencesNoticeProps {
+  /**
+   * Visual tone. Defaults to "error" since the component's primary use is
+   * destructive confirms; pass "warning" for reversible-but-noteworthy
+   * actions (rotating a key, toggling beta).
+   */
+  variant?: AlertVariant;
+  /**
+   * Heading. Required so the kit doesn't ship product copy — callers
+   * supply something contextual (e.g. "Before you continue", "Deleting
+   * this app will:", "Heads up").
+   */
+  title: string;
+  /** One bullet per item. ReactNode so callers can mix in <strong>, links, etc. */
+  items: ReactNode[];
+  className?: string;
+}
+
+export function ConsequencesNotice({
+  variant = "error",
+  title,
+  items,
+  className,
+}: ConsequencesNoticeProps) {
+  return (
+    <Alert variant={variant} hideIcon title={title} className={className}>
+      <ul className="list-disc pl-4 space-y-1.5">
+        {items.map((item, i) => (
+          <li key={i}>{item}</li>
+        ))}
+      </ul>
+    </Alert>
+  );
+}

--- a/src/components/ui/feedback/snackbar/Snackbar.tsx
+++ b/src/components/ui/feedback/snackbar/Snackbar.tsx
@@ -103,7 +103,7 @@ export function Snackbar({
   return (
     <div
       className={cn(
-        "z-50 flex justify-center px-4",
+        "z-[70] flex justify-center px-4",
         "transition-all duration-300 ease-out",
         inline ? "absolute bottom-4 inset-x-0" : "fixed bottom-4 inset-x-0",
         visible && open

--- a/src/components/ui/surfaces/dialog/Dialog.tsx
+++ b/src/components/ui/surfaces/dialog/Dialog.tsx
@@ -123,10 +123,10 @@ export function Dialog({
     <>
       <div
         aria-hidden="true"
-        className="!m-0 fixed inset-0 z-50 bg-black/50"
+        className="!m-0 fixed inset-0 z-[60] bg-black/50"
         onClick={() => onClose?.()}
       />
-      <div className="!m-0 fixed inset-0 z-50 flex items-center justify-center pointer-events-none">
+      <div className="!m-0 fixed inset-0 z-[60] flex items-center justify-center pointer-events-none">
         <div
           ref={dialogRef}
           tabIndex={-1}

--- a/src/components/ui/surfaces/type-to-confirm-dialog/TypeToConfirmDialog.stories.tsx
+++ b/src/components/ui/surfaces/type-to-confirm-dialog/TypeToConfirmDialog.stories.tsx
@@ -1,0 +1,112 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Button } from "@/components/ui/actions/button/Button";
+import { ConsequencesNotice } from "@/components/ui/feedback/consequences-notice/ConsequencesNotice";
+import { TypeToConfirmDialog } from "./TypeToConfirmDialog";
+
+const meta: Meta<typeof TypeToConfirmDialog> = {
+  title: "UI/Surfaces/TypeToConfirmDialog",
+  component: TypeToConfirmDialog,
+};
+
+export default meta;
+type Story = StoryObj<typeof TypeToConfirmDialog>;
+
+export const DisableAccount: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button color="error" onClick={() => setOpen(true)}>
+          Disable account
+        </Button>
+        <TypeToConfirmDialog
+          open={open}
+          onClose={() => setOpen(false)}
+          onConfirm={() => {
+            setOpen(false);
+            // eslint-disable-next-line no-alert
+            alert("Account disabled (demo)");
+          }}
+          phrase="disable"
+          warnTitle="Disable this account?"
+          confirmActionLabel="Disable account"
+          consequences={
+            <ConsequencesNotice
+              title="Before you continue"
+              items={[
+                "You'll be signed out of every device immediately.",
+                "API tokens and modules linked to this account stop working.",
+                <>
+                  You can restore the account within <strong>90 days</strong> via
+                  the email link we send.
+                </>,
+                "After 90 days, the account and its data are permanently deleted.",
+              ]}
+            />
+          }
+        />
+      </>
+    );
+  },
+};
+
+export const DeleteApp: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button color="error" onClick={() => setOpen(true)}>
+          Delete app
+        </Button>
+        <TypeToConfirmDialog
+          open={open}
+          onClose={() => setOpen(false)}
+          onConfirm={() => {
+            setOpen(false);
+            // eslint-disable-next-line no-alert
+            alert("App deleted (demo)");
+          }}
+          phrase="delete"
+          warnTitle="Delete this app?"
+          confirmActionLabel="Delete app"
+          consequences={
+            <ConsequencesNotice
+              title="Deleting this app will:"
+              items={[
+                "Stop all running modules associated with the app.",
+                "Revoke API tokens scoped to this app.",
+                <>
+                  Schedule the app's data for deletion in{" "}
+                  <strong>30 days</strong>.
+                </>,
+                "Cancel any active subscriptions.",
+              ]}
+            />
+          }
+        />
+      </>
+    );
+  },
+};
+
+export const NoConsequencesBody: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <Button color="error" onClick={() => setOpen(true)}>
+          Open
+        </Button>
+        <TypeToConfirmDialog
+          open={open}
+          onClose={() => setOpen(false)}
+          onConfirm={() => setOpen(false)}
+          phrase="confirm"
+          warnTitle="Are you sure?"
+          confirmActionLabel="Yes, do it"
+        />
+      </>
+    );
+  },
+};

--- a/src/components/ui/surfaces/type-to-confirm-dialog/TypeToConfirmDialog.test.tsx
+++ b/src/components/ui/surfaces/type-to-confirm-dialog/TypeToConfirmDialog.test.tsx
@@ -1,0 +1,127 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TypeToConfirmDialog } from "./TypeToConfirmDialog";
+
+afterEach(cleanup);
+
+function renderDialog(overrides: Partial<React.ComponentProps<typeof TypeToConfirmDialog>> = {}) {
+  const onClose = vi.fn();
+  const onConfirm = vi.fn();
+  const utils = render(
+    <TypeToConfirmDialog
+      open
+      onClose={onClose}
+      onConfirm={onConfirm}
+      phrase="delete"
+      warnTitle="Delete this app?"
+      confirmActionLabel="Delete app"
+      consequences={<p>This is destructive.</p>}
+      {...overrides}
+    />,
+  );
+  return { ...utils, onClose, onConfirm };
+}
+
+describe("TypeToConfirmDialog", () => {
+  it("opens at the warn stage with the consequences body", () => {
+    renderDialog();
+    expect(screen.getByText("Delete this app?")).toBeInTheDocument();
+    expect(screen.getByText("This is destructive.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Continue" })).toBeInTheDocument();
+  });
+
+  it("Continue advances to the type stage and shows the input", () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    expect(screen.getByText("Type 'delete' to confirm")).toBeInTheDocument();
+    // Consequences body repeats so the user sees the same info before typing.
+    expect(screen.getByText("This is destructive.")).toBeInTheDocument();
+    expect(screen.getByLabelText("Confirmation")).toBeInTheDocument();
+  });
+
+  it("disables the confirm button until the phrase matches (case-insensitive, trimmed)", () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+
+    const confirmBtn = screen.getByRole("button", { name: "Delete app" });
+    const input = screen.getByLabelText("Confirmation");
+
+    expect(confirmBtn).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "del" } });
+    expect(confirmBtn).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "  DELETE  " } });
+    expect(confirmBtn).not.toBeDisabled();
+  });
+
+  it("calls onConfirm when the matched confirm button is clicked", () => {
+    const { onConfirm } = renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    fireEvent.change(screen.getByLabelText("Confirmation"), {
+      target: { value: "delete" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Delete app" }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it("calls onClose from Cancel on the warn stage", () => {
+    const { onClose } = renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("resets to warn stage and clears input when reopened", () => {
+    const { rerender } = render(
+      <TypeToConfirmDialog
+        open
+        onClose={() => {}}
+        onConfirm={() => {}}
+        phrase="x"
+        warnTitle="W"
+        confirmActionLabel="Go"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    fireEvent.change(screen.getByLabelText("Confirmation"), {
+      target: { value: "x" },
+    });
+
+    rerender(
+      <TypeToConfirmDialog
+        open={false}
+        onClose={() => {}}
+        onConfirm={() => {}}
+        phrase="x"
+        warnTitle="W"
+        confirmActionLabel="Go"
+      />,
+    );
+    rerender(
+      <TypeToConfirmDialog
+        open
+        onClose={() => {}}
+        onConfirm={() => {}}
+        phrase="x"
+        warnTitle="W"
+        confirmActionLabel="Go"
+      />,
+    );
+
+    // Back at warn stage — type-stage title should NOT appear.
+    expect(screen.queryByText("Type 'x' to confirm")).not.toBeInTheDocument();
+    expect(screen.getByText("W")).toBeInTheDocument();
+  });
+
+  it("disables Cancel + Confirm while loading", () => {
+    renderDialog({ loading: true });
+    fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+    fireEvent.change(screen.getByLabelText("Confirmation"), {
+      target: { value: "delete" },
+    });
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    // Confirm button shows a loading spinner; the Button component renders
+    // it as disabled when loading is true.
+    expect(screen.getByRole("button", { name: "Delete app" })).toBeDisabled();
+  });
+});

--- a/src/components/ui/surfaces/type-to-confirm-dialog/TypeToConfirmDialog.tsx
+++ b/src/components/ui/surfaces/type-to-confirm-dialog/TypeToConfirmDialog.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useId, useState, type ReactNode } from "react";
+
+import { Dialog } from "@/components/ui/surfaces/dialog/Dialog";
+import { FloatingLabelInput } from "@/components/ui/inputs/floating-label-input/FloatingLabelInput";
+import type { ButtonProps } from "@/components/ui/actions/button/Button";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "TypeToConfirmDialog",
+  description:
+    "Two-step destructive confirm flow: a consequences-explainer Dialog followed by a type-to-confirm input. Mirrors the GitHub/Stripe danger-zone pattern.",
+};
+
+export interface TypeToConfirmDialogProps {
+  /** Open state for the entire flow. The component owns the warn→type stage internally. */
+  open: boolean;
+  /** Fired on Cancel, Escape, backdrop click, or after a successful onConfirm. */
+  onClose: () => void;
+  /** Called when the user types the phrase and clicks the confirm button. */
+  onConfirm: () => void | Promise<void>;
+  /**
+   * Phrase the user must type. Comparison is case-insensitive and trims
+   * surrounding whitespace.
+   */
+  phrase: string;
+  /** Title for the warn-step Dialog (e.g. "Disable this account?"). */
+  warnTitle: string;
+  /**
+   * Title for the type-step Dialog. Defaults to `Type '<phrase>' to confirm`
+   * so simple consumers don't have to repeat the phrase.
+   */
+  confirmTitle?: string;
+  /** Label for the confirm button on the type step (e.g. "Disable account"). */
+  confirmActionLabel: string;
+  /** Label for the warn-step Continue button. Default "Continue". */
+  warnActionLabel?: string;
+  /** Color tone for both action buttons. Default "error". */
+  color?: ButtonProps["color"];
+  /**
+   * Notice/consequences body. Shown in BOTH stages so the user sees the same
+   * information at the warn step and again when typing to confirm. Typically
+   * a `<ConsequencesNotice />`. Should be stateless — it mounts twice (once
+   * per stage Dialog), so any internal state will reset on the warn→type
+   * transition.
+   */
+  consequences?: ReactNode;
+  /** Loading state for the confirm action. Disables Cancel + Confirm while true. */
+  loading?: boolean;
+}
+
+export function TypeToConfirmDialog({
+  open,
+  onClose,
+  onConfirm,
+  phrase,
+  warnTitle,
+  confirmTitle,
+  confirmActionLabel,
+  warnActionLabel = "Continue",
+  color = "error",
+  consequences,
+  loading = false,
+}: TypeToConfirmDialogProps) {
+  const [stage, setStage] = useState<"warn" | "type">("warn");
+  const [input, setInput] = useState("");
+  const inputId = useId();
+
+  // Reset stage and input whenever the flow closes so the next open starts
+  // fresh at the warn step. Doing this in an effect (instead of inside
+  // onClose) covers Escape, backdrop-click, and parent-driven closes that
+  // bypass our handlers.
+  useEffect(() => {
+    if (!open) {
+      setStage("warn");
+      setInput("");
+    }
+  }, [open]);
+
+  const matched = input.trim().toLowerCase() === phrase.toLowerCase();
+  const resolvedConfirmTitle = confirmTitle ?? `Type '${phrase}' to confirm`;
+  const cancelAction = (disabled?: boolean) => ({
+    label: "Cancel",
+    variant: "text" as const,
+    onClick: onClose,
+    disabled,
+  });
+
+  return (
+    <>
+      <Dialog
+        open={open && stage === "warn"}
+        onClose={onClose}
+        title={warnTitle}
+        actions={[
+          cancelAction(),
+          {
+            label: warnActionLabel,
+            variant: "filled",
+            color,
+            onClick: () => setStage("type"),
+          },
+        ]}
+      >
+        {consequences}
+      </Dialog>
+
+      <Dialog
+        open={open && stage === "type"}
+        onClose={onClose}
+        title={resolvedConfirmTitle}
+        actions={[
+          cancelAction(loading),
+          {
+            label: confirmActionLabel,
+            variant: "filled",
+            color,
+            disabled: !matched || loading,
+            loading,
+            onClick: onConfirm,
+          },
+        ]}
+      >
+        <div className="space-y-3">
+          {consequences}
+          <p className="text-sm text-on-surface-variant">
+            To confirm, type{" "}
+            <span className="font-mono font-medium text-on-surface">
+              {phrase}
+            </span>{" "}
+            below.
+          </p>
+          <FloatingLabelInput
+            id={inputId}
+            type="text"
+            label="Confirmation"
+            size="sm"
+            hideLabel
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            autoFocus
+            autoComplete="off"
+          />
+        </div>
+      </Dialog>
+    </>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,10 +51,18 @@ export {
   type AlertVariant,
 } from "./components/ui/feedback/alert/Alert";
 export {
+  ConsequencesNotice,
+  type ConsequencesNoticeProps,
+} from "./components/ui/feedback/consequences-notice/ConsequencesNotice";
+export {
   Dialog,
   type DialogProps,
   type DialogAction,
 } from "./components/ui/surfaces/dialog/Dialog";
+export {
+  TypeToConfirmDialog,
+  type TypeToConfirmDialogProps,
+} from "./components/ui/surfaces/type-to-confirm-dialog/TypeToConfirmDialog";
 export {
   Surface,
   type SurfaceProps,


### PR DESCRIPTION
## Summary
Two fixes that surface together when a destructive Alert is rendered inside a Dialog while the AppShell agent sidebar is docked.

- **Alert**: new \`hideIcon?: boolean\` prop drops the leading variant icon. Useful when the Alert sits inside a Dialog or section that already conveys severity (e.g. "Disable account" two-step confirm in web-account#31).
- **Dialog**: backdrop + content move from \`z-50\` to \`z-[60]\`. The docked agent sidebar uses \`relative z-50\` and its internal popups go up to \`z-[51]\`, so a same-z Dialog tied or lost on DOM order. Bumping to 60 ensures modals always sit above app-shell layers.

Bumps to **0.2.5** (additive prop + bugfix).

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm test src/components/ui/feedback/alert/ src/components/ui/surfaces/dialog/\` — 17/17 passing
- [x] \`pnpm build\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)