### PR TITLE
feat(agent-sidebar): MultiQuestion ask with tabs + list layouts

### DIFF
--- a/src/components/ui/agent-sidebar/AgentAsks.stories.tsx
+++ b/src/components/ui/agent-sidebar/AgentAsks.stories.tsx
@@ -15,8 +15,6 @@ const meta: Meta = {
 
 export default meta;
 
-// Tabs layout — for weighted decisions where each option needs explanation.
-// Use `choice` with style="cards" so options show a description per option.
 export const MultiQuestionTabs: StoryObj = {
   render: () => {
     const [status, setStatus] = useState<"pending" | "submitted">("pending");
@@ -159,8 +157,6 @@ export const MultiQuestionTabs: StoryObj = {
   },
 };
 
-// List layout — for simple preferences with quick-pick options. Use `choice`
-// with style="segmented" so options are visible inline (no Combobox click).
 export const MultiQuestionList: StoryObj = {
   render: () => {
     const [status, setStatus] = useState<"pending" | "submitted">("pending");

--- a/src/components/ui/agent-sidebar/AgentAsks.stories.tsx
+++ b/src/components/ui/agent-sidebar/AgentAsks.stories.tsx
@@ -117,6 +117,42 @@ export const MultiQuestionTabs: StoryObj = {
               },
             ],
           },
+          {
+            id: "addons",
+            type: "choice",
+            style: "cards",
+            multiple: true,
+            label: "Add-on services",
+            tabLabel: "Add-ons",
+            description:
+              "Pick any infrastructure you also want scaffolded. Multiple selections allowed.",
+            options: [
+              {
+                value: "redis",
+                label: "Redis cache",
+                description:
+                  "In-memory cache + queue. Recommended for sessions, rate-limit, and pub-sub.",
+              },
+              {
+                value: "s3",
+                label: "Object storage (S3)",
+                description:
+                  "For user uploads, exports, backups. Bucket + signed-URL helpers ship with it.",
+              },
+              {
+                value: "ses",
+                label: "Transactional email",
+                description:
+                  "AWS SES wired up with verified-domain check and a default template package.",
+              },
+              {
+                value: "otel",
+                label: "OpenTelemetry",
+                description:
+                  "Traces + metrics exporter. Adds the OTEL SDK and a default collector config.",
+              },
+            ],
+          },
         ]}
       />
     );
