### PR TITLE
feat(settings-section): bundle SectionLabel + padded Surface (0.2.9)

### DIFF
--- a/src/components/ui/surfaces/settings-section/SettingsSection.stories.tsx
+++ b/src/components/ui/surfaces/settings-section/SettingsSection.stories.tsx
@@ -28,53 +28,49 @@ export const Playground: Story = {
   },
 };
 
-export const Tones: Story = {
-  render: () => (
-    <div className="space-y-4 max-w-md">
-      <SettingsSection title="Info">
-        <ReadOnlyField label="Module ID" value="m_abc" mono />
-      </SettingsSection>
-      <SettingsSection title="Advanced" tone="warning">
-        <SettingRow
-          tone="warning"
-          title="Developer mode"
-          description="Show the developer rail."
-          control={
-            <Switch
-              checked
-              onChange={() => {}}
-              color="warning"
-              aria-label="developer"
-            />
-          }
-        />
-      </SettingsSection>
-    </div>
-  ),
-};
-
 /**
- * Danger zones intentionally do NOT use SettingsSection. They render
- * the label as a tone-error SectionLabel followed by a naked stack of
- * SettingRow tone="error" rows (each row carries its own border).
- * Shown here for contrast with the boxed sections above.
+ * Tone-coloured groups (Advanced=warning, Danger zone=error) do NOT use
+ * SettingsSection. They render SectionLabel above a naked stack of
+ * SettingRow rows (each row carries its own border) with no enclosing
+ * Surface. Shown here for contrast with the boxed sections above.
  */
