### PR TITLE
fix(kit): inverse mode on SegmentedButton + FloatingLabelInput + Switch

### DIFF
--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -542,7 +542,6 @@ export function AgentSidebarMultiQuestion({
               size="sm"
               onClick={handleSubmit}
               rightIcon="check"
-              className="bg-inverse-primary/15! text-inverse-primary! hover:bg-inverse-primary! hover:text-inverse-surface!"
             >
               {submitLabel}
             </Button>

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -131,41 +131,6 @@ function formatAnswer(
   return value;
 }
 
-// Reskin kit primitives (FloatingLabelInput / SegmentedButton / Switch) for
-// the inverse-themed agent sidebar. Each entry uses arbitrary descendant or
-// state-variant selectors with v4 trailing `!` to override the primitive's
-// internal default tokens. Until those primitives gain a first-class
-// `inverse` mode, these overrides are the bridge.
-const inverseOverrides = {
-  fieldContainer: cn(
-    "[&>div]:bg-inverse-on-surface/[0.06]!",
-    "[&>div]:border-outline-variant/30!",
-    "[&>div]:hover:border-outline-variant/50!",
-    "[&>div]:focus-within:border-inverse-primary/60!",
-    "[&>div]:focus-within:ring-inverse-primary/30!",
-  ),
-  fieldInput: cn(
-    "text-inverse-on-surface!",
-    "placeholder:text-inverse-on-surface/40!",
-    "focus:text-inverse-on-surface!",
-    "py-1.5!",
-  ),
-  segmented: cn(
-    "flex-wrap",
-    "[&>button[aria-pressed=true]]:bg-inverse-primary!",
-    "[&>button[aria-pressed=true]]:text-inverse-surface!",
-    "[&>button[aria-pressed=false]]:bg-inverse-on-surface/[0.06]!",
-    "[&>button[aria-pressed=false]]:text-inverse-on-surface/70!",
-    "[&>button[aria-pressed=false]]:hover:bg-inverse-on-surface/[0.12]!",
-    "[&>button[aria-pressed=false]]:hover:text-inverse-on-surface!",
-  ),
-  switch: cn(
-    "aria-checked:bg-inverse-primary!",
-    "aria-[checked=false]:bg-inverse-on-surface/20!",
-    "[&>span]:bg-inverse-surface!",
-  ),
-};
-
 function renderField(
   q: AgentSidebarQuestion,
   value: AgentSidebarMultiQuestionAnswer,
@@ -186,8 +151,7 @@ function renderField(
           value={typeof value === "string" ? value : ""}
           onChange={(e) => setAnswer(q.id, e.target.value)}
           disabled={submitted}
-          containerClassName={inverseOverrides.fieldContainer}
-          className={inverseOverrides.fieldInput}
+          inverse
         />
       );
     }
@@ -200,8 +164,7 @@ function renderField(
         value={typeof value === "string" ? value : ""}
         onChange={(e) => setAnswer(q.id, e.target.value)}
         disabled={submitted}
-        containerClassName={inverseOverrides.fieldContainer}
-        className={inverseOverrides.fieldInput}
+        inverse
       />
     );
   }
@@ -212,7 +175,7 @@ function renderField(
         onChange={(checked) => setAnswer(q.id, checked)}
         aria-label={q.label}
         disabled={submitted}
-        className={inverseOverrides.switch}
+        inverse
       />
     );
   }
@@ -245,7 +208,8 @@ function renderField(
           disabled={submitted}
           onChange={(v) => setAnswer(q.id, v === singleCurrent ? "" : v)}
           options={q.options.map((o) => ({ value: o.value, label: o.label }))}
-          className={inverseOverrides.segmented}
+          inverse
+          className="flex-wrap"
         />
       );
     }
