### PR TITLE
feat(app-shell): default content padding pt-12 pb-16 (0.2.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -163,8 +163,7 @@ function AppShellInner({
               <main className="relative flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
                 <div
                   className={cn(
-                    "mx-auto w-full px-6 pb-24",
-                    appSwitcher ? "pt-20" : "pt-6",
+                    "mx-auto w-full px-6 pt-12 pb-16",
                     contentClassName,
                   )}
                 >


### PR DESCRIPTION
## Summary
Replaces AppShell's content-area defaults with a single \`pt-12 pb-16\` so consuming apps don't need to override them.

| Case | Before | After |
|---|---|---|
| With appSwitcher | \`pt-20 pb-24\` | \`pt-12 pb-16\` |
| Without appSwitcher | \`pt-6 pb-24\` | \`pt-12 pb-16\` |

Apps that pass \`contentClassName\` continue to override via tailwind-merge.

Bumps 0.2.7 → 0.2.8.

## Test plan
- [x] \`pnpm typecheck\` clean
- [ ] CI publishes 0.2.8
- [ ] After \`pnpm install\` in web-account / web-applications, content padding matches without explicit override

🤖 Generated with [Claude Code](https://claude.com/claude-code)