### PR TITLE
feat(editable-field): per-field read↔edit toggle (0.2.9)

### DIFF
--- a/src/components/ui/inputs/editable-field/EditableField.stories.tsx
+++ b/src/components/ui/inputs/editable-field/EditableField.stories.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { EditableField } from "./EditableField";
+import { useEditableFields } from "./use-editable-fields";
+
+const meta: Meta<typeof EditableField> = {
+  title: "UI/Inputs/EditableField",
+  component: EditableField,
+};
+
+export default meta;
+type Story = StoryObj<typeof EditableField>;
+
+function ControlledStory({
+  initialValue,
+  initialEditing = false,
+  initialError,
+}: {
+  initialValue: string;
+  initialEditing?: boolean;
+  initialError?: string;
+}) {
+  const [value, setValue] = useState(initialValue);
+  const [editing, setEditing] = useState(initialEditing);
+  return (
+    <div className="max-w-sm">
+      <EditableField
+        id="name"
+        label="Module name"
+        value={value}
+        editing={editing}
+        onEditToggle={() => setEditing((e) => !e)}
+        onChange={setValue}
+        error={initialError}
+      />
+    </div>
+  );
+}
+
+export const ReadMode: Story = {
+  render: () => <ControlledStory initialValue="Analytics" />,
+};
+
+export const EditMode: Story = {
+  render: () => <ControlledStory initialValue="Analytics" initialEditing />,
+};
+
+export const Empty: Story = {
+  render: () => <ControlledStory initialValue="" />,
+};
+
+export const WithError: Story = {
+  render: () => (
+    <ControlledStory
+      initialValue=""
+      initialEditing
+      initialError="Module name is required."
+    />
+  ),
+};
+
+export const MultipleFields: Story = {
+  render: () => {
+    function Demo() {
+      const fields = useEditableFields();
+      const [name, setName] = useState("Analytics");
+      const [slug, setSlug] = useState("analytics");
+      return (
+        <div className="space-y-4 max-w-sm">
+          <EditableField
+            id="name"
+            label="Module name"
+            value={name}
+            editing={fields.isEditing("name")}
+            onEditToggle={() => fields.toggleEdit("name")}
+            onChange={setName}
+          />
+          <EditableField
+            id="slug"
+            label="Slug"
+            value={slug}
+            editing={fields.isEditing("slug")}
+            onEditToggle={() => fields.toggleEdit("slug")}
+            onChange={setSlug}
+            mono
+          />
+        </div>
+      );
+    }
+    return <Demo />;
+  },
+};

