### PR TITLE
chore: bump 0.2.7 (release AppShell scrollbar gap)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary
The \`py-4\` AppShell change from #167 was merged but the version wasn't bumped, so CI didn't republish — consumers on \`^0.2.6\` still get the pre-fix code. Bumps 0.2.6 → 0.2.7 to release.

## Test plan
- [ ] CI publishes 0.2.7 to GitHub Packages
- [ ] After \`pnpm install\` in web-account / web-applications, scrollbar shows 16px gap above and below

🤖 Generated with [Claude Code](https://claude.com/claude-code)