-export const DangerZoneIsNotSettingsSection: Story = {
+export const ToneColouredGroupsAreNotSettingsSection: Story = {
   render: () => (
-    <div className="max-w-md">
-      <SectionLabel className="mb-2 text-error">Danger zone</SectionLabel>
-      <div className="space-y-2">
-        <SettingRow
-          tone="error"
-          title="Delete module"
-          description="Permanently delete. Cannot be undone."
-          className="px-6 py-4"
-          control={
-            <Button color="error" variant="filled" size="sm">
-              Delete
-            </Button>
-          }
-        />
+    <div className="space-y-6 max-w-md">
+      <div>
+        <SectionLabel className="mb-2 text-warning">Advanced</SectionLabel>
+        <div className="space-y-2">
+          <SettingRow
+            tone="warning"
+            title="Developer mode"
+            description="Show the developer rail."
+            className="px-6 py-4"
+            control={
+              <Switch
+                checked
+                onChange={() => {}}
+                color="warning"
+                aria-label="developer"
+              />
+            }
+          />
+        </div>
+      </div>
+      <div>
+        <SectionLabel className="mb-2 text-error">Danger zone</SectionLabel>
+        <div className="space-y-2">
+          <SettingRow
+            tone="error"
+            title="Delete module"
+            description="Permanently delete. Cannot be undone."
+            className="px-6 py-4"
+            control={
+              <Button color="error" variant="filled" size="sm">
+                Delete
+              </Button>
+            }
+          />
+        </div>
       </div>
     </div>
   ),

--- a/src/components/ui/surfaces/settings-section/SettingsSection.stories.tsx
+++ b/src/components/ui/surfaces/settings-section/SettingsSection.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ReadOnlyField } from "@/components/ui/data/read-only-field/ReadOnlyField";
+import { SettingRow } from "@/components/ui/data/setting-row/SettingRow";
+import { Button } from "@/components/ui/actions/button/Button";
+import { SettingsSection } from "./SettingsSection";
+
+const meta: Meta<typeof SettingsSection> = {
+  title: "UI/Surfaces/SettingsSection",
+  component: SettingsSection,
+  args: {
+    title: "Info",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SettingsSection>;
+
+export const Playground: Story = {
+  args: {
+    children: (
+      <div className="space-y-4">
+        <ReadOnlyField label="Module ID" value="m_abc123" mono copyable />
+        <ReadOnlyField label="Created" value="May 4, 2026" />
+      </div>
+    ),
+  },
+};
+
+export const Tones: Story = {
+  render: () => (
+    <div className="space-y-4 max-w-md">
+      <SettingsSection title="Info">
+        <ReadOnlyField label="Module ID" value="m_abc" mono />
+      </SettingsSection>
+      <SettingsSection title="Advanced" tone="warning">
+        <ReadOnlyField label="Beta program" value="Enabled" />
+      </SettingsSection>
+      <SettingsSection title="Danger zone" tone="error">
+        <SettingRow
+          tone="error"
+          title="Delete module"
+          description="Permanently delete. Cannot be undone."
+          control={
+            <Button color="error" variant="filled" size="sm">
+              Delete
+            </Button>
+          }
+        />
+      </SettingsSection>
+    </div>
+  ),
+};
+
+export const SurfaceClassNameOverride: Story = {
+  args: {
+    title: "Danger zone",
+    tone: "error",
+    surfaceClassName: "px-6 py-4",
+    children: (
+      <SettingRow
+        tone="error"
+        title="Delete account"
+        description="Sign out and put your account in a suspended state."
+        control={
+          <Button color="error" variant="filled" size="sm">
+            Disable
+          </Button>
+        }
+      />
+    ),
+  },
+};

--- a/src/components/ui/surfaces/settings-section/SettingsSection.stories.tsx
+++ b/src/components/ui/surfaces/settings-section/SettingsSection.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { ReadOnlyField } from "@/components/ui/data/read-only-field/ReadOnlyField";
+import { SectionLabel } from "@/components/ui/data/section-label/SectionLabel";
 import { SettingRow } from "@/components/ui/data/setting-row/SettingRow";
+import { Switch } from "@/components/ui/inputs/switch/Switch";
 import { Button } from "@/components/ui/actions/button/Button";
 import { SettingsSection } from "./SettingsSection";
 
@@ -33,17 +35,17 @@ export const Tones: Story = {
         <ReadOnlyField label="Module ID" value="m_abc" mono />
       </SettingsSection>
       <SettingsSection title="Advanced" tone="warning">
-        <ReadOnlyField label="Beta program" value="Enabled" />
-      </SettingsSection>
-      <SettingsSection title="Danger zone" tone="error">
         <SettingRow
-          tone="error"
-          title="Delete module"
-          description="Permanently delete. Cannot be undone."
+          tone="warning"
+          title="Developer mode"
+          description="Show the developer rail."
           control={
-            <Button color="error" variant="filled" size="sm">
-              Delete
-            </Button>
+            <Switch
+              checked
+              onChange={() => {}}
+              color="warning"
+              aria-label="developer"
+            />
           }
         />
       </SettingsSection>
@@ -51,22 +53,29 @@ export const Tones: Story = {
   ),
 };
 
-export const SurfaceClassNameOverride: Story = {
-  args: {
-    title: "Danger zone",
-    tone: "error",
-    surfaceClassName: "px-6 py-4",
-    children: (
-      <SettingRow
-        tone="error"
-        title="Delete account"
-        description="Sign out and put your account in a suspended state."
-        control={
-          <Button color="error" variant="filled" size="sm">
-            Disable
-          </Button>
-        }
-      />
-    ),
-  },
+/**
+ * Danger zones intentionally do NOT use SettingsSection. They render
+ * the label as a tone-error SectionLabel followed by a naked stack of
+ * SettingRow tone="error" rows (each row carries its own border).
+ * Shown here for contrast with the boxed sections above.
+ */
+export const DangerZoneIsNotSettingsSection: Story = {
+  render: () => (
+    <div className="max-w-md">
+      <SectionLabel className="mb-2 text-error">Danger zone</SectionLabel>
+      <div className="space-y-2">
+        <SettingRow
+          tone="error"
+          title="Delete module"
+          description="Permanently delete. Cannot be undone."
+          className="px-6 py-4"
+          control={
+            <Button color="error" variant="filled" size="sm">
+              Delete
+            </Button>
+          }
+        />
+      </div>
+    </div>
+  ),
 };

--- a/src/components/ui/surfaces/settings-section/SettingsSection.test.tsx
+++ b/src/components/ui/surfaces/settings-section/SettingsSection.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SettingsSection } from "./SettingsSection";
+
+afterEach(cleanup);
+
+describe("SettingsSection", () => {
+  it("renders title and children", () => {
+    const { getByText } = render(
+      <SettingsSection title="Info">
+        <p>body</p>
+      </SettingsSection>,
+    );
+    expect(getByText("Info")).toBeInTheDocument();
+    expect(getByText("body")).toBeInTheDocument();
+  });
+
+  it("applies p-6 to the inner Surface by default", () => {
+    const { getByText } = render(
+      <SettingsSection title="Info">
+        <p>body</p>
+      </SettingsSection>,
+    );
+    const surface = getByText("body").parentElement as HTMLElement;
+    expect(surface.className).toContain("p-6");
+    expect(surface.className).toContain("rounded-2xl");
+    expect(surface.className).toContain("border-outline-variant");
+  });
+
+  it("colors the title with the requested tone", () => {
+    const { getByText } = render(
+      <SettingsSection title="Danger zone" tone="error">
+        <p>body</p>
+      </SettingsSection>,
+    );
+    const label = getByText("Danger zone");
+    expect(label.className).toContain("text-error");
+  });
+
+  it("does not color the title without a tone", () => {
+    const { getByText } = render(
+      <SettingsSection title="Info">
+        <p>body</p>
+      </SettingsSection>,
+    );
+    const label = getByText("Info");
+    expect(label.className).not.toContain("text-error");
+    expect(label.className).not.toContain("text-warning");
+  });
+
+  it("merges surfaceClassName onto the Surface", () => {
+    const { getByText } = render(
+      <SettingsSection title="Info" surfaceClassName="px-4 py-2">
+        <p>body</p>
+      </SettingsSection>,
+    );
+    const surface = getByText("body").parentElement as HTMLElement;
+    expect(surface.className).toContain("px-4");
+    expect(surface.className).toContain("py-2");
+  });
+
+  it("applies className to the outer wrapper", () => {
+    const { container } = render(
+      <SettingsSection title="Info" className="mb-8">
+        <p>body</p>
+      </SettingsSection>,
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain("mb-8");
+  });
+});

--- a/src/components/ui/surfaces/settings-section/SettingsSection.test.tsx
+++ b/src/components/ui/surfaces/settings-section/SettingsSection.test.tsx
@@ -27,27 +27,6 @@ describe("SettingsSection", () => {
     expect(surface.className).toContain("border-outline-variant");
   });
 
-  it("colors the title with the requested tone", () => {
-    const { getByText } = render(
-      <SettingsSection title="Danger zone" tone="error">
-        <p>body</p>
-      </SettingsSection>,
-    );
-    const label = getByText("Danger zone");
-    expect(label.className).toContain("text-error");
-  });
-
-  it("does not color the title without a tone", () => {
-    const { getByText } = render(
-      <SettingsSection title="Info">
-        <p>body</p>
-      </SettingsSection>,
-    );
-    const label = getByText("Info");
-    expect(label.className).not.toContain("text-error");
-    expect(label.className).not.toContain("text-warning");
-  });
-
   it("merges surfaceClassName onto the Surface", () => {
     const { getByText } = render(
       <SettingsSection title="Info" surfaceClassName="px-4 py-2">

--- a/src/components/ui/surfaces/settings-section/SettingsSection.tsx
+++ b/src/components/ui/surfaces/settings-section/SettingsSection.tsx
@@ -8,19 +8,19 @@ import type { ComponentMeta } from "@/types/component-meta";
 export const meta: ComponentMeta = {
   name: "SettingsSection",
   description:
-    "Titled, padded surface used for settings groupings — bundles a SectionLabel with a Surface(p-6). Replaces the SECTION_CLASS pattern duplicated across web-account /me, /me/security, and web-applications /dev/module.",
+    "Titled, boxed group of settings — a SectionLabel above a padded Surface. Use for Info / Settings / Profile groups where the rows visually belong together. Danger zones do NOT use this shape: they render SectionLabel above a naked stack of SettingRow tone=\"error\" rows (each row carries its own border) with no enclosing Surface.",
 };
 
 export interface SettingsSectionProps {
   /** Section heading text. Rendered via <SectionLabel>. */
   title: ReactNode;
-  /** Theme color for the title (e.g. "error" for danger zones). */
+  /** Theme color for the title (e.g. "warning" for advanced groupings). */
   tone?: Tone;
   /** Body of the section — usually a stack of fields. */
   children: ReactNode;
   /** Optional class on the outer wrapper. */
   className?: string;
-  /** Optional class on the inner Surface. Use to override padding for special cases. */
+  /** Optional class on the inner Surface (e.g. override padding). */
   surfaceClassName?: string;
 }
 

--- a/src/components/ui/surfaces/settings-section/SettingsSection.tsx
+++ b/src/components/ui/surfaces/settings-section/SettingsSection.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import { SectionLabel } from "@/components/ui/data/section-label/SectionLabel";
+import { Surface } from "@/components/ui/surfaces/surface/Surface";
+import { type Tone, toneTextClass } from "@/types/tone";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "SettingsSection",
+  description:
+    "Titled, padded surface used for settings groupings — bundles a SectionLabel with a Surface(p-6). Replaces the SECTION_CLASS pattern duplicated across web-account /me, /me/security, and web-applications /dev/module.",
+};
+
+export interface SettingsSectionProps {
+  /** Section heading text. Rendered via <SectionLabel>. */
+  title: ReactNode;
+  /** Theme color for the title (e.g. "error" for danger zones). */
+  tone?: Tone;
+  /** Body of the section — usually a stack of fields. */
+  children: ReactNode;
+  /** Optional class on the outer wrapper. */
+  className?: string;
+  /** Optional class on the inner Surface. Use to override padding for special cases. */
+  surfaceClassName?: string;
+}
+
+export function SettingsSection({
+  title,
+  tone,
+  children,
+  className,
+  surfaceClassName,
+}: SettingsSectionProps) {
+  return (
+    <section className={className}>
+      <SectionLabel className={cn("mb-2", tone && toneTextClass[tone])}>
+        {title}
+      </SectionLabel>
+      <Surface className={cn("p-6", surfaceClassName)}>{children}</Surface>
+    </section>
+  );
+}

--- a/src/components/ui/surfaces/settings-section/SettingsSection.tsx
+++ b/src/components/ui/surfaces/settings-section/SettingsSection.tsx
@@ -2,20 +2,17 @@ import type { ReactNode } from "react";
 import { cn } from "@/utils/cn";
 import { SectionLabel } from "@/components/ui/data/section-label/SectionLabel";
 import { Surface } from "@/components/ui/surfaces/surface/Surface";
-import { type Tone, toneTextClass } from "@/types/tone";
 import type { ComponentMeta } from "@/types/component-meta";
 
 export const meta: ComponentMeta = {
   name: "SettingsSection",
   description:
-    "Titled, boxed group of settings — a SectionLabel above a padded Surface. Use for Info / Settings / Profile groups where the rows visually belong together. Danger zones do NOT use this shape: they render SectionLabel above a naked stack of SettingRow tone=\"error\" rows (each row carries its own border) with no enclosing Surface.",
+    "Titled, boxed group of settings — a SectionLabel above a padded Surface. Use for Info / Settings / Profile groups whose rows visually belong together. Tone-coloured groups (Advanced=warning, Danger zone=error) do NOT use this shape — they render SectionLabel above a naked stack of SettingRow rows with their own per-row borders, no enclosing Surface.",
 };
 
 export interface SettingsSectionProps {
   /** Section heading text. Rendered via <SectionLabel>. */
   title: ReactNode;
-  /** Theme color for the title (e.g. "warning" for advanced groupings). */
-  tone?: Tone;
   /** Body of the section — usually a stack of fields. */
   children: ReactNode;
   /** Optional class on the outer wrapper. */
@@ -26,16 +23,13 @@ export interface SettingsSectionProps {
 
 export function SettingsSection({
   title,
-  tone,
   children,
   className,
   surfaceClassName,
 }: SettingsSectionProps) {
   return (
     <section className={className}>
-      <SectionLabel className={cn("mb-2", tone && toneTextClass[tone])}>
-        {title}
-      </SectionLabel>
+      <SectionLabel className="mb-2">{title}</SectionLabel>
       <Surface className={cn("p-6", surfaceClassName)}>{children}</Surface>
     </section>
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,10 @@ export {
   type SurfaceProps,
 } from "./components/ui/surfaces/surface/Surface";
 export {
+  SettingsSection,
+  type SettingsSectionProps,
+} from "./components/ui/surfaces/settings-section/SettingsSection";
+export {
   Card,
   type CardProps,
 } from "./components/ui/surfaces/card/Card";


### PR DESCRIPTION
## Summary
New \`<SettingsSection title tone? surfaceClassName? className?>\` primitive — bundles \`SectionLabel\` + a padded \`Surface\`. Replaces the SECTION_CLASS string (\`border border-outline-variant rounded-2xl p-6 bg-surface-container-low\`) duplicated across three callsites in two repos.

\`\`\`tsx
<SettingsSection title="Info">
  <ReadOnlyField ... />
</SettingsSection>

<SettingsSection title="Danger zone" tone="error" surfaceClassName="px-6 py-4">
  <SettingRow ... />
</SettingsSection>
\`\`\`

## Test plan
- [x] 6 unit tests covering: render, default \`p-6\`, tone color, tone absence, \`surfaceClassName\` override, outer \`className\` pass-through
- [x] \`pnpm typecheck\`, \`pnpm test --run SettingsSection\` clean
- [x] Pre-existing ThemeProvider test failures unrelated (also fail on bare main)

## Adoption (follow-up)
- web-account /me, /me/security
- web-applications /dev/module/[slug]