@@ -148,6 +184,20 @@ export const MultiQuestionList: StoryObj = {
               { value: "system", label: "System" },
               { value: "light", label: "Light" },
               { value: "dark", label: "Dark" },
+            ],
+          },
+          {
+            id: "channels",
+            type: "choice",
+            style: "segmented",
+            multiple: true,
+            label: "Notify me via",
+            description: "Pick any channels you want product updates on.",
+            options: [
+              { value: "email", label: "Email" },
+              { value: "push", label: "Push" },
+              { value: "sms", label: "SMS" },
+              { value: "slack", label: "Slack" },
             ],
           },
           {

--- a/src/components/ui/agent-sidebar/AgentAsks.stories.tsx
+++ b/src/components/ui/agent-sidebar/AgentAsks.stories.tsx
@@ -1,0 +1,168 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { AgentSidebarMultiQuestion } from "./AgentSidebarMultiQuestion";
+
+const meta: Meta = {
+  title: "Agent/Asks",
+  decorators: [
+    (Story) => (
+      <div className="h-[640px] w-[420px] rounded-2xl overflow-hidden flex flex-col bg-on-background p-4 overflow-y-auto">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+// Tabs layout is for *decisions* — multiple sections, each with weighted
+// trade-offs. Example: scaffolding a new service. Each tab is one decision,
+// each option is a multi-choice card with an explanation to help pick.
+export const MultiQuestionTabs: StoryObj = {
+  render: () => {
+    const [status, setStatus] = useState<"pending" | "submitted">("pending");
+    return (
+      <AgentSidebarMultiQuestion
+        title="Scaffold a new service"
+        description="Pick the building blocks. The agent will generate the project skeleton from your choices."
+        status={status}
+        onSubmit={(answers) => {
+          console.log("submitted", answers);
+          setStatus("submitted");
+        }}
+        questions={[
+          {
+            id: "database",
+            type: "choice",
+            label: "Primary database",
+            tabLabel: "Database",
+            description:
+              "Where the service stores its core records. You can add a cache or analytics store later.",
+            options: [
+              {
+                value: "postgres",
+                label: "PostgreSQL",
+                description:
+                  "Battle-tested, ACID, JSON support, large extension ecosystem. Best general-purpose default.",
+              },
+              {
+                value: "mysql",
+                label: "MySQL",
+                description:
+                  "Wide hosting support, mature replication, ubiquitous tooling. Smaller feature surface than Postgres.",
+              },
+              {
+                value: "sqlite",
+                label: "SQLite",
+                description:
+                  "Zero-config, single-file. Great for embedded, local-first, or sub-1k QPS workloads.",
+              },
+            ],
+          },
+          {
+            id: "auth",
+            type: "choice",
+            label: "Authentication strategy",
+            tabLabel: "Auth",
+            description:
+              "How users prove who they are. Affects token storage, refresh flow, and which middleware ships.",
+            options: [
+              {
+                value: "session",
+                label: "Server sessions",
+                description:
+                  "HTTP-only cookies, server-side store. Simplest model. Best for first-party web apps.",
+              },
+              {
+                value: "jwt",
+                label: "Stateless JWT",
+                description:
+                  "Self-contained signed tokens. No session table, but harder to revoke. Common for APIs and mobile.",
+              },
+              {
+                value: "oauth",
+                label: "OAuth / OIDC",
+                description:
+                  "Delegate to an identity provider (Google, Okta, Auth0). Best for enterprise SSO requirements.",
+              },
+            ],
+          },
+          {
+            id: "hosting",
+            type: "choice",
+            label: "Deploy target",
+            tabLabel: "Hosting",
+            description:
+              "Drives the Dockerfile, IaC scaffold, and CI workflow generated for you.",
+            options: [
+              {
+                value: "aws-lambda",
+                label: "AWS Lambda",
+                description:
+                  "Pay-per-request, fast cold-starts on small services, great for spiky traffic.",
+              },
+              {
+                value: "aws-ecs",
+                label: "AWS ECS Fargate",
+                description:
+                  "Long-running containers, no cold starts, easier WebSockets. Higher idle cost than Lambda.",
+              },
+              {
+                value: "vercel",
+                label: "Vercel",
+                description:
+                  "Push-to-deploy with edge runtime. Best for frontends and lightweight Node APIs.",
+              },
+            ],
+          },
+        ]}
+      />
+    );
+  },
+};
+
+// List layout is for simple, low-stakes preference forms — short labels, no
+// per-question explanation needed.
+export const MultiQuestionList: StoryObj = {
+  render: () => {
+    const [status, setStatus] = useState<"pending" | "submitted">("pending");
+    return (
+      <AgentSidebarMultiQuestion
+        layout="list"
+        title="Customize your experience"
+        description="Pick a few defaults. You can change these any time from preferences."
+        status={status}
+        onSubmit={(answers) => {
+          console.log("submitted", answers);
+          setStatus("submitted");
+        }}
+        questions={[
+          {
+            id: "theme",
+            type: "select",
+            label: "Theme",
+            options: [
+              { value: "system", label: "Match system" },
+              { value: "light", label: "Light" },
+              { value: "dark", label: "Dark" },
+            ],
+            defaultValue: "system",
+          },
+          {
+            id: "marketing",
+            type: "toggle",
+            label: "Send product update emails",
+            defaultValue: false,
+          },
+          {
+            id: "displayName",
+            type: "text",
+            label: "Display name",
+            placeholder: "Alice",
+            defaultValue: "Alice",
+          },
+        ]}
+      />
+    );
+  },
+};

--- a/src/components/ui/agent-sidebar/AgentAsks.stories.tsx
+++ b/src/components/ui/agent-sidebar/AgentAsks.stories.tsx
@@ -15,9 +15,8 @@ const meta: Meta = {
 
 export default meta;
 
-// Tabs layout is for *decisions* — multiple sections, each with weighted
-// trade-offs. Example: scaffolding a new service. Each tab is one decision,
-// each option is a multi-choice card with an explanation to help pick.
+// Tabs layout — for weighted decisions where each option needs explanation.
+// Use `choice` with style="cards" so options show a description per option.
 export const MultiQuestionTabs: StoryObj = {
   render: () => {
     const [status, setStatus] = useState<"pending" | "submitted">("pending");
@@ -34,6 +33,7 @@ export const MultiQuestionTabs: StoryObj = {
           {
             id: "database",
             type: "choice",
+            style: "cards",
             label: "Primary database",
             tabLabel: "Database",
             description:
@@ -62,6 +62,7 @@ export const MultiQuestionTabs: StoryObj = {
           {
             id: "auth",
             type: "choice",
+            style: "cards",
             label: "Authentication strategy",
             tabLabel: "Auth",
             description:
@@ -90,6 +91,7 @@ export const MultiQuestionTabs: StoryObj = {
           {
             id: "hosting",
             type: "choice",
+            style: "cards",
             label: "Deploy target",
             tabLabel: "Hosting",
             description:
@@ -121,8 +123,8 @@ export const MultiQuestionTabs: StoryObj = {
   },
 };
 
-// List layout is for simple, low-stakes preference forms — short labels, no
-// per-question explanation needed.
+// List layout — for simple preferences with quick-pick options. Use `choice`
+// with style="segmented" so options are visible inline (no Combobox click).
 export const MultiQuestionList: StoryObj = {
   render: () => {
     const [status, setStatus] = useState<"pending" | "submitted">("pending");
@@ -139,14 +141,14 @@ export const MultiQuestionList: StoryObj = {
         questions={[
           {
             id: "theme",
-            type: "select",
+            type: "choice",
+            style: "segmented",
             label: "Theme",
             options: [
-              { value: "system", label: "Match system" },
+              { value: "system", label: "System" },
               { value: "light", label: "Light" },
               { value: "dark", label: "Dark" },
             ],
-            defaultValue: "system",
           },
           {
             id: "marketing",

--- a/src/components/ui/agent-sidebar/AgentSidebar.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebar.tsx
@@ -21,6 +21,7 @@ export {
   type AgentSidebarMultiQuestionStatus,
   type AgentSidebarMultiQuestionAnswer,
   type AgentSidebarMultiQuestionLayout,
+  type AgentSidebarChoiceStyle,
 } from "./AgentSidebarMultiQuestion";
 export {
   AgentSidebarMessages,

--- a/src/components/ui/agent-sidebar/AgentSidebar.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebar.tsx
@@ -15,6 +15,14 @@ export {
   type AgentSidebarAgentMessageProps,
 } from "./AgentSidebarMessage";
 export {
+  AgentSidebarMultiQuestion,
+  type AgentSidebarMultiQuestionProps,
+  type AgentSidebarQuestion,
+  type AgentSidebarMultiQuestionStatus,
+  type AgentSidebarMultiQuestionAnswer,
+  type AgentSidebarMultiQuestionLayout,
+} from "./AgentSidebarMultiQuestion";
+export {
   AgentSidebarMessages,
   type AgentSidebarMessage,
   type AgentSidebarMessagesProps,

--- a/src/components/ui/agent-sidebar/AgentSidebarMessages.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMessages.tsx
@@ -4,6 +4,13 @@ import {
   AgentSidebarUserMessage,
   AgentSidebarAgentMessage,
 } from "./AgentSidebarMessage";
+import {
+  AgentSidebarMultiQuestion,
+  type AgentSidebarQuestion,
+  type AgentSidebarMultiQuestionStatus,
+  type AgentSidebarMultiQuestionAnswer,
+  type AgentSidebarMultiQuestionLayout,
+} from "./AgentSidebarMultiQuestion";
 
 export type AgentSidebarMessage =
   | {
@@ -16,10 +23,25 @@ export type AgentSidebarMessage =
       role: "agent";
       content: string;
       streaming?: boolean;
+    }
+  | {
+      id: string;
+      role: "agent";
+      kind: "multi-question";
+      title: string;
+      description?: string;
+      questions: AgentSidebarQuestion[];
+      submitLabel?: string;
+      status?: AgentSidebarMultiQuestionStatus;
+      layout?: AgentSidebarMultiQuestionLayout;
     };
 
 export interface AgentSidebarMessagesProps {
   messages: AgentSidebarMessage[];
+  onSubmitMultiQuestion?: (
+    messageId: string,
+    answers: Record<string, AgentSidebarMultiQuestionAnswer>,
+  ) => void;
   /** Auto-scroll to the latest message. Default: true. */
   autoScroll?: boolean;
   className?: string;
@@ -39,6 +61,7 @@ function findScrollParent(el: HTMLElement | null): HTMLElement | null {
 
 export function AgentSidebarMessages({
   messages,
+  onSubmitMultiQuestion,
   autoScroll = true,
   className,
 }: AgentSidebarMessagesProps) {
@@ -74,6 +97,20 @@ export function AgentSidebarMessages({
       {messages.map((m) => {
         if (m.role === "user") {
           return <AgentSidebarUserMessage key={m.id} content={m.content} />;
+        }
+        if ("kind" in m) {
+          return (
+            <AgentSidebarMultiQuestion
+              key={m.id}
+              title={m.title}
+              description={m.description}
+              questions={m.questions}
+              submitLabel={m.submitLabel}
+              status={m.status}
+              layout={m.layout}
+              onSubmit={(answers) => onSubmitMultiQuestion?.(m.id, answers)}
+            />
+          );
         }
         return (
           <AgentSidebarAgentMessage

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -230,35 +230,31 @@ function renderField(
   };
 
   if (q.style === "segmented") {
-    if (!isMulti) {
-      return (
-        <SegmentedButton
-          size="sm"
-          aria-label={q.label}
-          value={singleCurrent}
-          disabled={submitted}
-          onChange={(v) => setAnswer(q.id, v === singleCurrent ? "" : v)}
-          options={q.options.map((o) => ({ value: o.value, label: o.label }))}
-        />
-      );
-    }
-    // segmented + multiple → independent toggle chips
     return (
       <div
-        role="group"
+        role={isMulti ? "group" : "radiogroup"}
         aria-label={q.label}
         className="flex flex-wrap gap-1.5"
       >
         {q.options.map((opt) => {
-          const selected = selectedValues.has(opt.value);
+          const selected = isMulti
+            ? selectedValues.has(opt.value)
+            : opt.value === singleCurrent;
+          const handleClick = () => {
+            if (isMulti) {
+              toggleMulti(opt.value);
+            } else {
+              setAnswer(q.id, selected ? "" : opt.value);
+            }
+          };
           return (
             <button
               key={opt.value}
               type="button"
-              role="checkbox"
+              role={isMulti ? "checkbox" : "radio"}
               aria-checked={selected}
               disabled={submitted}
-              onClick={() => toggleMulti(opt.value)}
+              onClick={handleClick}
               className={cn(
                 "rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50",
                 selected

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -4,6 +4,7 @@ import { Icon } from "@/components/ui/media/icon/Icon";
 import { Button } from "@/components/ui/actions/button/Button";
 import { FloatingLabelInput } from "@/components/ui/inputs/floating-label-input/FloatingLabelInput";
 import { SegmentedButton } from "@/components/ui/inputs/segmented-button/SegmentedButton";
+import { Switch } from "@/components/ui/inputs/switch/Switch";
 
 interface QuestionBase {
   id: string;
@@ -102,7 +103,6 @@ function isAnswered(
   q: AgentSidebarQuestion,
   value: AgentSidebarMultiQuestionAnswer,
 ): boolean {
-  // A switch always has a valid answer (on or off); never flag it as missing.
   if (q.type === "toggle") return true;
   if (q.type === "choice" && q.multiple) {
     return Array.isArray(value) && value.length > 0;
@@ -161,6 +161,12 @@ const inverseSegmentedClass = cn(
   "[&>button[aria-pressed=false]]:hover:text-inverse-on-surface!",
 );
 
+const inverseSwitchClass = cn(
+  "aria-checked:bg-inverse-primary!",
+  "aria-[checked=false]:bg-inverse-on-surface/20!",
+  "[&>span]:bg-inverse-surface!",
+);
+
 function renderField(
   q: AgentSidebarQuestion,
   value: AgentSidebarMultiQuestionAnswer,
@@ -202,28 +208,16 @@ function renderField(
   }
   if (q.type === "toggle") {
     return (
-      <button
-        id={fieldId}
-        type="button"
-        role="switch"
-        aria-checked={!!value}
+      <Switch
+        checked={!!value}
+        onChange={(checked) => setAnswer(q.id, checked)}
+        aria-label={q.label}
         disabled={submitted}
-        onClick={() => setAnswer(q.id, !value)}
-        className={cn(
-          "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors disabled:opacity-50",
-          value ? "bg-inverse-primary" : "bg-inverse-on-surface/20",
-        )}
-      >
-        <span
-          className={cn(
-            "inline-block h-4 w-4 rounded-full bg-inverse-surface shadow transition-transform",
-            value ? "translate-x-[18px]" : "translate-x-0.5",
-          )}
-        />
-      </button>
+        className={inverseSwitchClass}
+      />
     );
   }
-  // choice
+  if (q.type === "choice") {
   const isMulti = q.multiple === true;
   const selectedValues = isMulti
     ? new Set(Array.isArray(value) ? value : [])
@@ -256,9 +250,6 @@ function renderField(
         />
       );
     }
-    // segmented + multiple → independent toggle chips, styled to match
-    // SegmentedButton's selected/unselected look so single and multi
-    // segmented questions read as the same control.
     return (
       <div
         role="group"
@@ -358,6 +349,9 @@ function renderField(
       })}
     </div>
   );
+  }
+  const _exhaustive: never = q;
+  return _exhaustive;
 }
 
 export function AgentSidebarMultiQuestion({
@@ -386,7 +380,6 @@ export function AgentSidebarMultiQuestion({
   const isReview = activeTabId === REVIEW_TAB_ID;
   const activeIdx = questions.findIndex((q) => q.id === activeTabId);
   const active = activeIdx >= 0 ? questions[activeIdx] : null;
-  const safeIdx = activeIdx >= 0 ? activeIdx : 0;
 
   const summaries = questions.map((q) => {
     const value = answers[q.id];
@@ -548,9 +541,9 @@ export function AgentSidebarMultiQuestion({
                 <Button
                   variant="text"
                   size="sm"
-                  disabled={safeIdx === 0}
+                  disabled={activeIdx === 0}
                   onClick={() => {
-                    const next = questions[Math.max(0, safeIdx - 1)];
+                    const next = questions[Math.max(0, activeIdx - 1)];
                     if (next) setActiveTabId(next.id);
                   }}
                   leftIcon="arrow_back"
@@ -561,10 +554,10 @@ export function AgentSidebarMultiQuestion({
                 <Button
                   variant="text"
                   size="sm"
-                  disabled={safeIdx === questions.length - 1}
+                  disabled={activeIdx === questions.length - 1}
                   onClick={() => {
                     const next =
-                      questions[Math.min(questions.length - 1, safeIdx + 1)];
+                      questions[Math.min(questions.length - 1, activeIdx + 1)];
                     if (next) setActiveTabId(next.id);
                   }}
                   rightIcon="arrow_forward"

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -153,6 +153,7 @@ const inverseFieldInput = cn(
 // so single-select segmented matches the inverse-primary chip palette used
 // by multi-select segmented above.
 const inverseSegmentedClass = cn(
+  "flex-wrap",
   "[&>button[aria-pressed=true]]:bg-inverse-primary!",
   "[&>button[aria-pressed=true]]:text-inverse-surface!",
   "[&>button[aria-pressed=false]]:bg-inverse-on-surface/[0.06]!",

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -1,0 +1,492 @@
+import { useState, type ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import { Icon } from "@/components/ui/media/icon/Icon";
+import { Button } from "@/components/ui/actions/button/Button";
+import { Combobox } from "@/components/ui/inputs/combobox/Combobox";
+import { SegmentedButton } from "@/components/ui/inputs/segmented-button/SegmentedButton";
+
+interface QuestionBase {
+  id: string;
+  label: string;
+  /** Extra explanatory text shown prominently in tabs layout, and below the label in list layout. */
+  description?: string;
+  /** Short label used on the tab pill in tabs layout. Defaults to `label`. */
+  tabLabel?: string;
+}
+
+export type AgentSidebarQuestion =
+  | (QuestionBase & {
+      type: "text";
+      placeholder?: string;
+      defaultValue?: string;
+    })
+  | (QuestionBase & {
+      type: "textarea";
+      placeholder?: string;
+      defaultValue?: string;
+    })
+  | (QuestionBase & {
+      type: "select";
+      options: { value: string; label: string }[];
+      defaultValue?: string;
+    })
+  | (QuestionBase & {
+      type: "toggle";
+      defaultValue?: boolean;
+    })
+  | (QuestionBase & {
+      type: "choice";
+      options: {
+        value: string;
+        label: string;
+        description?: string;
+      }[];
+      defaultValue?: string;
+    });
+
+export type AgentSidebarMultiQuestionStatus = "pending" | "submitted";
+
+export type AgentSidebarMultiQuestionAnswer = string | boolean;
+
+export type AgentSidebarMultiQuestionLayout = "list" | "tabs";
+
+export interface AgentSidebarMultiQuestionProps {
+  title: string;
+  description?: string;
+  questions: AgentSidebarQuestion[];
+  submitLabel?: string;
+  status?: AgentSidebarMultiQuestionStatus;
+  onSubmit?: (answers: Record<string, AgentSidebarMultiQuestionAnswer>) => void;
+  className?: string;
+  /** "tabs" (default) shows one question at a time with a tab pill row + description.
+   *  "list" stacks all fields vertically with compact labels. */
+  layout?: AgentSidebarMultiQuestionLayout;
+}
+
+const REVIEW_TAB_ID = "__review__";
+
+const borderByStatus: Record<AgentSidebarMultiQuestionStatus, string> = {
+  pending: "border-outline-variant/30",
+  submitted: "border-inverse-primary/40",
+};
+
+const headerByStatus: Record<
+  AgentSidebarMultiQuestionStatus,
+  { text: string; color: string; icon: string }
+> = {
+  pending: {
+    text: "Answer to continue",
+    color: "text-inverse-on-surface/55",
+    icon: "edit_note",
+  },
+  submitted: { text: "Submitted", color: "text-inverse-primary", icon: "check_circle" },
+};
+
+function initialAnswers(
+  questions: AgentSidebarQuestion[],
+): Record<string, AgentSidebarMultiQuestionAnswer> {
+  const out: Record<string, AgentSidebarMultiQuestionAnswer> = {};
+  for (const q of questions) {
+    if (q.type === "toggle") out[q.id] = q.defaultValue ?? false;
+    else if (q.type === "select")
+      out[q.id] = q.defaultValue ?? q.options[0]?.value ?? "";
+    else if (q.type === "choice") out[q.id] = q.defaultValue ?? "";
+    else out[q.id] = q.defaultValue ?? "";
+  }
+  return out;
+}
+
+function isAnswered(
+  q: AgentSidebarQuestion,
+  value: AgentSidebarMultiQuestionAnswer,
+): boolean {
+  if (q.type === "toggle") return value !== (q.defaultValue ?? false);
+  if (typeof value !== "string") return false;
+  if (q.type === "select")
+    return value !== (q.defaultValue ?? q.options[0]?.value ?? "");
+  if (q.type === "choice") return value.length > 0;
+  return value.trim().length > 0;
+}
+
+function formatAnswer(
+  q: AgentSidebarQuestion,
+  value: AgentSidebarMultiQuestionAnswer,
+): string {
+  if (q.type === "toggle") return value ? "On" : "Off";
+  if (typeof value !== "string" || value.length === 0) return "";
+  if (q.type === "choice" || q.type === "select") {
+    const opt = q.options.find((o) => o.value === value);
+    return opt?.label ?? value;
+  }
+  return value;
+}
+
+const fieldCls =
+  "w-full rounded-md bg-inverse-on-surface/[0.06] border border-transparent px-2.5 py-1.5 text-sm text-inverse-on-surface placeholder:text-inverse-on-surface/30 focus:outline-none focus:border-inverse-primary/60 focus:bg-inverse-on-surface/[0.08] disabled:opacity-50";
+
+function renderField(
+  q: AgentSidebarQuestion,
+  value: AgentSidebarMultiQuestionAnswer,
+  setAnswer: (id: string, v: AgentSidebarMultiQuestionAnswer) => void,
+  submitted: boolean,
+): ReactNode {
+  const fieldId = `mq-${q.id}`;
+  if (q.type === "text") {
+    return (
+      <input
+        id={fieldId}
+        type="text"
+        className={fieldCls}
+        placeholder={q.placeholder}
+        value={typeof value === "string" ? value : ""}
+        onChange={(e) => setAnswer(q.id, e.target.value)}
+        disabled={submitted}
+      />
+    );
+  }
+  if (q.type === "textarea") {
+    return (
+      <textarea
+        id={fieldId}
+        className={cn(fieldCls, "resize-none min-h-[60px]")}
+        placeholder={q.placeholder}
+        rows={3}
+        value={typeof value === "string" ? value : ""}
+        onChange={(e) => setAnswer(q.id, e.target.value)}
+        disabled={submitted}
+      />
+    );
+  }
+  if (q.type === "select") {
+    return (
+      <Combobox
+        id={fieldId}
+        label={q.label}
+        hideLabel
+        size="sm"
+        disabled={submitted}
+        value={typeof value === "string" ? value : ""}
+        onChange={(v) => setAnswer(q.id, v)}
+        options={q.options}
+      />
+    );
+  }
+  if (q.type === "choice") {
+    const current = typeof value === "string" ? value : "";
+    return (
+      <div role="radiogroup" aria-labelledby={fieldId} className="flex flex-col gap-1.5">
+        {q.options.map((opt) => {
+          const selected = opt.value === current;
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              disabled={submitted}
+              onClick={() => setAnswer(q.id, selected ? "" : opt.value)}
+              className={cn(
+                "group flex items-start gap-2.5 rounded-md border px-3 py-2.5 text-left transition-colors disabled:opacity-50",
+                selected
+                  ? "border-inverse-primary/60 bg-inverse-primary/[0.08]"
+                  : "border-outline-variant/25 bg-inverse-on-surface/[0.03] hover:border-outline-variant/50 hover:bg-inverse-on-surface/[0.06]",
+              )}
+            >
+              <span
+                className={cn(
+                  "mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-2 transition-colors",
+                  selected
+                    ? "border-inverse-primary"
+                    : "border-inverse-on-surface/30 group-hover:border-inverse-on-surface/50",
+                )}
+              >
+                {selected && (
+                  <span className="block h-1.5 w-1.5 rounded-full bg-inverse-primary" />
+                )}
+              </span>
+              <span className="flex-1 min-w-0">
+                <span className="block text-sm font-medium text-inverse-on-surface">
+                  {opt.label}
+                </span>
+                {opt.description && (
+                  <span className="block text-xs text-inverse-on-surface/60 mt-0.5 leading-relaxed">
+                    {opt.description}
+                  </span>
+                )}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+  return (
+    <button
+      id={fieldId}
+      type="button"
+      role="switch"
+      aria-checked={!!value}
+      disabled={submitted}
+      onClick={() => setAnswer(q.id, !value)}
+      className={cn(
+        "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors disabled:opacity-50",
+        value ? "bg-inverse-primary" : "bg-inverse-on-surface/20",
+      )}
+    >
+      <span
+        className={cn(
+          "inline-block h-4 w-4 rounded-full bg-inverse-surface shadow transition-transform",
+          value ? "translate-x-[18px]" : "translate-x-0.5",
+        )}
+      />
+    </button>
+  );
+}
+
+export function AgentSidebarMultiQuestion({
+  title,
+  description,
+  questions,
+  submitLabel = "Submit",
+  status = "pending",
+  onSubmit,
+  className,
+  layout = "tabs",
+}: AgentSidebarMultiQuestionProps) {
+  const [answers, setAnswers] = useState(() => initialAnswers(questions));
+  const [activeTabId, setActiveTabId] = useState<string>(
+    questions[0]?.id ?? REVIEW_TAB_ID,
+  );
+  const submitted = status === "submitted";
+  const header = headerByStatus[status];
+
+  const setAnswer = (id: string, value: AgentSidebarMultiQuestionAnswer) => {
+    setAnswers((prev) => ({ ...prev, [id]: value }));
+  };
+
+  const handleSubmit = () => onSubmit?.(answers);
+
+  const isReview = activeTabId === REVIEW_TAB_ID;
+  const activeIdx = questions.findIndex((q) => q.id === activeTabId);
+  const active = activeIdx >= 0 ? questions[activeIdx] : null;
+  const safeIdx = activeIdx >= 0 ? activeIdx : 0;
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border bg-inverse-on-surface/[0.03] transition-colors",
+        borderByStatus[status],
+        className,
+      )}
+    >
+      <div className="flex items-center gap-1.5 px-3 pt-2.5 pb-1">
+        <Icon name={header.icon} size={12} className={header.color} />
+        <span
+          className={cn(
+            "text-[10px] font-medium uppercase tracking-[0.08em]",
+            header.color,
+          )}
+        >
+          {header.text}
+        </span>
+      </div>
+
+      <div className="px-3 pb-3">
+        <div className="text-sm font-medium text-inverse-on-surface leading-snug">
+          {title}
+        </div>
+        {description && (
+          <div className="text-xs text-inverse-on-surface/55 mt-0.5 leading-snug">
+            {description}
+          </div>
+        )}
+
+        {layout === "tabs" && !submitted ? (
+          <>
+            <div className="mt-3">
+              <SegmentedButton
+                aria-label="Select a question"
+                size="sm"
+                value={activeTabId}
+                onChange={(id) => setActiveTabId(id)}
+                options={[
+                  ...questions.map((q) => {
+                    const answered = isAnswered(q, answers[q.id]);
+                    return {
+                      value: q.id,
+                      label: q.tabLabel ?? q.label,
+                      tone: answered ? "muted" : "warn",
+                    } as const;
+                  }),
+                  { value: REVIEW_TAB_ID, label: "Review" },
+                ]}
+              />
+            </div>
+
+            {isReview ? (
+              <div className="mt-3 flex flex-col gap-2">
+                {questions.map((q) => {
+                  const value = answers[q.id];
+                  const answered = isAnswered(q, value);
+                  const ans = formatAnswer(q, value);
+                  const filled = answered && !!ans;
+                  return (
+                    <div
+                      key={q.id}
+                      className="flex flex-col gap-0.5 rounded-md bg-inverse-on-surface/[0.04] px-3 py-2"
+                    >
+                      <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-inverse-on-surface/55">
+                        {q.label}
+                      </span>
+                      {filled ? (
+                        <span className="text-sm text-inverse-on-surface">{ans}</span>
+                      ) : (
+                        <span className="text-sm italic text-warning-container">
+                          Not answered
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            ) : active ? (
+              <div className="mt-3 rounded-md border border-outline-variant/20 px-3 py-3 flex flex-col gap-2">
+                <div className="text-sm font-medium text-inverse-on-surface leading-snug">
+                  {active.label}
+                </div>
+                {active.description && (
+                  <div className="text-xs text-inverse-on-surface/65 leading-relaxed">
+                    {active.description}
+                  </div>
+                )}
+                <div className={cn(active.type === "toggle" && "flex justify-end")}>
+                  {renderField(active, answers[active.id], setAnswer, submitted)}
+                </div>
+              </div>
+            ) : null}
+          </>
+        ) : layout === "tabs" && submitted ? (
+          <div className="mt-3 flex flex-col gap-2">
+            {questions.map((q) => {
+              const value = answers[q.id];
+              const answered = isAnswered(q, value);
+              const ans = formatAnswer(q, value);
+              const filled = answered && !!ans;
+              return (
+                <div
+                  key={q.id}
+                  className="flex flex-col gap-0.5 rounded-md bg-inverse-on-surface/[0.04] px-3 py-2"
+                >
+                  <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-inverse-on-surface/55">
+                    {q.label}
+                  </span>
+                  {filled ? (
+                    <span className="text-sm text-inverse-on-surface">{ans}</span>
+                  ) : (
+                    <span className="text-sm italic text-warning-container">
+                      Not answered
+                    </span>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="mt-2.5 flex flex-col gap-2.5">
+            {questions.map((q) => {
+              const value = answers[q.id];
+              const fieldId = `mq-${q.id}`;
+              if (q.type === "toggle") {
+                return (
+                  <div
+                    key={q.id}
+                    className="flex items-center justify-between gap-3 rounded-md bg-inverse-on-surface/[0.06] px-2.5 py-2"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <label
+                        htmlFor={fieldId}
+                        className="text-sm text-inverse-on-surface block"
+                      >
+                        {q.label}
+                      </label>
+                      {q.description && (
+                        <span className="text-xs text-inverse-on-surface/55 block mt-0.5">
+                          {q.description}
+                        </span>
+                      )}
+                    </div>
+                    {renderField(q, value, setAnswer, submitted)}
+                  </div>
+                );
+              }
+              return (
+                <div key={q.id} className="flex flex-col gap-1">
+                  <label
+                    htmlFor={fieldId}
+                    className="text-[10px] font-medium uppercase tracking-[0.08em] text-inverse-on-surface/55"
+                  >
+                    {q.label}
+                  </label>
+                  {q.description && (
+                    <span className="text-xs text-inverse-on-surface/55 -mt-0.5">
+                      {q.description}
+                    </span>
+                  )}
+                  {renderField(q, value, setAnswer, submitted)}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {!submitted && (
+          <div className="mt-3 flex items-center justify-between gap-2">
+            {layout === "tabs" && questions.length > 1 && !isReview ? (
+              <div className="flex gap-1">
+                <Button
+                  variant="text"
+                  size="sm"
+                  disabled={safeIdx === 0}
+                  onClick={() => {
+                    const next = questions[Math.max(0, safeIdx - 1)];
+                    if (next) setActiveTabId(next.id);
+                  }}
+                  leftIcon="arrow_back"
+                  className="text-inverse-on-surface/60 hover:text-inverse-on-surface hover:bg-inverse-on-surface/10"
+                >
+                  Prev
+                </Button>
+                <Button
+                  variant="text"
+                  size="sm"
+                  disabled={safeIdx === questions.length - 1}
+                  onClick={() => {
+                    const next =
+                      questions[Math.min(questions.length - 1, safeIdx + 1)];
+                    if (next) setActiveTabId(next.id);
+                  }}
+                  rightIcon="arrow_forward"
+                  className="text-inverse-on-surface/60 hover:text-inverse-on-surface hover:bg-inverse-on-surface/10"
+                >
+                  Next
+                </Button>
+              </div>
+            ) : (
+              <span />
+            )}
+            <Button
+              variant="tonal"
+              color="primary"
+              size="sm"
+              onClick={handleSubmit}
+              rightIcon="check"
+              className="hover:bg-primary hover:text-on-primary"
+            >
+              {submitLabel}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -94,7 +94,8 @@ function isAnswered(
   q: AgentSidebarQuestion,
   value: AgentSidebarMultiQuestionAnswer,
 ): boolean {
-  if (q.type === "toggle") return value !== (q.defaultValue ?? false);
+  // A switch always has a valid answer (on or off); never flag it as missing.
+  if (q.type === "toggle") return true;
   if (typeof value !== "string") return false;
   if (q.type === "choice") return value.length > 0;
   return value.trim().length > 0;
@@ -104,7 +105,7 @@ function formatAnswer(
   q: AgentSidebarQuestion,
   value: AgentSidebarMultiQuestionAnswer,
 ): string {
-  if (q.type === "toggle") return value ? "On" : "Off";
+  if (q.type === "toggle") return value ? "Enabled" : "Not enabled";
   if (typeof value !== "string" || value.length === 0) return "";
   if (q.type === "choice") {
     const opt = q.options.find((o) => o.value === value);

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -2,7 +2,6 @@ import { useState, type ReactNode } from "react";
 import { cn } from "@/utils/cn";
 import { Icon } from "@/components/ui/media/icon/Icon";
 import { Button } from "@/components/ui/actions/button/Button";
-import { Combobox } from "@/components/ui/inputs/combobox/Combobox";
 import { FloatingLabelInput } from "@/components/ui/inputs/floating-label-input/FloatingLabelInput";
 import { SegmentedButton } from "@/components/ui/inputs/segmented-button/SegmentedButton";
 
@@ -15,20 +14,14 @@ interface QuestionBase {
   tabLabel?: string;
 }
 
+export type AgentSidebarChoiceStyle = "segmented" | "cards";
+
 export type AgentSidebarQuestion =
   | (QuestionBase & {
       type: "text";
+      /** When true, renders as a textarea. */
+      multiline?: boolean;
       placeholder?: string;
-      defaultValue?: string;
-    })
-  | (QuestionBase & {
-      type: "textarea";
-      placeholder?: string;
-      defaultValue?: string;
-    })
-  | (QuestionBase & {
-      type: "select";
-      options: { value: string; label: string }[];
       defaultValue?: string;
     })
   | (QuestionBase & {
@@ -37,6 +30,9 @@ export type AgentSidebarQuestion =
     })
   | (QuestionBase & {
       type: "choice";
+      /** "segmented" — all options visible inline as a pill row (use for short labels, no descriptions).
+       *  "cards" — radio-card list with title + description per option (use for weighted decisions). */
+      style: AgentSidebarChoiceStyle;
       options: {
         value: string;
         label: string;
@@ -89,9 +85,6 @@ function initialAnswers(
   const out: Record<string, AgentSidebarMultiQuestionAnswer> = {};
   for (const q of questions) {
     if (q.type === "toggle") out[q.id] = q.defaultValue ?? false;
-    else if (q.type === "select")
-      out[q.id] = q.defaultValue ?? q.options[0]?.value ?? "";
-    else if (q.type === "choice") out[q.id] = q.defaultValue ?? "";
     else out[q.id] = q.defaultValue ?? "";
   }
   return out;
@@ -103,8 +96,6 @@ function isAnswered(
 ): boolean {
   if (q.type === "toggle") return value !== (q.defaultValue ?? false);
   if (typeof value !== "string") return false;
-  if (q.type === "select")
-    return value !== (q.defaultValue ?? q.options[0]?.value ?? "");
   if (q.type === "choice") return value.length > 0;
   return value.trim().length > 0;
 }
@@ -115,7 +106,7 @@ function formatAnswer(
 ): string {
   if (q.type === "toggle") return value ? "On" : "Off";
   if (typeof value !== "string" || value.length === 0) return "";
-  if (q.type === "choice" || q.type === "select") {
+  if (q.type === "choice") {
     const opt = q.options.find((o) => o.value === value);
     return opt?.label ?? value;
   }
@@ -147,6 +138,23 @@ function renderField(
 ): ReactNode {
   const fieldId = `mq-${q.id}`;
   if (q.type === "text") {
+    if (q.multiline) {
+      return (
+        <FloatingLabelInput
+          id={fieldId}
+          label={q.placeholder ?? q.label}
+          hideLabel
+          multiline
+          size="sm"
+          rows={3}
+          value={typeof value === "string" ? value : ""}
+          onChange={(e) => setAnswer(q.id, e.target.value)}
+          disabled={submitted}
+          containerClassName={inverseFieldContainer}
+          className={inverseFieldInput}
+        />
+      );
+    }
     return (
       <FloatingLabelInput
         id={fieldId}
@@ -161,107 +169,88 @@ function renderField(
       />
     );
   }
-  if (q.type === "textarea") {
+  if (q.type === "toggle") {
     return (
-      <FloatingLabelInput
+      <button
         id={fieldId}
-        label={q.placeholder ?? q.label}
-        hideLabel
-        multiline
-        size="sm"
-        rows={3}
-        value={typeof value === "string" ? value : ""}
-        onChange={(e) => setAnswer(q.id, e.target.value)}
+        type="button"
+        role="switch"
+        aria-checked={!!value}
         disabled={submitted}
-        containerClassName={inverseFieldContainer}
-        className={inverseFieldInput}
-      />
+        onClick={() => setAnswer(q.id, !value)}
+        className={cn(
+          "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors disabled:opacity-50",
+          value ? "bg-inverse-primary" : "bg-inverse-on-surface/20",
+        )}
+      >
+        <span
+          className={cn(
+            "inline-block h-4 w-4 rounded-full bg-inverse-surface shadow transition-transform",
+            value ? "translate-x-[18px]" : "translate-x-0.5",
+          )}
+        />
+      </button>
     );
   }
-  if (q.type === "select") {
+  // choice
+  const current = typeof value === "string" ? value : "";
+  if (q.style === "segmented") {
     return (
-      <Combobox
-        id={fieldId}
-        label={q.label}
-        hideLabel
+      <SegmentedButton
         size="sm"
+        aria-label={q.label}
+        value={current}
         disabled={submitted}
-        value={typeof value === "string" ? value : ""}
-        onChange={(v) => setAnswer(q.id, v)}
-        options={q.options}
-        className={inverseFieldContainer}
+        onChange={(v) => setAnswer(q.id, v === current ? "" : v)}
+        options={q.options.map((o) => ({ value: o.value, label: o.label }))}
       />
-    );
-  }
-  if (q.type === "choice") {
-    const current = typeof value === "string" ? value : "";
-    return (
-      <div role="radiogroup" aria-labelledby={fieldId} className="flex flex-col gap-1.5">
-        {q.options.map((opt) => {
-          const selected = opt.value === current;
-          return (
-            <button
-              key={opt.value}
-              type="button"
-              role="radio"
-              aria-checked={selected}
-              disabled={submitted}
-              onClick={() => setAnswer(q.id, selected ? "" : opt.value)}
-              className={cn(
-                "group flex items-start gap-2.5 rounded-md border px-3 py-2.5 text-left transition-colors disabled:opacity-50",
-                selected
-                  ? "border-inverse-primary/60 bg-inverse-primary/[0.08]"
-                  : "border-outline-variant/25 bg-inverse-on-surface/[0.03] hover:border-outline-variant/50 hover:bg-inverse-on-surface/[0.06]",
-              )}
-            >
-              <span
-                className={cn(
-                  "mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-2 transition-colors",
-                  selected
-                    ? "border-inverse-primary"
-                    : "border-inverse-on-surface/30 group-hover:border-inverse-on-surface/50",
-                )}
-              >
-                {selected && (
-                  <span className="block h-1.5 w-1.5 rounded-full bg-inverse-primary" />
-                )}
-              </span>
-              <span className="flex-1 min-w-0">
-                <span className="block text-sm font-medium text-inverse-on-surface">
-                  {opt.label}
-                </span>
-                {opt.description && (
-                  <span className="block text-xs text-inverse-on-surface/60 mt-0.5 leading-relaxed">
-                    {opt.description}
-                  </span>
-                )}
-              </span>
-            </button>
-          );
-        })}
-      </div>
     );
   }
   return (
-    <button
-      id={fieldId}
-      type="button"
-      role="switch"
-      aria-checked={!!value}
-      disabled={submitted}
-      onClick={() => setAnswer(q.id, !value)}
-      className={cn(
-        "relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors disabled:opacity-50",
-        value ? "bg-inverse-primary" : "bg-inverse-on-surface/20",
-      )}
-    >
-      <span
-        className={cn(
-          "inline-block h-4 w-4 rounded-full bg-inverse-surface shadow transition-transform",
-          value ? "translate-x-[18px]" : "translate-x-0.5",
-        )}
-      />
-    </button>
+    <div role="radiogroup" aria-labelledby={fieldId} className="flex flex-col gap-1.5">
+      {q.options.map((opt) => {
+        const selected = opt.value === current;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            disabled={submitted}
+            onClick={() => setAnswer(q.id, selected ? "" : opt.value)}
+            className={cn(
+              "group flex items-start gap-2.5 rounded-md border px-3 py-2.5 text-left transition-colors disabled:opacity-50",
+              selected
+                ? "border-inverse-primary/60 bg-inverse-primary/[0.08]"
+                : "border-outline-variant/25 bg-inverse-on-surface/[0.03] hover:border-outline-variant/50 hover:bg-inverse-on-surface/[0.06]",
+            )}
+          >
+            <span
+              className={cn(
+                "mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-2 transition-colors",
+                selected
+                  ? "border-inverse-primary"
+                  : "border-inverse-on-surface/30 group-hover:border-inverse-on-surface/50",
+              )}
+            >
+              {selected && (
+                <span className="block h-1.5 w-1.5 rounded-full bg-inverse-primary" />
+              )}
+            </span>
+            <span className="flex-1 min-w-0">
+              <span className="block text-sm font-medium text-inverse-on-surface">
+                {opt.label}
+              </span>
+              {opt.description && (
+                <span className="block text-xs text-inverse-on-surface/60 mt-0.5 leading-relaxed">
+                  {opt.description}
+                </span>
+              )}
+            </span>
+          </button>
+        );
+      })}
+    </div>
   );
 }
 

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -450,7 +450,7 @@ export function AgentSidebarMultiQuestion({
                 size="sm"
                 value={activeTabId}
                 onChange={(id) => setActiveTabId(id)}
-                className="[&>button]:flex-1"
+                className="flex-wrap"
                 options={[
                   ...summaries.map(({ q, answered }) => ({
                     value: q.id,

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -450,6 +450,7 @@ export function AgentSidebarMultiQuestion({
                 size="sm"
                 value={activeTabId}
                 onChange={(id) => setActiveTabId(id)}
+                className="[&>button]:flex-1"
                 options={[
                   ...summaries.map(({ q, answered }) => ({
                     value: q.id,

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -126,17 +126,17 @@ function formatAnswer(
 // agent sidebar. Targets the components' bordered wrapper (`bg-surface-container-low`
 // → inverse fill) and the input/textarea element text/placeholder colors.
 const inverseFieldContainer = cn(
-  "[&>div]:!bg-inverse-on-surface/[0.06]",
-  "[&>div]:!border-outline-variant/30",
-  "[&>div]:hover:!border-outline-variant/50",
-  "[&>div]:focus-within:!border-inverse-primary/60",
-  "[&>div]:focus-within:!ring-inverse-primary/30",
+  "[&>div]:bg-inverse-on-surface/[0.06]!",
+  "[&>div]:border-outline-variant/30!",
+  "[&>div]:hover:border-outline-variant/50!",
+  "[&>div]:focus-within:border-inverse-primary/60!",
+  "[&>div]:focus-within:ring-inverse-primary/30!",
 );
 
 const inverseFieldInput = cn(
-  "!text-inverse-on-surface",
-  "placeholder:!text-inverse-on-surface/40",
-  "focus:!text-inverse-on-surface",
+  "text-inverse-on-surface!",
+  "placeholder:text-inverse-on-surface/40!",
+  "focus:text-inverse-on-surface!",
 );
 
 function renderField(
@@ -487,7 +487,7 @@ export function AgentSidebarMultiQuestion({
               size="sm"
               onClick={handleSubmit}
               rightIcon="check"
-              className="!bg-inverse-primary/15 !text-inverse-primary hover:!bg-inverse-primary hover:!text-inverse-surface"
+              className="bg-inverse-primary/15! text-inverse-primary! hover:bg-inverse-primary! hover:text-inverse-surface!"
             >
               {submitLabel}
             </Button>

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -267,12 +267,16 @@ function renderField(
               disabled={submitted}
               onClick={() => toggleMulti(opt.value)}
               className={cn(
-                "rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50",
+                "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50",
                 selected
                   ? "bg-inverse-primary text-inverse-surface"
                   : "bg-inverse-on-surface/[0.06] text-inverse-on-surface/70 hover:bg-inverse-on-surface/[0.12] hover:text-inverse-on-surface",
               )}
             >
+              <Icon
+                name={selected ? "check_box" : "check_box_outline_blank"}
+                size={14}
+              />
               {opt.label}
             </button>
           );
@@ -314,26 +318,24 @@ function renderField(
                 : "border-outline-variant/25 bg-inverse-on-surface/[0.03] hover:border-outline-variant/50 hover:bg-inverse-on-surface/[0.06]",
             )}
           >
-            <span
+            <Icon
+              name={
+                isMulti
+                  ? selected
+                    ? "check_box"
+                    : "check_box_outline_blank"
+                  : selected
+                    ? "radio_button_checked"
+                    : "radio_button_unchecked"
+              }
+              size={20}
               className={cn(
-                "mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center border-2 transition-colors",
-                isMulti ? "rounded-sm" : "rounded-full",
+                "shrink-0 mt-0.5 transition-colors",
                 selected
-                  ? "border-inverse-primary bg-inverse-primary"
-                  : "border-inverse-on-surface/30 group-hover:border-inverse-on-surface/50",
+                  ? "text-inverse-primary"
+                  : "text-inverse-on-surface/45 group-hover:text-inverse-on-surface/65",
               )}
-            >
-              {selected &&
-                (isMulti ? (
-                  <Icon
-                    name="check"
-                    size={12}
-                    className="text-inverse-surface"
-                  />
-                ) : (
-                  <span className="block h-1.5 w-1.5 rounded-full bg-inverse-surface" />
-                ))}
-            </span>
+            />
             <span className="flex-1 min-w-0">
               <span className="block text-sm font-medium text-inverse-on-surface">
                 {opt.label}

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -131,42 +131,40 @@ function formatAnswer(
   return value;
 }
 
-// Override FloatingLabelInput / Combobox internals for the inverse-themed
-// agent sidebar. Targets the components' bordered wrapper (`bg-surface-container-low`
-// → inverse fill) and the input/textarea element text/placeholder colors.
-const inverseFieldContainer = cn(
-  "[&>div]:bg-inverse-on-surface/[0.06]!",
-  "[&>div]:border-outline-variant/30!",
-  "[&>div]:hover:border-outline-variant/50!",
-  "[&>div]:focus-within:border-inverse-primary/60!",
-  "[&>div]:focus-within:ring-inverse-primary/30!",
-);
-
-const inverseFieldInput = cn(
-  "text-inverse-on-surface!",
-  "placeholder:text-inverse-on-surface/40!",
-  "focus:text-inverse-on-surface!",
-  "py-1.5!",
-);
-
-// Override SegmentedButton's per-button bg/text on the inverse-themed sidebar
-// so single-select segmented matches the inverse-primary chip palette used
-// by multi-select segmented above.
-const inverseSegmentedClass = cn(
-  "flex-wrap",
-  "[&>button[aria-pressed=true]]:bg-inverse-primary!",
-  "[&>button[aria-pressed=true]]:text-inverse-surface!",
-  "[&>button[aria-pressed=false]]:bg-inverse-on-surface/[0.06]!",
-  "[&>button[aria-pressed=false]]:text-inverse-on-surface/70!",
-  "[&>button[aria-pressed=false]]:hover:bg-inverse-on-surface/[0.12]!",
-  "[&>button[aria-pressed=false]]:hover:text-inverse-on-surface!",
-);
-
-const inverseSwitchClass = cn(
-  "aria-checked:bg-inverse-primary!",
-  "aria-[checked=false]:bg-inverse-on-surface/20!",
-  "[&>span]:bg-inverse-surface!",
-);
+// Reskin kit primitives (FloatingLabelInput / SegmentedButton / Switch) for
+// the inverse-themed agent sidebar. Each entry uses arbitrary descendant or
+// state-variant selectors with v4 trailing `!` to override the primitive's
+// internal default tokens. Until those primitives gain a first-class
+// `inverse` mode, these overrides are the bridge.
+const inverseOverrides = {
+  fieldContainer: cn(
+    "[&>div]:bg-inverse-on-surface/[0.06]!",
+    "[&>div]:border-outline-variant/30!",
+    "[&>div]:hover:border-outline-variant/50!",
+    "[&>div]:focus-within:border-inverse-primary/60!",
+    "[&>div]:focus-within:ring-inverse-primary/30!",
+  ),
+  fieldInput: cn(
+    "text-inverse-on-surface!",
+    "placeholder:text-inverse-on-surface/40!",
+    "focus:text-inverse-on-surface!",
+    "py-1.5!",
+  ),
+  segmented: cn(
+    "flex-wrap",
+    "[&>button[aria-pressed=true]]:bg-inverse-primary!",
+    "[&>button[aria-pressed=true]]:text-inverse-surface!",
+    "[&>button[aria-pressed=false]]:bg-inverse-on-surface/[0.06]!",
+    "[&>button[aria-pressed=false]]:text-inverse-on-surface/70!",
+    "[&>button[aria-pressed=false]]:hover:bg-inverse-on-surface/[0.12]!",
+    "[&>button[aria-pressed=false]]:hover:text-inverse-on-surface!",
+  ),
+  switch: cn(
+    "aria-checked:bg-inverse-primary!",
+    "aria-[checked=false]:bg-inverse-on-surface/20!",
+    "[&>span]:bg-inverse-surface!",
+  ),
+};
 
 function renderField(
   q: AgentSidebarQuestion,
@@ -188,8 +186,8 @@ function renderField(
           value={typeof value === "string" ? value : ""}
           onChange={(e) => setAnswer(q.id, e.target.value)}
           disabled={submitted}
-          containerClassName={inverseFieldContainer}
-          className={inverseFieldInput}
+          containerClassName={inverseOverrides.fieldContainer}
+          className={inverseOverrides.fieldInput}
         />
       );
     }
@@ -202,8 +200,8 @@ function renderField(
         value={typeof value === "string" ? value : ""}
         onChange={(e) => setAnswer(q.id, e.target.value)}
         disabled={submitted}
-        containerClassName={inverseFieldContainer}
-        className={inverseFieldInput}
+        containerClassName={inverseOverrides.fieldContainer}
+        className={inverseOverrides.fieldInput}
       />
     );
   }
@@ -214,7 +212,7 @@ function renderField(
         onChange={(checked) => setAnswer(q.id, checked)}
         aria-label={q.label}
         disabled={submitted}
-        className={inverseSwitchClass}
+        className={inverseOverrides.switch}
       />
     );
   }
@@ -247,7 +245,7 @@ function renderField(
           disabled={submitted}
           onChange={(v) => setAnswer(q.id, v === singleCurrent ? "" : v)}
           options={q.options.map((o) => ({ value: o.value, label: o.label }))}
-          className={inverseSegmentedClass}
+          className={inverseOverrides.segmented}
         />
       );
     }

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -271,6 +271,35 @@ export function AgentSidebarMultiQuestion({
   const active = activeIdx >= 0 ? questions[activeIdx] : null;
   const safeIdx = activeIdx >= 0 ? activeIdx : 0;
 
+  const summaries = questions.map((q) => {
+    const value = answers[q.id];
+    const answered = isAnswered(q, value);
+    const ans = formatAnswer(q, value);
+    return { q, value, answered, ans, filled: answered && !!ans };
+  });
+
+  const renderSummary = () => (
+    <div className="mt-3 flex flex-col gap-2">
+      {summaries.map(({ q, ans, filled }) => (
+        <div
+          key={q.id}
+          className="flex flex-col gap-0.5 rounded-md bg-inverse-on-surface/[0.04] px-3 py-2"
+        >
+          <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-inverse-on-surface/55">
+            {q.label}
+          </span>
+          {filled ? (
+            <span className="text-sm text-inverse-on-surface">{ans}</span>
+          ) : (
+            <span className="text-sm italic text-warning-container">
+              Not answered
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+
   return (
     <div
       className={cn(
@@ -310,45 +339,20 @@ export function AgentSidebarMultiQuestion({
                 value={activeTabId}
                 onChange={(id) => setActiveTabId(id)}
                 options={[
-                  ...questions.map((q) => {
-                    const answered = isAnswered(q, answers[q.id]);
-                    return {
-                      value: q.id,
-                      label: q.tabLabel ?? q.label,
-                      tone: answered ? "muted" : "warn",
-                    } as const;
-                  }),
+                  ...summaries.map(({ q, answered }) => ({
+                    value: q.id,
+                    label: q.tabLabel ?? q.label,
+                    tone: (answered ? "muted" : "warning") as
+                      | "muted"
+                      | "warning",
+                  })),
                   { value: REVIEW_TAB_ID, label: "Review" },
                 ]}
               />
             </div>
 
             {isReview ? (
-              <div className="mt-3 flex flex-col gap-2">
-                {questions.map((q) => {
-                  const value = answers[q.id];
-                  const answered = isAnswered(q, value);
-                  const ans = formatAnswer(q, value);
-                  const filled = answered && !!ans;
-                  return (
-                    <div
-                      key={q.id}
-                      className="flex flex-col gap-0.5 rounded-md bg-inverse-on-surface/[0.04] px-3 py-2"
-                    >
-                      <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-inverse-on-surface/55">
-                        {q.label}
-                      </span>
-                      {filled ? (
-                        <span className="text-sm text-inverse-on-surface">{ans}</span>
-                      ) : (
-                        <span className="text-sm italic text-warning-container">
-                          Not answered
-                        </span>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
+              renderSummary()
             ) : active ? (
               <div className="mt-3 rounded-md border border-outline-variant/20 px-3 py-3 flex flex-col gap-2">
                 <div className="text-sm font-medium text-inverse-on-surface leading-snug">
@@ -366,31 +370,7 @@ export function AgentSidebarMultiQuestion({
             ) : null}
           </>
         ) : layout === "tabs" && submitted ? (
-          <div className="mt-3 flex flex-col gap-2">
-            {questions.map((q) => {
-              const value = answers[q.id];
-              const answered = isAnswered(q, value);
-              const ans = formatAnswer(q, value);
-              const filled = answered && !!ans;
-              return (
-                <div
-                  key={q.id}
-                  className="flex flex-col gap-0.5 rounded-md bg-inverse-on-surface/[0.04] px-3 py-2"
-                >
-                  <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-inverse-on-surface/55">
-                    {q.label}
-                  </span>
-                  {filled ? (
-                    <span className="text-sm text-inverse-on-surface">{ans}</span>
-                  ) : (
-                    <span className="text-sm italic text-warning-container">
-                      Not answered
-                    </span>
-                  )}
-                </div>
-              );
-            })}
-          </div>
+          renderSummary()
         ) : (
           <div className="mt-2.5 flex flex-col gap-2.5">
             {questions.map((q) => {

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/utils/cn";
 import { Icon } from "@/components/ui/media/icon/Icon";
 import { Button } from "@/components/ui/actions/button/Button";
 import { Combobox } from "@/components/ui/inputs/combobox/Combobox";
+import { FloatingLabelInput } from "@/components/ui/inputs/floating-label-input/FloatingLabelInput";
 import { SegmentedButton } from "@/components/ui/inputs/segmented-button/SegmentedButton";
 
 interface QuestionBase {
@@ -121,8 +122,22 @@ function formatAnswer(
   return value;
 }
 
-const fieldCls =
-  "w-full rounded-md bg-inverse-on-surface/[0.06] border border-transparent px-2.5 py-1.5 text-sm text-inverse-on-surface placeholder:text-inverse-on-surface/30 focus:outline-none focus:border-inverse-primary/60 focus:bg-inverse-on-surface/[0.08] disabled:opacity-50";
+// Override FloatingLabelInput / Combobox internals for the inverse-themed
+// agent sidebar. Targets the components' bordered wrapper (`bg-surface-container-low`
+// → inverse fill) and the input/textarea element text/placeholder colors.
+const inverseFieldContainer = cn(
+  "[&>div]:!bg-inverse-on-surface/[0.06]",
+  "[&>div]:!border-outline-variant/30",
+  "[&>div]:hover:!border-outline-variant/50",
+  "[&>div]:focus-within:!border-inverse-primary/60",
+  "[&>div]:focus-within:!ring-inverse-primary/30",
+);
+
+const inverseFieldInput = cn(
+  "!text-inverse-on-surface",
+  "placeholder:!text-inverse-on-surface/40",
+  "focus:!text-inverse-on-surface",
+);
 
 function renderField(
   q: AgentSidebarQuestion,
@@ -133,27 +148,33 @@ function renderField(
   const fieldId = `mq-${q.id}`;
   if (q.type === "text") {
     return (
-      <input
+      <FloatingLabelInput
         id={fieldId}
-        type="text"
-        className={fieldCls}
-        placeholder={q.placeholder}
+        label={q.placeholder ?? q.label}
+        hideLabel
+        size="sm"
         value={typeof value === "string" ? value : ""}
         onChange={(e) => setAnswer(q.id, e.target.value)}
         disabled={submitted}
+        containerClassName={inverseFieldContainer}
+        className={inverseFieldInput}
       />
     );
   }
   if (q.type === "textarea") {
     return (
-      <textarea
+      <FloatingLabelInput
         id={fieldId}
-        className={cn(fieldCls, "resize-none min-h-[60px]")}
-        placeholder={q.placeholder}
+        label={q.placeholder ?? q.label}
+        hideLabel
+        multiline
+        size="sm"
         rows={3}
         value={typeof value === "string" ? value : ""}
         onChange={(e) => setAnswer(q.id, e.target.value)}
         disabled={submitted}
+        containerClassName={inverseFieldContainer}
+        className={inverseFieldInput}
       />
     );
   }
@@ -168,6 +189,7 @@ function renderField(
         value={typeof value === "string" ? value : ""}
         onChange={(v) => setAnswer(q.id, v)}
         options={q.options}
+        className={inverseFieldContainer}
       />
     );
   }

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -146,6 +146,7 @@ const inverseFieldInput = cn(
   "text-inverse-on-surface!",
   "placeholder:text-inverse-on-surface/40!",
   "focus:text-inverse-on-surface!",
+  "py-1.5!",
 );
 
 // Override SegmentedButton's per-button bg/text on the inverse-themed sidebar

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -148,6 +148,18 @@ const inverseFieldInput = cn(
   "focus:text-inverse-on-surface!",
 );
 
+// Override SegmentedButton's per-button bg/text on the inverse-themed sidebar
+// so single-select segmented matches the inverse-primary chip palette used
+// by multi-select segmented above.
+const inverseSegmentedClass = cn(
+  "[&>button[aria-pressed=true]]:bg-inverse-primary!",
+  "[&>button[aria-pressed=true]]:text-inverse-surface!",
+  "[&>button[aria-pressed=false]]:bg-inverse-on-surface/[0.06]!",
+  "[&>button[aria-pressed=false]]:text-inverse-on-surface/70!",
+  "[&>button[aria-pressed=false]]:hover:bg-inverse-on-surface/[0.12]!",
+  "[&>button[aria-pressed=false]]:hover:text-inverse-on-surface!",
+);
+
 function renderField(
   q: AgentSidebarQuestion,
   value: AgentSidebarMultiQuestionAnswer,
@@ -230,31 +242,38 @@ function renderField(
   };
 
   if (q.style === "segmented") {
+    if (!isMulti) {
+      return (
+        <SegmentedButton
+          size="sm"
+          aria-label={q.label}
+          value={singleCurrent}
+          disabled={submitted}
+          onChange={(v) => setAnswer(q.id, v === singleCurrent ? "" : v)}
+          options={q.options.map((o) => ({ value: o.value, label: o.label }))}
+          className={inverseSegmentedClass}
+        />
+      );
+    }
+    // segmented + multiple → independent toggle chips, styled to match
+    // SegmentedButton's selected/unselected look so single and multi
+    // segmented questions read as the same control.
     return (
       <div
-        role={isMulti ? "group" : "radiogroup"}
+        role="group"
         aria-label={q.label}
         className="flex flex-wrap gap-1.5"
       >
         {q.options.map((opt) => {
-          const selected = isMulti
-            ? selectedValues.has(opt.value)
-            : opt.value === singleCurrent;
-          const handleClick = () => {
-            if (isMulti) {
-              toggleMulti(opt.value);
-            } else {
-              setAnswer(q.id, selected ? "" : opt.value);
-            }
-          };
+          const selected = selectedValues.has(opt.value);
           return (
             <button
               key={opt.value}
               type="button"
-              role={isMulti ? "checkbox" : "radio"}
+              role="checkbox"
               aria-checked={selected}
               disabled={submitted}
-              onClick={handleClick}
+              onClick={() => toggleMulti(opt.value)}
               className={cn(
                 "rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50",
                 selected

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -487,7 +487,7 @@ export function AgentSidebarMultiQuestion({
               size="sm"
               onClick={handleSubmit}
               rightIcon="check"
-              className="hover:bg-primary hover:text-on-primary"
+              className="!bg-inverse-primary/15 !text-inverse-primary hover:!bg-inverse-primary hover:!text-inverse-surface"
             >
               {submitLabel}
             </Button>

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -33,17 +33,20 @@ export type AgentSidebarQuestion =
       /** "segmented" — all options visible inline as a pill row (use for short labels, no descriptions).
        *  "cards" — radio-card list with title + description per option (use for weighted decisions). */
       style: AgentSidebarChoiceStyle;
+      /** When true the user can pick more than one option; the answer is an array of values.
+       *  Renders square check indicators (cards) or independently-toggling chips (segmented). */
+      multiple?: boolean;
       options: {
         value: string;
         label: string;
         description?: string;
       }[];
-      defaultValue?: string;
+      defaultValue?: string | string[];
     });
 
 export type AgentSidebarMultiQuestionStatus = "pending" | "submitted";
 
-export type AgentSidebarMultiQuestionAnswer = string | boolean;
+export type AgentSidebarMultiQuestionAnswer = string | boolean | string[];
 
 export type AgentSidebarMultiQuestionLayout = "list" | "tabs";
 
@@ -84,8 +87,13 @@ function initialAnswers(
 ): Record<string, AgentSidebarMultiQuestionAnswer> {
   const out: Record<string, AgentSidebarMultiQuestionAnswer> = {};
   for (const q of questions) {
-    if (q.type === "toggle") out[q.id] = q.defaultValue ?? false;
-    else out[q.id] = q.defaultValue ?? "";
+    if (q.type === "toggle") {
+      out[q.id] = q.defaultValue ?? false;
+    } else if (q.type === "choice" && q.multiple) {
+      out[q.id] = Array.isArray(q.defaultValue) ? q.defaultValue : [];
+    } else {
+      out[q.id] = typeof q.defaultValue === "string" ? q.defaultValue : "";
+    }
   }
   return out;
 }
@@ -96,6 +104,9 @@ function isAnswered(
 ): boolean {
   // A switch always has a valid answer (on or off); never flag it as missing.
   if (q.type === "toggle") return true;
+  if (q.type === "choice" && q.multiple) {
+    return Array.isArray(value) && value.length > 0;
+  }
   if (typeof value !== "string") return false;
   if (q.type === "choice") return value.length > 0;
   return value.trim().length > 0;
@@ -106,6 +117,12 @@ function formatAnswer(
   value: AgentSidebarMultiQuestionAnswer,
 ): string {
   if (q.type === "toggle") return value ? "Enabled" : "Not enabled";
+  if (q.type === "choice" && q.multiple) {
+    if (!Array.isArray(value) || value.length === 0) return "";
+    return value
+      .map((v) => q.options.find((o) => o.value === v)?.label ?? v)
+      .join(", ");
+  }
   if (typeof value !== "string" || value.length === 0) return "";
   if (q.type === "choice") {
     const opt = q.options.find((o) => o.value === value);
@@ -194,31 +211,95 @@ function renderField(
     );
   }
   // choice
-  const current = typeof value === "string" ? value : "";
+  const isMulti = q.multiple === true;
+  const selectedValues = isMulti
+    ? new Set(Array.isArray(value) ? value : [])
+    : new Set<string>();
+  const singleCurrent = !isMulti && typeof value === "string" ? value : "";
+
+  const toggleMulti = (optValue: string) => {
+    const arr = Array.isArray(value) ? [...value] : [];
+    if (selectedValues.has(optValue)) {
+      setAnswer(
+        q.id,
+        arr.filter((v) => v !== optValue),
+      );
+    } else {
+      setAnswer(q.id, [...arr, optValue]);
+    }
+  };
+
   if (q.style === "segmented") {
+    if (!isMulti) {
+      return (
+        <SegmentedButton
+          size="sm"
+          aria-label={q.label}
+          value={singleCurrent}
+          disabled={submitted}
+          onChange={(v) => setAnswer(q.id, v === singleCurrent ? "" : v)}
+          options={q.options.map((o) => ({ value: o.value, label: o.label }))}
+        />
+      );
+    }
+    // segmented + multiple → independent toggle chips
     return (
-      <SegmentedButton
-        size="sm"
+      <div
+        role="group"
         aria-label={q.label}
-        value={current}
-        disabled={submitted}
-        onChange={(v) => setAnswer(q.id, v === current ? "" : v)}
-        options={q.options.map((o) => ({ value: o.value, label: o.label }))}
-      />
+        className="flex flex-wrap gap-1.5"
+      >
+        {q.options.map((opt) => {
+          const selected = selectedValues.has(opt.value);
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              role="checkbox"
+              aria-checked={selected}
+              disabled={submitted}
+              onClick={() => toggleMulti(opt.value)}
+              className={cn(
+                "rounded-md px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50",
+                selected
+                  ? "bg-inverse-primary text-inverse-surface"
+                  : "bg-inverse-on-surface/[0.06] text-inverse-on-surface/70 hover:bg-inverse-on-surface/[0.12] hover:text-inverse-on-surface",
+              )}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
     );
   }
+
+  // cards
   return (
-    <div role="radiogroup" aria-labelledby={fieldId} className="flex flex-col gap-1.5">
+    <div
+      role={isMulti ? "group" : "radiogroup"}
+      aria-labelledby={fieldId}
+      className="flex flex-col gap-1.5"
+    >
       {q.options.map((opt) => {
-        const selected = opt.value === current;
+        const selected = isMulti
+          ? selectedValues.has(opt.value)
+          : opt.value === singleCurrent;
+        const handleClick = () => {
+          if (isMulti) {
+            toggleMulti(opt.value);
+          } else {
+            setAnswer(q.id, selected ? "" : opt.value);
+          }
+        };
         return (
           <button
             key={opt.value}
             type="button"
-            role="radio"
+            role={isMulti ? "checkbox" : "radio"}
             aria-checked={selected}
             disabled={submitted}
-            onClick={() => setAnswer(q.id, selected ? "" : opt.value)}
+            onClick={handleClick}
             className={cn(
               "group flex items-start gap-2.5 rounded-md border px-3 py-2.5 text-left transition-colors disabled:opacity-50",
               selected
@@ -228,15 +309,23 @@ function renderField(
           >
             <span
               className={cn(
-                "mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-2 transition-colors",
+                "mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center border-2 transition-colors",
+                isMulti ? "rounded-sm" : "rounded-full",
                 selected
-                  ? "border-inverse-primary"
+                  ? "border-inverse-primary bg-inverse-primary"
                   : "border-inverse-on-surface/30 group-hover:border-inverse-on-surface/50",
               )}
             >
-              {selected && (
-                <span className="block h-1.5 w-1.5 rounded-full bg-inverse-primary" />
-              )}
+              {selected &&
+                (isMulti ? (
+                  <Icon
+                    name="check"
+                    size={12}
+                    className="text-inverse-surface"
+                  />
+                ) : (
+                  <span className="block h-1.5 w-1.5 rounded-full bg-inverse-surface" />
+                ))}
             </span>
             <span className="flex-1 min-w-0">
               <span className="block text-sm font-medium text-inverse-on-surface">

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -369,10 +369,10 @@ export function AgentSidebarMultiQuestion({
               </div>
             ) : null}
           </>
-        ) : layout === "tabs" && submitted ? (
+        ) : submitted ? (
           renderSummary()
         ) : (
-          <div className="mt-2.5 flex flex-col gap-2.5">
+          <div className="mt-2.5 flex flex-col gap-2">
             {questions.map((q) => {
               const value = answers[q.id];
               const fieldId = `mq-${q.id}`;
@@ -380,17 +380,17 @@ export function AgentSidebarMultiQuestion({
                 return (
                   <div
                     key={q.id}
-                    className="flex items-center justify-between gap-3 rounded-md bg-inverse-on-surface/[0.06] px-2.5 py-2"
+                    className="rounded-md border border-outline-variant/20 px-3 py-2.5 flex items-center justify-between gap-3"
                   >
                     <div className="flex-1 min-w-0">
                       <label
                         htmlFor={fieldId}
-                        className="text-sm text-inverse-on-surface block"
+                        className="text-sm font-medium text-inverse-on-surface block leading-snug"
                       >
                         {q.label}
                       </label>
                       {q.description && (
-                        <span className="text-xs text-inverse-on-surface/55 block mt-0.5">
+                        <span className="text-xs text-inverse-on-surface/55 block mt-0.5 leading-relaxed">
                           {q.description}
                         </span>
                       )}
@@ -400,18 +400,23 @@ export function AgentSidebarMultiQuestion({
                 );
               }
               return (
-                <div key={q.id} className="flex flex-col gap-1">
-                  <label
-                    htmlFor={fieldId}
-                    className="text-[10px] font-medium uppercase tracking-[0.08em] text-inverse-on-surface/55"
-                  >
-                    {q.label}
-                  </label>
-                  {q.description && (
-                    <span className="text-xs text-inverse-on-surface/55 -mt-0.5">
-                      {q.description}
-                    </span>
-                  )}
+                <div
+                  key={q.id}
+                  className="rounded-md border border-outline-variant/20 px-3 py-2.5 flex flex-col gap-2"
+                >
+                  <div>
+                    <label
+                      htmlFor={fieldId}
+                      className="text-sm font-medium text-inverse-on-surface block leading-snug"
+                    >
+                      {q.label}
+                    </label>
+                    {q.description && (
+                      <span className="text-xs text-inverse-on-surface/55 block mt-0.5 leading-relaxed">
+                        {q.description}
+                      </span>
+                    )}
+                  </div>
                   {renderField(q, value, setAnswer, submitted)}
                 </div>
               );

--- a/src/components/ui/inputs/segmented-button/SegmentedButton.tsx
+++ b/src/components/ui/inputs/segmented-button/SegmentedButton.tsx
@@ -8,7 +8,7 @@ export const meta: ComponentMeta = {
     "Horizontal group of toggle buttons where exactly one option is selected at a time",
 };
 
-export type SegmentedButtonOptionTone = "default" | "warn" | "muted";
+export type SegmentedButtonOptionTone = "default" | "warning" | "muted";
 
 export interface SegmentedButtonOption<T extends string = string> {
   readonly value: T;
@@ -72,7 +72,7 @@ export function SegmentedButton<T extends string = string>({
             sizeStyles[size],
             value === opt.value
               ? "bg-primary text-on-primary"
-              : opt.tone === "warn"
+              : opt.tone === "warning"
                 ? "bg-warning-container text-on-warning-container hover:bg-warning/20"
                 : opt.tone === "muted"
                   ? "bg-surface-container/40 text-on-surface-variant/70 hover:bg-surface-container hover:text-on-surface-variant"

--- a/src/components/ui/inputs/segmented-button/SegmentedButton.tsx
+++ b/src/components/ui/inputs/segmented-button/SegmentedButton.tsx
@@ -8,10 +8,16 @@ export const meta: ComponentMeta = {
     "Horizontal group of toggle buttons where exactly one option is selected at a time",
 };
 
+export type SegmentedButtonOptionTone = "default" | "warn" | "muted";
+
 export interface SegmentedButtonOption<T extends string = string> {
   readonly value: T;
   readonly label: string;
+  /** Visual tone for the unselected state. Defaults to "default". */
+  readonly tone?: SegmentedButtonOptionTone;
 }
+
+export type SegmentedButtonSize = "sm" | "md";
 
 export interface SegmentedButtonProps<T extends string = string> {
   options: readonly SegmentedButtonOption<T>[];
@@ -20,7 +26,13 @@ export interface SegmentedButtonProps<T extends string = string> {
   "aria-label"?: string;
   disabled?: boolean;
   className?: string;
+  size?: SegmentedButtonSize;
 }
+
+const sizeStyles: Record<SegmentedButtonSize, string> = {
+  sm: "px-3 py-1.5 rounded-md text-xs",
+  md: "px-4 py-2 rounded-xl text-sm",
+};
 
 export function SegmentedButton<T extends string = string>({
   options,
@@ -29,6 +41,7 @@ export function SegmentedButton<T extends string = string>({
   "aria-label": ariaLabel,
   disabled = false,
   className,
+  size = "md",
 }: SegmentedButtonProps<T>) {
   if (isDev) {
     if (options.length === 0) {
@@ -55,10 +68,15 @@ export function SegmentedButton<T extends string = string>({
           disabled={disabled}
           aria-pressed={value === opt.value}
           className={cn(
-            "px-4 py-2 rounded-xl text-sm font-medium transition-colors",
+            "font-medium transition-colors",
+            sizeStyles[size],
             value === opt.value
               ? "bg-primary text-on-primary"
-              : "bg-surface-container text-on-surface-variant hover:bg-surface-container-high",
+              : opt.tone === "warn"
+                ? "bg-warning-container text-on-warning-container hover:bg-warning/20"
+                : opt.tone === "muted"
+                  ? "bg-surface-container/40 text-on-surface-variant/70 hover:bg-surface-container hover:text-on-surface-variant"
+                  : "bg-surface-container text-on-surface-variant hover:bg-surface-container-high",
             disabled
               ? "opacity-50 cursor-not-allowed"
               : "cursor-pointer",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,8 @@ export {
   SegmentedButton,
   type SegmentedButtonProps,
   type SegmentedButtonOption,
+  type SegmentedButtonSize,
+  type SegmentedButtonOptionTone,
 } from "./components/ui/inputs/segmented-button/SegmentedButton";
 export {
   Switch,
@@ -212,6 +214,12 @@ export {
   type AgentSidebarUserMessageProps,
   AgentSidebarAgentMessage,
   type AgentSidebarAgentMessageProps,
+  AgentSidebarMultiQuestion,
+  type AgentSidebarMultiQuestionProps,
+  type AgentSidebarQuestion,
+  type AgentSidebarMultiQuestionStatus,
+  type AgentSidebarMultiQuestionAnswer,
+  type AgentSidebarMultiQuestionLayout,
   AgentSidebarMessages,
   type AgentSidebarMessage,
   type AgentSidebarMessagesProps,

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,6 +220,7 @@ export {
   type AgentSidebarMultiQuestionStatus,
   type AgentSidebarMultiQuestionAnswer,
   type AgentSidebarMultiQuestionLayout,
+  type AgentSidebarChoiceStyle,
   AgentSidebarMessages,
   type AgentSidebarMessage,
   type AgentSidebarMessagesProps,


### PR DESCRIPTION
> Stacked on top of #174. Once #174 merges, GitHub will retarget this to \`main\` automatically.

## Summary
- New \`AgentSidebarMultiQuestion\` ask card the agent can render in the chat stream when it needs the user to make several decisions before continuing
- Two layouts:
  - **\`tabs\`** (default) — one question at a time; \`SegmentedButton\` switches between them and includes a final \`Review\` tab that previews answers read-only; warn / muted / primary tones flag unanswered vs answered vs active
  - **\`list\`** — all fields stacked, single bottom Submit
- Five question types: \`text\`, \`textarea\`, \`select\` (uses \`Combobox\`), \`toggle\`, and a new \`choice\` (radio cards with title + description per option, for high-stakes decisions)
- After submit: tab strip + active question card hide; clean summary list shows each question's answer (\"Not answered\" in warn-color text for blanks)
- \`AgentSidebarMessages\` dispatcher extended with \`multi-question\` kind + \`onSubmitMultiQuestion\` callback

## Kit extensions
- \`SegmentedButton\` gains \`size=\"sm\"\` (compact \`px-3 py-1.5 rounded-md text-xs\`) and per-option \`tone=\"default\" | \"warning\" | \"muted\"\` for richer state signalling. Defaults preserve existing behavior.

## What you'll see in Storybook
- \`Agent/Asks/MultiQuestionTabs\` — \"Scaffold a new service\" example (Database / Auth / Hosting), each question has \`choice\` cards with descriptions to help decide
- \`Agent/Asks/MultiQuestionList\` — simple \"Customize your experience\" preferences (theme select / marketing toggle / display name text)

## Notable design decisions
- Inverse-theme aware: status accents use \`inverse-primary\` (light cyan in light mode) so they read on the dark agent sidebar; warn-color text uses \`text-warning-container\` for the same reason
- Choice radio: no preselected default; clicking the selected option deselects it (toggle off)
- Single \`summaries\` derivation feeds the tabs row + the review/submitted body — no per-render duplicated walks of \`questions\`
- Review tab is preview-only — bottom Submit button is the single submission trigger

## Test plan
- [ ] Storybook: \`Agent/Asks/MultiQuestionTabs\` — pick options across three tabs, click \`Review\` to preview, then \`Submit\` and watch the tab strip + active card disappear into the summary view
- [ ] Storybook: leave one tab unanswered → its segmented pill shows the warn tint; submit anyway → that row in the summary shows \"Not answered\" in warning-container text
- [ ] Storybook: \`Agent/Asks/MultiQuestionList\` — same submit flow with the simpler stacked layout
- [ ] Verify \`pnpm typecheck\` is green
- [ ] Verify SegmentedButton existing stories aren't visually regressed (default tone/md size unchanged)

## Follow-up (not in this PR)
- text/textarea/toggle could swap to \`FloatingLabelInput\`/\`Switch\` once those primitives gain inverse-theme support
- ActionAsk redesign (was prototyped, kept for a separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)