### PR TITLE
chore: bump 0.2.9 — release SettingsSection + EditableField

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary
Version bump to release the two recently-merged kit additions:
- [#171](https://github.com/mirrorstack-ai/web-ui-kit/pull/171) \`<SettingsSection>\`
- [#172](https://github.com/mirrorstack-ai/web-ui-kit/pull/172) \`<EditableField>\` + \`useEditableFields()\`

Both shipped without bumping; the \`release\` label on this PR triggers the publish workflow.

## Test plan
- [x] \`pnpm typecheck\` clean