@@ -447,6 +411,7 @@ export function AgentSidebarMultiQuestion({
               <SegmentedButton
                 aria-label="Select a question"
                 size="sm"
+                inverse
                 value={activeTabId}
                 onChange={(id) => setActiveTabId(id)}
                 className="flex-wrap"

--- a/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent-sidebar/AgentSidebarMultiQuestion.tsx
@@ -542,6 +542,7 @@ export function AgentSidebarMultiQuestion({
               size="sm"
               onClick={handleSubmit}
               rightIcon="check"
+              className="hover:bg-primary! hover:text-on-primary!"
             >
               {submitLabel}
             </Button>

--- a/src/components/ui/inputs/floating-label-input/FloatingLabelInput.tsx
+++ b/src/components/ui/inputs/floating-label-input/FloatingLabelInput.tsx
@@ -23,6 +23,9 @@ type BaseProps = {
   size?: FloatingLabelInputSize;
   /** Hide the floating label (useful for compact inline inputs) */
   hideLabel?: boolean;
+  /** Use inverse-themed tokens (for placement on inverse surfaces such as
+   *  the agent sidebar where the surrounding bg is `on-background`). */
+  inverse?: boolean;
 };
 
 type InputModeProps = BaseProps &
@@ -54,6 +57,7 @@ export function FloatingLabelInput(props: FloatingLabelInputProps) {
     disabled,
     size = "md",
     hideLabel = false,
+    inverse = false,
     multiline,
     maxLength,
   } = props;
@@ -100,9 +104,15 @@ export function FloatingLabelInput(props: FloatingLabelInputProps) {
   const isSmall = size === "sm";
 
   const fieldClassName = cn(
-    "peer w-full rounded-lg bg-transparent border-0 outline-none",
-    "text-on-surface transition-colors disabled:cursor-not-allowed",
-    error ? "focus:text-error" : "focus:text-primary",
+    "peer w-full rounded-lg bg-transparent border-0 outline-none transition-colors disabled:cursor-not-allowed",
+    inverse
+      ? "text-inverse-on-surface placeholder:text-inverse-on-surface/40"
+      : "text-on-surface",
+    error
+      ? "focus:text-error"
+      : inverse
+        ? "focus:text-inverse-on-surface"
+        : "focus:text-primary",
     isSmall ? "px-3 text-sm" : "px-4",
     multiline
       ? showCounter
@@ -114,24 +124,29 @@ export function FloatingLabelInput(props: FloatingLabelInputProps) {
   );
 
   const borderClassName = cn(
-    "relative flex border rounded-lg transition-colors bg-surface-container-low",
+    "relative flex border rounded-lg transition-colors",
+    inverse ? "bg-inverse-on-surface/[0.06]" : "bg-surface-container-low",
     multiline ? "items-start" : "items-center",
     error
       ? "border-error hover:border-error focus-within:ring-2 focus-within:ring-error focus-within:border-error"
-      : "border-outline-variant hover:border-primary focus-within:ring-2 focus-within:ring-primary focus-within:border-primary",
-    disabled && "opacity-50 cursor-not-allowed hover:border-outline-variant",
+      : inverse
+        ? "border-inverse-on-surface/30 hover:border-inverse-on-surface/50 focus-within:ring-2 focus-within:ring-inverse-primary/30 focus-within:border-inverse-primary/60"
+        : "border-outline-variant hover:border-primary focus-within:ring-2 focus-within:ring-primary focus-within:border-primary",
+    disabled && "opacity-50 cursor-not-allowed",
   );
 
   const labelClassName = cn(
-    "absolute z-10 font-normal px-1",
-    "bg-surface-container-low rounded-md transition-all duration-200 ease-in-out",
+    "absolute z-10 font-normal px-1 rounded-md transition-all duration-200 ease-in-out",
     "origin-top-left pointer-events-none",
+    inverse ? "bg-inverse-surface" : "bg-surface-container-low",
     isSmall
       ? "text-sm left-3 top-2.5 peer-focus:scale-75 peer-focus:top-0 peer-focus:-translate-y-1/2 peer-focus:left-2.5 peer-[:not(:placeholder-shown)]:scale-75 peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:-translate-y-1/2 peer-[:not(:placeholder-shown)]:left-2.5"
       : "text-base left-4 top-4 peer-focus:scale-75 peer-focus:top-0 peer-focus:-translate-y-1/2 peer-focus:left-3 peer-[:not(:placeholder-shown)]:scale-75 peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:-translate-y-1/2 peer-[:not(:placeholder-shown)]:left-3",
     error
       ? "text-error peer-focus:text-error"
-      : "text-on-surface-variant peer-focus:text-primary",
+      : inverse
+        ? "text-inverse-on-surface/55 peer-focus:text-inverse-primary"
+        : "text-on-surface-variant peer-focus:text-primary",
   );
 
   return (

--- a/src/components/ui/inputs/segmented-button/SegmentedButton.tsx
+++ b/src/components/ui/inputs/segmented-button/SegmentedButton.tsx
@@ -27,12 +27,40 @@ export interface SegmentedButtonProps<T extends string = string> {
   disabled?: boolean;
   className?: string;
   size?: SegmentedButtonSize;
+  /** Use inverse-themed tokens (for placement on inverse surfaces such as
+   *  the agent sidebar where the surrounding bg is `on-background`). */
+  inverse?: boolean;
 }
 
 const sizeStyles: Record<SegmentedButtonSize, string> = {
   sm: "px-3 py-1.5 rounded-md text-xs",
   md: "px-4 py-2 rounded-xl text-sm",
 };
+
+function buttonStyle(
+  selected: boolean,
+  tone: SegmentedButtonOptionTone | undefined,
+  inverse: boolean,
+): string {
+  if (selected) {
+    return inverse
+      ? "bg-inverse-primary text-inverse-surface"
+      : "bg-primary text-on-primary";
+  }
+  if (tone === "warning") {
+    return inverse
+      ? "bg-warning-container/90 text-on-warning-container hover:bg-warning-container"
+      : "bg-warning-container text-on-warning-container hover:bg-warning/20";
+  }
+  if (tone === "muted") {
+    return inverse
+      ? "bg-inverse-on-surface/[0.04] text-inverse-on-surface/45 hover:bg-inverse-on-surface/[0.08] hover:text-inverse-on-surface/70"
+      : "bg-surface-container/40 text-on-surface-variant/70 hover:bg-surface-container hover:text-on-surface-variant";
+  }
+  return inverse
+    ? "bg-inverse-on-surface/[0.06] text-inverse-on-surface/70 hover:bg-inverse-on-surface/[0.12] hover:text-inverse-on-surface"
+    : "bg-surface-container text-on-surface-variant hover:bg-surface-container-high";
+}
 
 export function SegmentedButton<T extends string = string>({
   options,
@@ -42,6 +70,7 @@ export function SegmentedButton<T extends string = string>({
   disabled = false,
   className,
   size = "md",
+  inverse = false,
 }: SegmentedButtonProps<T>) {
   if (isDev) {
     if (options.length === 0) {
@@ -70,13 +99,7 @@ export function SegmentedButton<T extends string = string>({
           className={cn(
             "font-medium transition-colors",
             sizeStyles[size],
-            value === opt.value
-              ? "bg-primary text-on-primary"
-              : opt.tone === "warning"
-                ? "bg-warning-container text-on-warning-container hover:bg-warning/20"
-                : opt.tone === "muted"
-                  ? "bg-surface-container/40 text-on-surface-variant/70 hover:bg-surface-container hover:text-on-surface-variant"
-                  : "bg-surface-container text-on-surface-variant hover:bg-surface-container-high",
+            buttonStyle(value === opt.value, opt.tone, inverse),
             disabled
               ? "opacity-50 cursor-not-allowed"
               : "cursor-pointer",

--- a/src/components/ui/inputs/switch/Switch.tsx
+++ b/src/components/ui/inputs/switch/Switch.tsx
@@ -18,6 +18,9 @@ export interface SwitchProps {
   readonly disabled?: boolean;
   readonly color?: SwitchColor;
   readonly className?: string;
+  /** Use inverse-themed tokens (for placement on inverse surfaces such as
+   *  the agent sidebar where the surrounding bg is `on-background`). */
+  readonly inverse?: boolean;
 }
 
 const trackColors: Record<SwitchColor, string> = {
@@ -40,6 +43,7 @@ export function Switch({
   disabled = false,
   color = "primary",
   className,
+  inverse = false,
 }: SwitchProps) {
   if (isDev) {
     if (!ariaLabel && !ariaLabelledBy) {
@@ -48,6 +52,15 @@ export function Switch({
       );
     }
   }
+
+  const trackOn = inverse && color === "primary"
+    ? "bg-inverse-primary"
+    : trackColors[color];
+  const trackOff = inverse ? "bg-inverse-on-surface/20" : "bg-outline-variant";
+  const thumbOn = inverse && color === "primary"
+    ? "bg-inverse-surface"
+    : thumbColors[color];
+  const thumbOff = inverse ? "bg-inverse-surface" : "bg-surface";
 
   return (
     <button
@@ -60,7 +73,7 @@ export function Switch({
       onClick={() => onChange(!checked)}
       className={cn(
         "relative w-11 h-6 rounded-full transition-colors shrink-0",
-        checked ? trackColors[color] : "bg-outline-variant",
+        checked ? trackOn : trackOff,
         disabled ? "opacity-50 cursor-not-allowed" : "cursor-pointer",
         className,
       )}
@@ -68,7 +81,7 @@ export function Switch({
       <span
         className={cn(
           "absolute top-0.5 left-0.5 w-5 h-5 rounded-full transition-transform",
-          checked ? `translate-x-5 ${thumbColors[color]}` : "bg-surface",
+          checked ? `translate-x-5 ${thumbOn}` : thumbOff,
         )}
       />
     </button>

--- a/src/theme.css
+++ b/src/theme.css
@@ -282,6 +282,10 @@ body {
   background: transparent;
 }
 
+main {
+  scrollbar-gutter: stable;
+}
+
 /* Material Symbols Rounded */
 .material-symbols-rounded {
   font-family: "Material Symbols Rounded";


### PR DESCRIPTION
## Summary
The agent sidebar reskinned three kit primitives via fragile arbitrary-descendant className overrides that targeted internal DOM (\`[&>button[aria-pressed=...]]:...\`, \`[&>div]:...\`, \`aria-checked:...\`). They were brittle to upstream changes and Tailwind v4's \`!\` suffix didn't always win — visible failure: SegmentedButton's selected pill rendered as \`bg-primary\` (light blue) in dark mode instead of \`bg-inverse-primary\`.

Replace the override hack with proper API: each primitive gains an opt-in \`inverse?: boolean\` prop that swaps its internal token palette to \`inverse-*\` equivalents. Default behavior preserved for existing callers.

## What changed

- **SegmentedButton** — extracted \`buttonStyle()\` helper that picks selected / tone="warning"|"muted" / default per-button styles based on \`inverse\`
- **FloatingLabelInput** — \`borderClassName\`, \`fieldClassName\`, \`labelClassName\` switch palettes; floating label backdrop becomes \`bg-inverse-surface\` so the label notch reads cleanly when the input sits on inverse surface
- **Switch** — track-on/off + thumbs swap palettes; only flips the primary palette since error/warning are state-tinted not theme-relative
- **AgentSidebarMultiQuestion** — drops the \`inverseOverrides\` constant and passes \`inverse\` to all three primitives. The \`flex-wrap\` wrap behavior moves to a per-call-site \`className\` since it's a layout decision, not a theme one

## Test plan
- [ ] Toggle dark mode at \`/me/preferences\` — agent sidebar's MultiQuestion ask cards should now render correctly: selected SegmentedButton pill = inverse-primary (dark teal in dark mode, light cyan in light mode); FLI input bg/border/text use inverse tokens; Switch on-track = inverse-primary
- [ ] Existing usages of SegmentedButton, FloatingLabelInput, Switch (without \`inverse\` prop) unchanged
- [ ] Storybook stories for the three primitives still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)