### PR TITLE
fix(agent-sidebar): pin input to bottom + add pending content slot

### DIFF
--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -41,6 +41,10 @@ export interface AppShellProps {
   /** Past conversations grouped by date — shown in the agent header history dropdown. */
   agentHistory?: AgentSidebarHistoryGroup[];
   onSelectAgentHistoryItem?: (id: string) => void;
+  /** Slot pinned directly above the agent input — used for messages the user
+   *  sent while the agent was still responding (queued input). Stays in view
+   *  with the input even when the messages list scrolls. */
+  agentPendingContent?: ReactNode;
 }
 
 export function AppShell(props: AppShellProps) {
@@ -68,6 +72,7 @@ function AppShellInner({
   onAgentMic,
   agentHistory,
   onSelectAgentHistoryItem,
+  agentPendingContent,
 }: AppShellProps) {
   const { sidebarWidth, setSidebarWidth } = useSidebarWidth();
   const [isResizing, setIsResizing] = useState(false);
@@ -222,10 +227,16 @@ function AppShellInner({
                 onSelectHistoryItem={onSelectAgentHistoryItem}
               />
 
-              <div className="rounded-2xl bg-on-background h-full flex flex-col">
+              <div className="rounded-2xl bg-on-background flex-1 min-h-0 flex flex-col">
                 <div className="flex-1 overflow-y-auto overflow-x-hidden p-4">
                   {agentSidebarContent}
                 </div>
+
+                {agentPendingContent && (
+                  <div className="shrink-0 px-4 pt-2 pb-0.5">
+                    {agentPendingContent}
+                  </div>
+                )}
 
                 <AgentSidebarInput
                   onSend={onAgentSend}

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -233,10 +233,8 @@ function AppShellInner({
                 </div>
 
                 {agentPendingContent && (
-                  <div className="shrink-0 px-3 pt-2 pb-1">
-                    <div className="rounded-xl bg-inverse-on-surface/[0.06] backdrop-blur-md border border-inverse-on-surface/[0.08] p-3">
-                      {agentPendingContent}
-                    </div>
+                  <div className="shrink-0 mx-3 mt-2 mb-1 rounded-xl bg-inverse-on-surface/[0.06] backdrop-blur-md border border-inverse-on-surface/[0.08] p-3">
+                    {agentPendingContent}
                   </div>
                 )}
 

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -233,8 +233,10 @@ function AppShellInner({
                 </div>
 
                 {agentPendingContent && (
-                  <div className="shrink-0 px-4 pt-2 pb-0.5">
-                    {agentPendingContent}
+                  <div className="shrink-0 px-3 pt-2 pb-1">
+                    <div className="rounded-xl bg-inverse-on-surface/[0.06] backdrop-blur-md border border-inverse-on-surface/[0.08] p-3">
+                      {agentPendingContent}
+                    </div>
                   </div>
                 )}
 

--- a/src/components/ui/agent-sidebar/AgentSidebarMessages.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMessages.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { cn } from "@/utils/cn";
+import { Icon } from "@/components/ui/media/icon/Icon";
 import {
   AgentSidebarUserMessage,
   AgentSidebarAgentMessage,
@@ -67,30 +68,38 @@ export function AgentSidebarMessages({
 }: AgentSidebarMessagesProps) {
   const endRef = useRef<HTMLDivElement>(null);
   const isFirstRunRef = useRef(true);
-  const wasNearBottomRef = useRef(true);
+  const isAtBottomRef = useRef(true);
+  const [isAtBottom, setIsAtBottom] = useState(true);
 
-  // If the user scrolled up to read history we don't yank the view back down
-  // on every streamed token.
   useEffect(() => {
     const parent = findScrollParent(endRef.current);
     if (!parent) return;
-    const onScroll = () => {
+    const update = () => {
       const distance = parent.scrollHeight - parent.scrollTop - parent.clientHeight;
-      wasNearBottomRef.current = distance <= NEAR_BOTTOM_PX;
+      const near = distance <= NEAR_BOTTOM_PX;
+      if (near !== isAtBottomRef.current) {
+        isAtBottomRef.current = near;
+        setIsAtBottom(near);
+      }
     };
-    parent.addEventListener("scroll", onScroll, { passive: true });
-    return () => parent.removeEventListener("scroll", onScroll);
+    update();
+    parent.addEventListener("scroll", update, { passive: true });
+    return () => parent.removeEventListener("scroll", update);
   }, []);
 
   useEffect(() => {
     if (!autoScroll) return;
-    if (!isFirstRunRef.current && !wasNearBottomRef.current) return;
+    if (!isFirstRunRef.current && !isAtBottomRef.current) return;
     endRef.current?.scrollIntoView({
       behavior: isFirstRunRef.current ? "auto" : "smooth",
       block: "end",
     });
     isFirstRunRef.current = false;
   }, [messages, autoScroll]);
+
+  const scrollToBottom = () => {
+    endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  };
 
   return (
     <div className={cn("flex flex-col gap-4", className)}>
@@ -121,6 +130,18 @@ export function AgentSidebarMessages({
         );
       })}
       <div ref={endRef} />
+      {!isAtBottom && (
+        <div className="sticky bottom-2 z-10 flex justify-center pointer-events-none -mt-4">
+          <button
+            type="button"
+            onClick={scrollToBottom}
+            className="pointer-events-auto inline-flex items-center gap-1 rounded-full bg-inverse-on-surface/[0.12] backdrop-blur-sm px-3 py-1.5 text-xs font-medium text-inverse-on-surface hover:bg-inverse-on-surface/[0.20] transition-colors shadow-sm"
+          >
+            <Icon name="arrow_downward" size={14} />
+            Back to bottom
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ui/agent-sidebar/AgentSidebarMessages.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMessages.tsx
@@ -131,6 +131,8 @@ export function AgentSidebarMessages({
       })}
       <div ref={endRef} />
       {!isAtBottom && (
+        // -mt-4 cancels the parent's gap-4 so the sticky pill sits flush
+        // against the last message instead of adding a gap row of layout.
         <div className="sticky bottom-2 z-10 flex justify-center pointer-events-none -mt-4">
           <button
             type="button"


### PR DESCRIPTION
## Summary
Fixes two AppShell agent-sidebar issues surfaced after #174 / #175 merged:

1. **Input pushed out of viewport on long chats.** The inner container used \`h-full\` which equaled the full sidebar height (already accounting for the header). When messages overflowed, the inner stretched below the viewport and the input followed, leaving it offscreen. Switched to \`flex-1 min-h-0\` so the inner only fills the remaining flex space — the input now stays pinned at the bottom of the visible viewport regardless of how much chat history scrolls.

2. **No place for queued user input while the agent is streaming.** Added an optional \`agentPendingContent?: ReactNode\` slot rendered directly above \`AgentSidebarInput\` (shrink-0, outside the scroll area). The consumer can render bubbles for messages the user typed while the agent was still responding to a previous turn; once the agent finishes and reads the next turn, the consumer moves them into the chat. The kit just provides the slot — queue logic lives with the consumer.

## Test plan
- [ ] Open the agent sidebar in web-account, send enough messages that the chat overflows. Verify the input stays at the bottom of the visible viewport.
- [ ] Resize the sidebar / collapse-expand. Input remains pinned.
- [ ] If wired, type a second message while the agent is still streaming the first reply — the second message renders in \`agentPendingContent\` (above the input). When the first reply finishes, the consumer moves it into the chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)