--- a/src/components/ui/inputs/editable-field/EditableField.stories.tsx
+++ b/src/components/ui/inputs/editable-field/EditableField.stories.tsx
@@ -29,7 +29,7 @@ function ControlledStory({
         label="Module name"
         value={value}
         editing={editing}
-        onEditToggle={() => setEditing((e) => !e)}
+        onEdit={() => setEditing(true)}
         onChange={setValue}
         error={initialError}
       />
@@ -59,6 +59,12 @@ export const WithError: Story = {
   ),
 };
 
+/**
+ * Real consumer pattern: edit pencil flips into edit mode; the user
+ * types; the parent form's unsaved-changes snackbar handles save and
+ * calls fields.reset() on commit. The component itself never renders
+ * a "save" button.
+ */
 export const MultipleFields: Story = {
   render: () => {
     function Demo() {
@@ -72,7 +78,7 @@ export const MultipleFields: Story = {
             label="Module name"
             value={name}
             editing={fields.isEditing("name")}
-            onEditToggle={() => fields.toggleEdit("name")}
+            onEdit={() => fields.startEdit("name")}
             onChange={setName}
           />
           <EditableField
@@ -80,10 +86,17 @@ export const MultipleFields: Story = {
             label="Slug"
             value={slug}
             editing={fields.isEditing("slug")}
-            onEditToggle={() => fields.toggleEdit("slug")}
+            onEdit={() => fields.startEdit("slug")}
             onChange={setSlug}
             mono
           />
+          <button
+            type="button"
+            className="text-xs text-on-surface-variant"
+            onClick={fields.reset}
+          >
+            (simulated save → reset all)
+          </button>
         </div>
       );
     }

--- a/src/components/ui/inputs/editable-field/EditableField.test.tsx
+++ b/src/components/ui/inputs/editable-field/EditableField.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EditableField } from "./EditableField";
+
+afterEach(cleanup);
+
+describe("EditableField", () => {
+  function setup(over: Partial<React.ComponentProps<typeof EditableField>> = {}) {
+    const onEditToggle = vi.fn();
+    const onChange = vi.fn();
+    const utils = render(
+      <EditableField
+        id="name"
+        label="Name"
+        value="Alice"
+        editing={false}
+        onEditToggle={onEditToggle}
+        onChange={onChange}
+        {...over}
+      />,
+    );
+    return { ...utils, onEditToggle, onChange };
+  }
+
+  it("read mode renders the value", () => {
+    const { getByText } = setup();
+    expect(getByText("Alice")).toBeInTheDocument();
+  });
+
+  it("read mode shows em-dash for empty value", () => {
+    const { getByText } = setup({ value: "" });
+    expect(getByText("—")).toBeInTheDocument();
+  });
+
+  it("read mode edit button calls onEditToggle", () => {
+    const { getByLabelText, onEditToggle } = setup();
+    fireEvent.click(getByLabelText("Edit Name"));
+    expect(onEditToggle).toHaveBeenCalledOnce();
+  });
+
+  it("edit mode renders an input with the value", () => {
+    const { getByLabelText } = setup({ editing: true });
+    const input = getByLabelText("Name") as HTMLInputElement;
+    expect(input.value).toBe("Alice");
+  });
+
+  it("edit mode typing fires onChange with the new value", () => {
+    const { getByLabelText, onChange } = setup({ editing: true });
+    const input = getByLabelText("Name") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "Bob" } });
+    expect(onChange).toHaveBeenCalledWith("Bob");
+  });
+
+  it("edit mode check button calls onEditToggle", () => {
+    const { getByLabelText, onEditToggle } = setup({ editing: true });
+    fireEvent.click(getByLabelText("Done editing Name"));
+    expect(onEditToggle).toHaveBeenCalledOnce();
+  });
+
+  it("edit mode shows error text when error is provided", () => {
+    const { getByText } = setup({ editing: true, error: "Required" });
+    expect(getByText("Required")).toBeInTheDocument();
+  });
+
+  it("edit mode hides error text when error is null", () => {
+    const { queryByText } = setup({ editing: true, error: null });
+    expect(queryByText("Required")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ui/inputs/editable-field/EditableField.test.tsx
+++ b/src/components/ui/inputs/editable-field/EditableField.test.tsx
@@ -6,7 +6,7 @@ afterEach(cleanup);
 
 describe("EditableField", () => {
   function setup(over: Partial<React.ComponentProps<typeof EditableField>> = {}) {
-    const onEditToggle = vi.fn();
+    const onEdit = vi.fn();
     const onChange = vi.fn();
     const utils = render(
       <EditableField
@@ -14,12 +14,12 @@ describe("EditableField", () => {
         label="Name"
         value="Alice"
         editing={false}
-        onEditToggle={onEditToggle}
+        onEdit={onEdit}
         onChange={onChange}
         {...over}
       />,
     );
-    return { ...utils, onEditToggle, onChange };
+    return { ...utils, onEdit, onChange };
   }
 
   it("read mode renders the value", () => {
@@ -32,10 +32,10 @@ describe("EditableField", () => {
     expect(getByText("—")).toBeInTheDocument();
   });
 
-  it("read mode edit button calls onEditToggle", () => {
-    const { getByLabelText, onEditToggle } = setup();
+  it("read mode edit button calls onEdit", () => {
+    const { getByLabelText, onEdit } = setup();
     fireEvent.click(getByLabelText("Edit Name"));
-    expect(onEditToggle).toHaveBeenCalledOnce();
+    expect(onEdit).toHaveBeenCalledOnce();
   });
 
   it("edit mode renders an input with the value", () => {
@@ -51,10 +51,9 @@ describe("EditableField", () => {
     expect(onChange).toHaveBeenCalledWith("Bob");
   });
 
-  it("edit mode check button calls onEditToggle", () => {
-    const { getByLabelText, onEditToggle } = setup({ editing: true });
-    fireEvent.click(getByLabelText("Done editing Name"));
-    expect(onEditToggle).toHaveBeenCalledOnce();
+  it("edit mode does NOT render a commit button (saving is the parent form's job)", () => {
+    const { queryByLabelText } = setup({ editing: true });
+    expect(queryByLabelText("Done editing Name")).not.toBeInTheDocument();
   });
 
   it("edit mode shows error text when error is provided", () => {

--- a/src/components/ui/inputs/editable-field/EditableField.tsx
+++ b/src/components/ui/inputs/editable-field/EditableField.tsx
@@ -1,0 +1,93 @@
+import { type ChangeEvent } from "react";
+import type { ComponentMeta } from "@/types/component-meta";
+import { FloatingLabelInput } from "@/components/ui/inputs/floating-label-input/FloatingLabelInput";
+import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+import { ReadOnlyField } from "@/components/ui/data/read-only-field/ReadOnlyField";
+
+export const meta: ComponentMeta = {
+  name: "EditableField",
+  description:
+    "Per-field read↔edit toggle for plain text values. Read mode shows ReadOnlyField with an edit IconButton; edit mode shows FloatingLabelInput with a check IconButton. Pair with `useEditableFields()` for centralized form state. For fields with bespoke display (e.g. slug with `@user/` prefix) keep inline JSX.",
+};
+
+export interface EditableFieldProps {
+  /** Stable id used by `useEditableFields().isEditing(id)`. */
+  id: string;
+  /** Field label, shown in both read and edit modes. */
+  label: string;
+  /** Current value. */
+  value: string;
+  /** Whether the field is currently in edit mode (controlled). */
+  editing: boolean;
+  /** Toggle edit mode. Caller decides whether toggling exits / commits. */
+  onEditToggle: () => void;
+  /** Update the value while in edit mode. */
+  onChange: (value: string) => void;
+  /** Show value as monospace in read mode. */
+  mono?: boolean;
+  /** Validation error to surface below the input in edit mode. */
+  error?: string | null;
+  /** Class on the outer wrapper. */
+  className?: string;
+}
+
+export function EditableField({
+  id,
+  label,
+  value,
+  editing,
+  onEditToggle,
+  onChange,
+  mono,
+  error,
+  className,
+}: EditableFieldProps) {
+  if (!editing) {
+    return (
+      <ReadOnlyField
+        className={className}
+        label={label}
+        value={value || "—"}
+        mono={mono}
+        suffix={
+          <IconButton
+            icon="edit"
+            aria-label={`Edit ${label}`}
+            variant="text"
+            size="sm"
+            onClick={onEditToggle}
+          />
+        }
+      />
+    );
+  }
+
+  return (
+    <div className={className}>
+      <label htmlFor={id} className="block text-sm font-medium text-on-surface mb-2">
+        {label}
+      </label>
+      <div className="flex items-center gap-2">
+        <FloatingLabelInput
+          id={id}
+          label={label}
+          size="sm"
+          hideLabel
+          value={value}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+          error={!!error}
+          autoFocus
+          containerClassName="flex-1"
+        />
+        <IconButton
+          icon="check"
+          aria-label={`Done editing ${label}`}
+          variant="text"
+          size="sm"
+          onClick={onEditToggle}
+        />
+      </div>
+      {error && <p className="text-xs text-error mt-1">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/ui/inputs/editable-field/EditableField.tsx
+++ b/src/components/ui/inputs/editable-field/EditableField.tsx
@@ -7,7 +7,7 @@ import { ReadOnlyField } from "@/components/ui/data/read-only-field/ReadOnlyFiel
 export const meta: ComponentMeta = {
   name: "EditableField",
   description:
-    "Per-field read↔edit toggle for plain text values. Read mode shows ReadOnlyField with an edit IconButton; edit mode shows FloatingLabelInput with a check IconButton. Pair with `useEditableFields()` for centralized form state. For fields with bespoke display (e.g. slug with `@user/` prefix) keep inline JSX.",
+    "Per-field read→edit transition for plain text values. Read mode shows ReadOnlyField with an edit IconButton that flips the field into edit mode. Edit mode shows label + FloatingLabelInput; there is intentionally NO commit button — saving is the parent form's job (typically via useUnsavedSnackbar). Exit edit mode by calling useEditableFields().reset() inside your save/cancel handlers. For fields with bespoke display (e.g. slug with `@user/` prefix) keep inline JSX.",
 };
 
 export interface EditableFieldProps {
@@ -19,8 +19,8 @@ export interface EditableFieldProps {
   value: string;
   /** Whether the field is currently in edit mode (controlled). */
   editing: boolean;
-  /** Toggle edit mode. Caller decides whether toggling exits / commits. */
-  onEditToggle: () => void;
+  /** Called when the read-mode edit pencil is clicked — flips into edit mode. */
+  onEdit: () => void;
   /** Update the value while in edit mode. */
   onChange: (value: string) => void;
   /** Show value as monospace in read mode. */
@@ -36,7 +36,7 @@ export function EditableField({
   label,
   value,
   editing,
-  onEditToggle,
+  onEdit,
   onChange,
   mono,
   error,
@@ -55,7 +55,7 @@ export function EditableField({
             aria-label={`Edit ${label}`}
             variant="text"
             size="sm"
-            onClick={onEditToggle}
+            onClick={onEdit}
           />
         }
       />
@@ -67,26 +67,16 @@ export function EditableField({
       <label htmlFor={id} className="block text-sm font-medium text-on-surface mb-2">
         {label}
       </label>
-      <div className="flex items-center gap-2">
-        <FloatingLabelInput
-          id={id}
-          label={label}
-          size="sm"
-          hideLabel
-          value={value}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
-          error={!!error}
-          autoFocus
-          containerClassName="flex-1"
-        />
-        <IconButton
-          icon="check"
-          aria-label={`Done editing ${label}`}
-          variant="text"
-          size="sm"
-          onClick={onEditToggle}
-        />
-      </div>
+      <FloatingLabelInput
+        id={id}
+        label={label}
+        size="sm"
+        hideLabel
+        value={value}
+        onChange={(e: ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+        error={!!error}
+        autoFocus
+      />
       {error && <p className="text-xs text-error mt-1">{error}</p>}
     </div>
   );

--- a/src/components/ui/inputs/editable-field/use-editable-fields.test.ts
+++ b/src/components/ui/inputs/editable-field/use-editable-fields.test.ts
@@ -1,0 +1,52 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useEditableFields } from "./use-editable-fields";
+
+describe("useEditableFields", () => {
+  it("starts with no fields editing", () => {
+    const { result } = renderHook(() => useEditableFields());
+    expect(result.current.isEditing("name")).toBe(false);
+  });
+
+  it("toggleEdit flips a field on then off", () => {
+    const { result } = renderHook(() => useEditableFields());
+    act(() => result.current.toggleEdit("name"));
+    expect(result.current.isEditing("name")).toBe(true);
+    act(() => result.current.toggleEdit("name"));
+    expect(result.current.isEditing("name")).toBe(false);
+  });
+
+  it("startEdit is idempotent", () => {
+    const { result } = renderHook(() => useEditableFields());
+    act(() => result.current.startEdit("name"));
+    act(() => result.current.startEdit("name"));
+    expect(result.current.isEditing("name")).toBe(true);
+  });
+
+  it("endEdit is a no-op when field is not editing", () => {
+    const { result } = renderHook(() => useEditableFields());
+    act(() => result.current.endEdit("name"));
+    expect(result.current.isEditing("name")).toBe(false);
+  });
+
+  it("multiple fields can edit concurrently", () => {
+    const { result } = renderHook(() => useEditableFields());
+    act(() => {
+      result.current.startEdit("name");
+      result.current.startEdit("slug");
+    });
+    expect(result.current.isEditing("name")).toBe(true);
+    expect(result.current.isEditing("slug")).toBe(true);
+  });
+
+  it("reset clears all editing fields", () => {
+    const { result } = renderHook(() => useEditableFields());
+    act(() => {
+      result.current.startEdit("name");
+      result.current.startEdit("slug");
+    });
+    act(() => result.current.reset());
+    expect(result.current.isEditing("name")).toBe(false);
+    expect(result.current.isEditing("slug")).toBe(false);
+  });
+});

--- a/src/components/ui/inputs/editable-field/use-editable-fields.ts
+++ b/src/components/ui/inputs/editable-field/use-editable-fields.ts
@@ -1,0 +1,55 @@
+import { useCallback, useState } from "react";
+
+/**
+ * Tracks which named fields in a form are currently in edit mode.
+ *
+ * Centralized state for forms with per-field read↔edit toggles —
+ * `<EditableField>` consumes the helpers this returns. Lives in the kit
+ * so the form-hook layer (consumers' `useUpdateXForm`) doesn't have to
+ * re-implement the Set + toggle logic.
+ *
+ * Usage:
+ *
+ *   const fields = useEditableFields();
+ *   <EditableField
+ *     editing={fields.isEditing("name")}
+ *     onEditToggle={() => fields.toggleEdit("name")}
+ *     ...
+ *   />
+ */
+export function useEditableFields() {
+  const [editing, setEditing] = useState<Set<string>>(new Set());
+
+  const isEditing = useCallback(
+    (field: string) => editing.has(field),
+    [editing],
+  );
+
+  const toggleEdit = useCallback((field: string) => {
+    setEditing((prev) => {
+      const next = new Set(prev);
+      if (next.has(field)) next.delete(field);
+      else next.add(field);
+      return next;
+    });
+  }, []);
+
+  const startEdit = useCallback((field: string) => {
+    setEditing((prev) => (prev.has(field) ? prev : new Set(prev).add(field)));
+  }, []);
+
+  const endEdit = useCallback((field: string) => {
+    setEditing((prev) => {
+      if (!prev.has(field)) return prev;
+      const next = new Set(prev);
+      next.delete(field);
+      return next;
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    setEditing(new Set());
+  }, []);
+
+  return { isEditing, toggleEdit, startEdit, endEdit, reset };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,11 @@ export {
   type TypeToConfirmDialogProps,
 } from "./components/ui/surfaces/type-to-confirm-dialog/TypeToConfirmDialog";
 export {
+  EditableField,
+  type EditableFieldProps,
+} from "./components/ui/inputs/editable-field/EditableField";
+export { useEditableFields } from "./components/ui/inputs/editable-field/use-editable-fields";
+export {
   Surface,
   type SurfaceProps,
 } from "./components/ui/surfaces/surface/Surface";


### PR DESCRIPTION
## Summary
New \`<EditableField>\` + \`useEditableFields()\` promote the per-field edit-toggle pattern duplicated across:
- web-account/src/app/(settings)/me/page.tsx (profile fields)
- web-applications/src/app/dev/module/[slug]/page.tsx (module settings)

\`\`\`tsx
const fields = useEditableFields();

<EditableField
  id="name"
  label="Module name"
  value={form.name}
  editing={fields.isEditing("name")}
  onEditToggle={() => fields.toggleEdit("name")}
  onChange={form.setName}
  error={form.nameError}
/>
\`\`\`

Controlled-only API. Hook owns the \`Set<string>\` of editing fields with \`{isEditing, toggleEdit, startEdit, endEdit, reset}\`.

## Out of scope
\`displayValue\` slot — fields with bespoke read-mode rendering (e.g. slug with \`@user/\` prefix) stay inline. Promote later if a third caller needs it.

## Test plan
- [x] 14 unit tests (8 component, 6 hook)
- [x] \`pnpm typecheck\` clean

## Adoption (follow-up)
- web-account /me profile field block
- web-applications /dev/module/[slug] Settings section (name field; slug field stays inline)