### PR TITLE
feat(data): add chart components (LineChart, BarChart, CompareBarChart, DualLineChart, Sparkline)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -36,6 +36,7 @@
   "dependencies": {
     "clsx": "^2.0.0",
     "react-easy-crop": "^5.5.7",
+    "recharts": "^2.15.4",
     "tailwind-merge": "^2.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       react-easy-crop:
         specifier: ^5.5.7
         version: 5.5.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      recharts:
+        specifier: ^2.15.4
+        version: 2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^2.0.0
         version: 2.6.1
@@ -720,6 +723,33 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -893,6 +923,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
@@ -905,6 +979,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -950,6 +1027,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1013,9 +1093,16 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -1118,6 +1205,10 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -1259,6 +1350,13 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -1339,6 +1437,10 @@ packages:
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
@@ -1387,6 +1489,9 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1418,8 +1523,26 @@ packages:
       react: '>=16.4.0'
       react-dom: '>=16.4.0'
 
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -1432,6 +1555,16 @@ packages:
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -1635,6 +1768,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -2297,6 +2433,30 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
@@ -2464,6 +2624,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   data-urls@5.0.0:
     dependencies:
       whatwg-mimetype: 4.0.0
@@ -2472,6 +2670,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -2503,6 +2703,11 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      csstype: 3.2.3
 
   dunder-proto@1.0.1:
     dependencies:
@@ -2579,7 +2784,11 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@4.0.7: {}
+
   expect-type@1.3.0: {}
+
+  fast-equals@5.4.0: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -2697,6 +2906,8 @@ snapshots:
 
   indent-string@4.0.0: {}
 
+  internmap@2.0.3: {}
+
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
@@ -2812,6 +3023,12 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lodash@4.18.1: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
@@ -2867,6 +3084,8 @@ snapshots:
 
   nwsapi@2.2.23: {}
 
+  object-assign@4.1.1: {}
+
   open@10.2.0:
     dependencies:
       default-browser: 5.5.0
@@ -2913,6 +3132,12 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   punycode@2.3.1: {}
 
   queue-lit@1.5.2: {}
@@ -2950,7 +3175,28 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       tslib: 2.8.1
 
+  react-is@16.13.1: {}
+
   react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
+
+  react-smooth@4.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      fast-equals: 5.4.0
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-transition-group: 4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+
+  react-transition-group@4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   react@19.2.4: {}
 
@@ -2965,6 +3211,23 @@ snapshots:
       source-map: 0.6.1
       tiny-invariant: 1.3.3
       tslib: 2.8.1
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.18.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   redent@3.0.0:
     dependencies:
@@ -3171,6 +3434,23 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-node@3.2.4(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:

--- a/src/components/ui/data/charts/BarChart.stories.tsx
+++ b/src/components/ui/data/charts/BarChart.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { BarChart } from "./BarChart";
+
+const months = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+const trend = months.map((label, i) => ({
+  label,
+  value: 420 + Math.round(Math.sin(i / 2) * 80) + i * 6,
+}));
+
+const meta: Meta<typeof BarChart> = {
+  title: "UI/Data/Charts/BarChart",
+  component: BarChart,
+  args: {
+    data: trend,
+    height: 120,
+    highlightLast: false,
+    unitPrefix: "$",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-2xl rounded-xl border border-outline-variant/40 bg-surface-container-low p-4">
+        <p className="text-xs font-medium text-on-surface-variant mb-3">
+          Monthly revenue
+        </p>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof BarChart>;
+
+export const Basic: Story = {};
+
+export const HighlightLast: Story = {
+  args: { highlightLast: true },
+};
+
+export const Themed: Story = {
+  args: {
+    color: "var(--color-success)",
+    highlightLast: true,
+  },
+};

--- a/src/components/ui/data/charts/BarChart.tsx
+++ b/src/components/ui/data/charts/BarChart.tsx
@@ -1,0 +1,124 @@
+import { useId } from "react";
+import {
+  Bar,
+  BarChart as RechartsBarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { ChartTooltip } from "./ChartTooltip";
+import {
+  AXIS_PROPS,
+  AXIS_TICK,
+  CHART_MARGIN,
+  GRID_PROPS,
+  formatChartValue,
+} from "./chart-defaults";
+
+export const meta: ComponentMeta = {
+  name: "BarChart",
+  description:
+    "Vertical bar chart with optional highlighted last bar (gradient + 1.0 opacity, others 0.35). Used for trend visualizations.",
+};
+
+export interface BarChartDatum {
+  label: string;
+  value: number;
+}
+
+export interface BarChartProps {
+  data: BarChartDatum[];
+  /** Bar color. Defaults to the primary theme token. */
+  color?: string;
+  /** Pixel height of the chart. Defaults to 100. */
+  height?: number;
+  /** Highlight the last bar with full opacity + gradient; others fade to 0.35. Defaults to false. */
+  highlightLast?: boolean;
+  /** Optional prefix used in Y axis + tooltip labels (e.g. "$"). */
+  unitPrefix?: string;
+  className?: string;
+}
+
+const DEFAULT_COLOR = "var(--color-primary)";
+
+export function BarChart({
+  data,
+  color = DEFAULT_COLOR,
+  height = 100,
+  highlightLast = false,
+  unitPrefix = "",
+  className,
+}: BarChartProps) {
+  const reactId = useId();
+  const gradientId = `bar-grad-${reactId}`;
+  const lastIndex = data.length - 1;
+
+  return (
+    <div className={cn("w-full", className)} style={{ height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <RechartsBarChart
+          data={data}
+          margin={CHART_MARGIN}
+          barCategoryGap="50%"
+        >
+          <defs>
+            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={color} stopOpacity={0.9} />
+              <stop offset="100%" stopColor={color} stopOpacity={0.5} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid {...GRID_PROPS} />
+          <XAxis
+            dataKey="label"
+            tick={AXIS_TICK}
+            interval="preserveStartEnd"
+            {...AXIS_PROPS}
+          />
+          <YAxis
+            tick={AXIS_TICK}
+            width={36}
+            tickFormatter={(v: number) => formatChartValue(v, unitPrefix)}
+            {...AXIS_PROPS}
+          />
+          <Tooltip
+            cursor={{ fill: "currentColor", fillOpacity: 0.05 }}
+            content={({ active, payload, label }) => {
+              if (!active || !payload?.length) return null;
+              const v = payload[0].value as number;
+              return (
+                <ChartTooltip
+                  active
+                  title={label}
+                  rows={[
+                    {
+                      label: "Value",
+                      value: formatChartValue(v, unitPrefix),
+                      color,
+                    },
+                  ]}
+                />
+              );
+            }}
+          />
+          <Bar dataKey="value" radius={[3, 3, 0, 0]} isAnimationActive={false}>
+            {data.map((entry, i) => {
+              const isLast = highlightLast && i === lastIndex;
+              return (
+                <Cell
+                  key={entry.label}
+                  fill={isLast ? `url(#${gradientId})` : color}
+                  fillOpacity={highlightLast ? (isLast ? 1 : 0.35) : 1}
+                />
+              );
+            })}
+          </Bar>
+        </RechartsBarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/ui/data/charts/ChartTooltip.tsx
+++ b/src/components/ui/data/charts/ChartTooltip.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+import { cn } from "@/utils/cn";
+
+export interface ChartTooltipRow {
+  label: string;
+  value: ReactNode;
+  color?: string;
+}
+
+export interface ChartTooltipProps {
+  active?: boolean;
+  title?: ReactNode;
+  rows: ChartTooltipRow[];
+  className?: string;
+}
+
+/**
+ * Shared tooltip surface used by every chart in the kit. Matches
+ * the surface-container + outline-variant card treatment from the
+ * web-applications hand-rolled charts.
+ */
+export function ChartTooltip({
+  active,
+  title,
+  rows,
+  className,
+}: ChartTooltipProps) {
+  if (!active || rows.length === 0) return null;
+  return (
+    <div
+      className={cn(
+        "pointer-events-none rounded-lg border border-outline-variant/40 bg-surface-container px-2.5 py-1.5 text-xs shadow-md",
+        className,
+      )}
+    >
+      {title != null && (
+        <p className="text-on-surface-variant mb-0.5">{title}</p>
+      )}
+      {rows.map((row, i) => (
+        <p
+          key={`${row.label}-${i}`}
+          className={cn(
+            "flex items-center gap-1.5",
+            i === 0 ? "font-medium text-on-surface" : "text-on-surface-variant/80",
+          )}
+        >
+          {row.color && (
+            <span
+              aria-hidden
+              className="inline-block h-2 w-2 rounded-full shrink-0"
+              style={{ background: row.color }}
+            />
+          )}
+          <span>{row.label}</span>
+          <span className="ml-auto tabular-nums">{row.value}</span>
+        </p>
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/data/charts/CompareBarChart.stories.tsx
+++ b/src/components/ui/data/charts/CompareBarChart.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { CompareBarChart } from "./CompareBarChart";
+
+const profitable = [
+  { label: "DB", cost: 1.2, charge: 2.4 },
+  { label: "Lambda", cost: 0.8, charge: 1.6 },
+  { label: "S3", cost: 0.4, charge: 0.7 },
+  { label: "CDN", cost: 0.6, charge: 0.95 },
+  { label: "Queue", cost: 0.3, charge: 0.55 },
+];
+
+const mixed = [
+  { label: "DB", cost: 1.2, charge: 2.4 },
+  { label: "Lambda", cost: 0.8, charge: 0.7 },
+  { label: "S3", cost: 0.4, charge: 0.7 },
+  { label: "CDN", cost: 0.6, charge: 0.5 },
+  { label: "Queue", cost: 0.3, charge: 0.55 },
+];
+
+const meta: Meta<typeof CompareBarChart> = {
+  title: "UI/Data/Charts/CompareBarChart",
+  component: CompareBarChart,
+  args: {
+    data: profitable,
+    height: 140,
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-2xl rounded-xl border border-outline-variant/40 bg-surface-container-low p-4">
+        <p className="text-xs font-medium text-on-surface-variant mb-3">
+          Cost vs charge
+        </p>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof CompareBarChart>;
+
+export const Basic: Story = {};
+
+export const Mixed: Story = {
+  args: { data: mixed },
+};
+
+export const Themed: Story = {
+  args: {
+    data: profitable,
+    costColor: "var(--color-tertiary)",
+    chargeColor: () => "var(--color-primary)",
+  },
+};

--- a/src/components/ui/data/charts/CompareBarChart.tsx
+++ b/src/components/ui/data/charts/CompareBarChart.tsx
@@ -1,0 +1,144 @@
+import {
+  Bar,
+  BarChart as RechartsBarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { ChartTooltip, type ChartTooltipRow } from "./ChartTooltip";
+import {
+  AXIS_PROPS,
+  AXIS_TICK,
+  CHART_MARGIN,
+  GRID_PROPS,
+} from "./chart-defaults";
+
+export const meta: ComponentMeta = {
+  name: "CompareBarChart",
+  description:
+    "Grouped two-bar-per-category chart comparing cost vs charge. The charge bar tints green when profitable and orange when not.",
+};
+
+export interface CompareBarChartDatum {
+  label: string;
+  cost: number;
+  charge: number;
+}
+
+export interface CompareBarChartProps {
+  data: CompareBarChartDatum[];
+  /** Color for the cost bar. Defaults to error theme token. */
+  costColor?: string;
+  /**
+   * Function returning the charge bar color per row. Default: green when
+   * `charge >= cost`, orange otherwise.
+   */
+  chargeColor?: (d: { cost: number; charge: number }) => string;
+  /** Pixel height of the chart. Defaults to 110. */
+  height?: number;
+  className?: string;
+}
+
+const DEFAULT_COST_COLOR = "var(--color-error)";
+const PROFITABLE_COLOR = "var(--color-success)";
+const UNPROFITABLE_COLOR = "var(--color-warning)";
+
+const defaultChargeColor = (d: { cost: number; charge: number }) =>
+  d.charge >= d.cost ? PROFITABLE_COLOR : UNPROFITABLE_COLOR;
+
+function formatTick(v: number) {
+  return `$${v.toFixed(2)}`;
+}
+
+export function CompareBarChart({
+  data,
+  costColor = DEFAULT_COST_COLOR,
+  chargeColor = defaultChargeColor,
+  height = 110,
+  className,
+}: CompareBarChartProps) {
+  return (
+    <div className={cn("w-full", className)} style={{ height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <RechartsBarChart
+          data={data}
+          margin={CHART_MARGIN}
+          barCategoryGap="20%"
+          barGap={2}
+        >
+          <CartesianGrid {...GRID_PROPS} />
+          <XAxis
+            dataKey="label"
+            tick={AXIS_TICK}
+            interval="preserveStartEnd"
+            {...AXIS_PROPS}
+          />
+          <YAxis
+            tick={AXIS_TICK}
+            width={40}
+            tickFormatter={formatTick}
+            {...AXIS_PROPS}
+          />
+          <Tooltip
+            cursor={{ fill: "currentColor", fillOpacity: 0.05 }}
+            content={({ active, payload, label }) => {
+              if (!active || !payload?.length) return null;
+              const cost = payload.find((p) => p.dataKey === "cost");
+              const charge = payload.find((p) => p.dataKey === "charge");
+              const datum =
+                (charge?.payload as
+                  | { cost: number; charge: number }
+                  | undefined) ??
+                (cost?.payload as
+                  | { cost: number; charge: number }
+                  | undefined);
+              const computedChargeColor =
+                datum != null ? chargeColor(datum) : PROFITABLE_COLOR;
+              const rows: ChartTooltipRow[] = [];
+              if (cost && typeof cost.value === "number") {
+                rows.push({
+                  label: "Cost",
+                  value: `$${cost.value.toFixed(2)}`,
+                  color: costColor,
+                });
+              }
+              if (charge && typeof charge.value === "number") {
+                rows.push({
+                  label: "Charge",
+                  value: `$${charge.value.toFixed(2)}`,
+                  color: computedChargeColor,
+                });
+              }
+              return <ChartTooltip active title={label} rows={rows} />;
+            }}
+          />
+          <Bar
+            dataKey="cost"
+            fill={costColor}
+            fillOpacity={0.5}
+            radius={[2, 2, 0, 0]}
+            isAnimationActive={false}
+          />
+          <Bar
+            dataKey="charge"
+            radius={[2, 2, 0, 0]}
+            isAnimationActive={false}
+          >
+            {data.map((entry) => (
+              <Cell
+                key={entry.label}
+                fill={chargeColor(entry)}
+                fillOpacity={0.7}
+              />
+            ))}
+          </Bar>
+        </RechartsBarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/ui/data/charts/DualLineChart.stories.tsx
+++ b/src/components/ui/data/charts/DualLineChart.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { DualLineChart } from "./DualLineChart";
+
+const days = Array.from({ length: 30 }, (_, i) => `${i + 1}`);
+
+const trend = days.map((label, i) => ({
+  label,
+  a: 320 + Math.round(Math.sin(i / 3) * 60) + i * 2,
+  b: 460 + Math.round(Math.cos(i / 4) * 80) + i * 3,
+}));
+
+const meta: Meta<typeof DualLineChart> = {
+  title: "UI/Data/Charts/DualLineChart",
+  component: DualLineChart,
+  args: {
+    data: trend,
+    height: 160,
+    fillUnderB: true,
+    labelA: "Cost",
+    labelB: "Income",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-3xl rounded-xl border border-outline-variant/40 bg-surface-container-low p-4">
+        <p className="text-xs font-medium text-on-surface-variant mb-3">
+          Cost vs income
+        </p>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof DualLineChart>;
+
+export const Basic: Story = {};
+
+export const NoFill: Story = {
+  args: { fillUnderB: false },
+};
+
+export const Themed: Story = {
+  args: {
+    colorA: "var(--color-warning)",
+    colorB: "var(--color-primary)",
+  },
+};

--- a/src/components/ui/data/charts/DualLineChart.tsx
+++ b/src/components/ui/data/charts/DualLineChart.tsx
@@ -1,0 +1,160 @@
+import { useId } from "react";
+import {
+  Area,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { ChartTooltip, type ChartTooltipRow } from "./ChartTooltip";
+import {
+  AXIS_PROPS,
+  AXIS_TICK,
+  CHART_MARGIN,
+  GRID_PROPS,
+} from "./chart-defaults";
+
+export const meta: ComponentMeta = {
+  name: "DualLineChart",
+  description:
+    "Two smooth lines on the same axes (e.g. cost vs income) with an optional gradient fill underneath the second line.",
+};
+
+export interface DualLineChartDatum {
+  label: string;
+  a: number;
+  b: number;
+}
+
+export interface DualLineChartProps {
+  data: DualLineChartDatum[];
+  /** Color of line A. Defaults to error theme token (cost). */
+  colorA?: string;
+  /** Color of line B. Defaults to success theme token (income). */
+  colorB?: string;
+  /** Render a gradient fill underneath line B only. Defaults to true. */
+  fillUnderB?: boolean;
+  /** Pixel height of the chart. Defaults to 120. */
+  height?: number;
+  /** Tooltip label for line A. Defaults to "A". */
+  labelA?: string;
+  /** Tooltip label for line B. Defaults to "B". */
+  labelB?: string;
+  className?: string;
+}
+
+const DEFAULT_COLOR_A = "var(--color-error)";
+const DEFAULT_COLOR_B = "var(--color-success)";
+
+function formatTick(v: number) {
+  return `$${Math.round(v)}`;
+}
+
+export function DualLineChart({
+  data,
+  colorA = DEFAULT_COLOR_A,
+  colorB = DEFAULT_COLOR_B,
+  fillUnderB = true,
+  height = 120,
+  labelA = "A",
+  labelB = "B",
+  className,
+}: DualLineChartProps) {
+  const reactId = useId();
+  const fillId = `dual-fill-${reactId}`;
+
+  return (
+    <div className={cn("w-full", className)} style={{ height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart data={data} margin={CHART_MARGIN}>
+          <defs>
+            <linearGradient id={fillId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={colorB} stopOpacity={0.12} />
+              <stop offset="100%" stopColor={colorB} stopOpacity={0.01} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid {...GRID_PROPS} />
+          <XAxis
+            dataKey="label"
+            tick={AXIS_TICK}
+            interval="preserveStartEnd"
+            minTickGap={24}
+            {...AXIS_PROPS}
+          />
+          <YAxis
+            tick={AXIS_TICK}
+            width={40}
+            tickFormatter={formatTick}
+            {...AXIS_PROPS}
+          />
+          <Tooltip
+            cursor={{
+              stroke: "currentColor",
+              strokeOpacity: 0.15,
+              strokeWidth: 1,
+            }}
+            content={({ active, payload, label }) => {
+              if (!active || !payload?.length) return null;
+              const a = payload.find((p) => p.dataKey === "a");
+              const b = payload.find((p) => p.dataKey === "b");
+              const rows: ChartTooltipRow[] = [];
+              if (a && typeof a.value === "number") {
+                rows.push({
+                  label: labelA,
+                  value: `$${Math.round(a.value)}`,
+                  color: colorA,
+                });
+              }
+              if (b && typeof b.value === "number") {
+                rows.push({
+                  label: labelB,
+                  value: `$${Math.round(b.value)}`,
+                  color: colorB,
+                });
+              }
+              return <ChartTooltip active title={label} rows={rows} />;
+            }}
+          />
+
+          {fillUnderB && (
+            <Area
+              type="monotone"
+              dataKey="b"
+              stroke="none"
+              fill={`url(#${fillId})`}
+              isAnimationActive={false}
+            />
+          )}
+
+          <Line
+            type="monotone"
+            dataKey="a"
+            stroke={colorA}
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            dot={false}
+            activeDot={{ r: 3.5, fill: colorA }}
+            isAnimationActive={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="b"
+            stroke={colorB}
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            dot={false}
+            activeDot={{ r: 3.5, fill: colorB }}
+            isAnimationActive={false}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/ui/data/charts/LineChart.stories.tsx
+++ b/src/components/ui/data/charts/LineChart.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { LineChart } from "./LineChart";
+
+function seed(n: number) {
+  const x = Math.sin(n + 1) * 10000;
+  return x - Math.floor(x);
+}
+
+const HOURLY_LABELS = Array.from(
+  { length: 24 },
+  (_, i) => `${String(i).padStart(2, "0")}:00`,
+);
+
+const requestsData = HOURLY_LABELS.map((label, i) => ({
+  label,
+  value: Math.max(0, 420 + (seed(i) - 0.5) * 360),
+}));
+
+const responseData = HOURLY_LABELS.map((label, i) => ({
+  label,
+  value: Math.max(0, 86 + (seed(i) - 0.5) * 68),
+  overlay: Math.max(0, 42 + (seed(i + 7) - 0.5) * 36),
+}));
+
+const coldStartData = HOURLY_LABELS.map((label, i) => ({
+  label,
+  value: Math.max(0, 210 + (seed(i + 3) - 0.5) * 160),
+}));
+
+const meta: Meta<typeof LineChart> = {
+  title: "UI/Data/Charts/LineChart",
+  component: LineChart,
+  args: {
+    data: requestsData,
+    height: 160,
+    unit: "",
+    showArea: true,
+    smooth: true,
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-3xl rounded-xl border border-outline-variant/40 bg-surface-container-low p-4">
+        <p className="text-xs font-medium text-on-surface-variant mb-3">
+          Requests / min
+        </p>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof LineChart>;
+
+export const Basic: Story = {};
+
+export const WithOverlay: Story = {
+  args: {
+    data: responseData,
+    unit: "ms",
+    overlayLabel: "p50",
+    showArea: false,
+    height: 140,
+  },
+};
+
+export const WithThreshold: Story = {
+  args: {
+    data: coldStartData,
+    unit: "ms",
+    thresholdY: 300,
+    height: 140,
+    color: "var(--color-warning)",
+  },
+};
+
+export const Themed: Story = {
+  args: {
+    data: requestsData,
+    color: "var(--color-tertiary)",
+    height: 140,
+  },
+};

--- a/src/components/ui/data/charts/LineChart.test.tsx
+++ b/src/components/ui/data/charts/LineChart.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { LineChart } from "./LineChart";
+
+afterEach(cleanup);
+
+const data = Array.from({ length: 6 }, (_, i) => ({
+  label: `t${i}`,
+  value: 10 + i * 5,
+}));
+
+const dataWithOverlay = data.map((d, i) => ({
+  ...d,
+  overlay: 5 + i * 3,
+}));
+
+describe("LineChart", () => {
+  it("renders a chart container without throwing", () => {
+    const { container } = render(<LineChart data={data} />);
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it("applies the given className", () => {
+    const { container } = render(
+      <LineChart data={data} className="custom-class" />,
+    );
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+
+  it("respects the height prop", () => {
+    const { container } = render(<LineChart data={data} height={200} />);
+    expect(container.firstChild).toHaveStyle({ height: "200px" });
+  });
+
+  it("renders with overlay data without throwing", () => {
+    const { container } = render(<LineChart data={dataWithOverlay} />);
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it("renders with thresholdY without throwing", () => {
+    const { container } = render(<LineChart data={data} thresholdY={20} />);
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it("renders with showArea=false without throwing", () => {
+    const { container } = render(<LineChart data={data} showArea={false} />);
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it("handles empty data without throwing", () => {
+    const { container } = render(<LineChart data={[]} />);
+    expect(container.firstChild).toBeTruthy();
+  });
+});

--- a/src/components/ui/data/charts/LineChart.tsx
+++ b/src/components/ui/data/charts/LineChart.tsx
@@ -1,0 +1,205 @@
+import { useId } from "react";
+import {
+  Area,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  ReferenceArea,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { ChartTooltip, type ChartTooltipRow } from "./ChartTooltip";
+import {
+  AXIS_PROPS,
+  AXIS_TICK,
+  CHART_MARGIN,
+  GRID_PROPS,
+  formatChartValue,
+} from "./chart-defaults";
+
+export const meta: ComponentMeta = {
+  name: "LineChart",
+  description:
+    "Smooth line chart with optional gradient area, secondary dashed overlay line, threshold band, and themed hover tooltip.",
+};
+
+export interface LineChartDatum {
+  label: string;
+  value: number;
+  overlay?: number;
+}
+
+export interface LineChartProps {
+  data: LineChartDatum[];
+  /** Stroke color of the main line. Defaults to the primary theme token. */
+  color?: string;
+  /** Stroke color of the optional dashed overlay line. */
+  overlayColor?: string;
+  /** Tooltip label for the overlay series. Defaults to "Overlay". */
+  overlayLabel?: string;
+  /** Pixel height of the chart. Defaults to 120. */
+  height?: number;
+  /** Suffix appended in tooltip + Y axis labels (e.g. "ms", "%"). */
+  unit?: string;
+  /** Render the gradient fill underneath the main line. Defaults to true. */
+  showArea?: boolean;
+  /** Y-value for the dashed warning threshold line + tinted band above it. */
+  thresholdY?: number;
+  /** Use Recharts monotone curve interpolation. Defaults to true. */
+  smooth?: boolean;
+  className?: string;
+}
+
+const DEFAULT_COLOR = "var(--color-primary)";
+const DEFAULT_OVERLAY_COLOR = "var(--color-on-surface-variant)";
+const THRESHOLD_COLOR = "var(--color-error)";
+
+export function LineChart({
+  data,
+  color = DEFAULT_COLOR,
+  overlayColor = DEFAULT_OVERLAY_COLOR,
+  overlayLabel = "Overlay",
+  height = 120,
+  unit = "",
+  showArea = true,
+  thresholdY,
+  smooth = true,
+  className,
+}: LineChartProps) {
+  const reactId = useId();
+  const fillId = `line-fill-${reactId}`;
+  const thresholdFillId = `line-threshold-${reactId}`;
+  const hasOverlay = data.some((d) => typeof d.overlay === "number");
+  const curveType = smooth ? "monotone" : "linear";
+
+  const allValues = data.flatMap((d) =>
+    typeof d.overlay === "number" ? [d.value, d.overlay] : [d.value],
+  );
+  const dataMax = allValues.length ? Math.max(...allValues) : 1;
+  const yMax = dataMax * 1.15 || 1;
+
+  return (
+    <div className={cn("w-full", className)} style={{ height }}>
+      <ResponsiveContainer width="100%" height="100%">
+        <ComposedChart data={data} margin={CHART_MARGIN}>
+          <defs>
+            <linearGradient id={fillId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={color} stopOpacity={0.18} />
+              <stop offset="100%" stopColor={color} stopOpacity={0.01} />
+            </linearGradient>
+            {thresholdY != null && (
+              <linearGradient id={thresholdFillId} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={THRESHOLD_COLOR} stopOpacity={0.2} />
+                <stop offset="100%" stopColor={THRESHOLD_COLOR} stopOpacity={0.02} />
+              </linearGradient>
+            )}
+          </defs>
+
+          <CartesianGrid {...GRID_PROPS} />
+          <XAxis
+            dataKey="label"
+            tick={AXIS_TICK}
+            interval="preserveStartEnd"
+            minTickGap={24}
+            {...AXIS_PROPS}
+          />
+          <YAxis
+            tick={AXIS_TICK}
+            domain={[0, yMax]}
+            width={36}
+            tickFormatter={(v: number) => formatChartValue(v, "", unit)}
+            {...AXIS_PROPS}
+          />
+
+          {thresholdY != null && showArea && (
+            <ReferenceArea
+              y1={thresholdY}
+              y2={yMax}
+              fill={`url(#${thresholdFillId})`}
+              ifOverflow="extendDomain"
+            />
+          )}
+          {thresholdY != null && (
+            <ReferenceLine
+              y={thresholdY}
+              stroke={THRESHOLD_COLOR}
+              strokeOpacity={0.4}
+              strokeDasharray="4 3"
+            />
+          )}
+
+          {showArea && (
+            <Area
+              type={curveType}
+              dataKey="value"
+              stroke="none"
+              fill={`url(#${fillId})`}
+              isAnimationActive={false}
+            />
+          )}
+
+          {hasOverlay && (
+            <Line
+              type={curveType}
+              dataKey="overlay"
+              stroke={overlayColor}
+              strokeOpacity={0.6}
+              strokeWidth={1.5}
+              strokeDasharray="4 3"
+              dot={false}
+              activeDot={{ r: 3, fill: overlayColor, fillOpacity: 0.85 }}
+              isAnimationActive={false}
+              connectNulls
+            />
+          )}
+
+          <Line
+            type={curveType}
+            dataKey="value"
+            stroke={color}
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            dot={false}
+            activeDot={{ r: 3.5, fill: color }}
+            isAnimationActive={false}
+          />
+
+          <Tooltip
+            cursor={{
+              stroke: "currentColor",
+              strokeOpacity: 0.15,
+              strokeWidth: 1,
+            }}
+            content={({ active, payload, label }) => {
+              if (!active || !payload?.length) return null;
+              const main = payload.find((p) => p.dataKey === "value");
+              const overlay = payload.find((p) => p.dataKey === "overlay");
+              const rows: ChartTooltipRow[] = [];
+              if (main && typeof main.value === "number") {
+                rows.push({
+                  label: "Value",
+                  value: formatChartValue(main.value, "", unit),
+                  color,
+                });
+              }
+              if (overlay && typeof overlay.value === "number") {
+                rows.push({
+                  label: overlayLabel,
+                  value: formatChartValue(overlay.value, "", unit),
+                  color: overlayColor,
+                });
+              }
+              return <ChartTooltip active title={label} rows={rows} />;
+            }}
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/ui/data/charts/Sparkline.stories.tsx
+++ b/src/components/ui/data/charts/Sparkline.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Sparkline } from "./Sparkline";
+
+const climbing = [10, 12, 11, 14, 17, 16, 18, 21, 22, 25];
+const dipping = [22, 21, 19, 20, 16, 14, 15, 13, 11, 10];
+
+const meta: Meta<typeof Sparkline> = {
+  title: "UI/Data/Charts/Sparkline",
+  component: Sparkline,
+  args: {
+    values: climbing,
+    width: 80,
+    height: 32,
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex items-center gap-4 rounded-xl border border-outline-variant/40 bg-surface-container-low px-4 py-3">
+        <span className="text-sm font-medium text-on-surface">Requests</span>
+        <Story />
+        <span className="text-xs text-on-surface-variant ml-auto tabular-nums">
+          25 / min
+        </span>
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Sparkline>;
+
+export const Basic: Story = {};
+
+export const Trending: Story = {
+  args: { values: dipping, color: "var(--color-error)" },
+};
+
+export const Themed: Story = {
+  args: {
+    values: climbing,
+    color: "var(--color-tertiary)",
+    width: 120,
+    height: 36,
+  },
+};

--- a/src/components/ui/data/charts/Sparkline.tsx
+++ b/src/components/ui/data/charts/Sparkline.tsx
@@ -1,0 +1,79 @@
+import { useId } from "react";
+import { Area, AreaChart, ResponsiveContainer } from "recharts";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "Sparkline",
+  description:
+    "Compact inline trend line with a soft gradient fill — used in dense tables where a single number wants context.",
+};
+
+export interface SparklineProps {
+  values: number[];
+  /** Stroke color. Defaults to the primary theme token. */
+  color?: string;
+  /** Pixel width. Defaults to 80. */
+  width?: number;
+  /** Pixel height. Defaults to 32. */
+  height?: number;
+  className?: string;
+}
+
+const DEFAULT_COLOR = "var(--color-primary)";
+
+export function Sparkline({
+  values,
+  color = DEFAULT_COLOR,
+  width = 80,
+  height = 32,
+  className,
+}: SparklineProps) {
+  const reactId = useId();
+  const fillId = `spark-fill-${reactId}`;
+
+  if (values.length < 2) {
+    return (
+      <div
+        className={cn("inline-block shrink-0", className)}
+        style={{ width, height }}
+        aria-hidden
+      />
+    );
+  }
+
+  const data = values.map((value, i) => ({ i, value }));
+
+  return (
+    <div
+      className={cn("inline-block shrink-0", className)}
+      style={{ width, height }}
+    >
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart
+          data={data}
+          margin={{ top: 2, right: 0, bottom: 2, left: 0 }}
+        >
+          <defs>
+            <linearGradient id={fillId} x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={color} stopOpacity={0.2} />
+              <stop offset="100%" stopColor={color} stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <Area
+            type="monotone"
+            dataKey="value"
+            stroke={color}
+            strokeWidth={1.5}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            fill={`url(#${fillId})`}
+            isAnimationActive={false}
+            dot={false}
+            activeDot={false}
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/components/ui/data/charts/chart-defaults.ts
+++ b/src/components/ui/data/charts/chart-defaults.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared visual defaults applied to every cartesian chart in the kit so the
+ * grid/axis treatment stays consistent across LineChart, BarChart,
+ * CompareBarChart, and DualLineChart.
+ */
+export const CHART_MARGIN = {
+  top: 8,
+  right: 4,
+  bottom: 0,
+  left: 0,
+} as const;
+
+export const GRID_PROPS = {
+  stroke: "currentColor",
+  strokeOpacity: 0.07,
+  vertical: false,
+} as const;
+
+export const AXIS_TICK = {
+  fontSize: 9,
+  fill: "currentColor",
+  fillOpacity: 0.4,
+} as const;
+
+export const AXIS_PROPS = {
+  stroke: "currentColor",
+  strokeOpacity: 0.4,
+  tickLine: false,
+  axisLine: false,
+} as const;
+
+/**
+ * Round to integer for values >= 1, two decimals otherwise. Matches the
+ * formatting convention used by the original web-applications charts.
+ */
+export function formatChartValue(
+  value: number,
+  prefix = "",
+  suffix = "",
+): string {
+  const formatted =
+    Math.abs(value) >= 1 ? Math.round(value).toString() : value.toFixed(2);
+  return `${prefix}${formatted}${suffix}`;
+}

--- a/src/components/ui/data/charts/index.ts
+++ b/src/components/ui/data/charts/index.ts
@@ -1,0 +1,18 @@
+export { LineChart, type LineChartProps, type LineChartDatum } from "./LineChart";
+export { BarChart, type BarChartProps, type BarChartDatum } from "./BarChart";
+export {
+  CompareBarChart,
+  type CompareBarChartProps,
+  type CompareBarChartDatum,
+} from "./CompareBarChart";
+export {
+  DualLineChart,
+  type DualLineChartProps,
+  type DualLineChartDatum,
+} from "./DualLineChart";
+export { Sparkline, type SparklineProps } from "./Sparkline";
+export {
+  ChartTooltip,
+  type ChartTooltipProps,
+  type ChartTooltipRow,
+} from "./ChartTooltip";

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,3 +241,19 @@ export {
   AppShell,
   type AppShellProps,
 } from "./components/layout/app-shell/app-shell/AppShell";
+export {
+  LineChart,
+  type LineChartProps,
+  type LineChartDatum,
+  BarChart,
+  type BarChartProps,
+  type BarChartDatum,
+  CompareBarChart,
+  type CompareBarChartProps,
+  type CompareBarChartDatum,
+  DualLineChart,
+  type DualLineChartProps,
+  type DualLineChartDatum,
+  Sparkline,
+  type SparklineProps,
+} from "./components/ui/data/charts";

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,12 @@
 import "@testing-library/jest-dom/vitest";
+
+// jsdom does not implement ResizeObserver. Recharts' ResponsiveContainer
+// uses it to track parent size. Provide a no-op polyfill so chart components
+// can render in tests.
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}


### PR DESCRIPTION
## Summary

PR-A4 of the charts swap. Adds five Recharts-based chart components to the kit so web-applications can drop the hand-rolled SVG primitives that currently live inline in service / billing pages.

### Components

- **LineChart** — smooth (monotone) line with optional gradient area fill, dashed overlay line, dashed red threshold line + tinted band above, themed hover tooltip
- **BarChart** — vertical bars with optional `highlightLast` (last bar at full opacity + gradient, others at 0.35)
- **CompareBarChart** — grouped 2-bar cost vs charge per category. The charge bar tints green when profitable and orange when not (configurable via `chargeColor` prop)
- **DualLineChart** — two smooth lines with optional gradient fill under line B (default behavior matches the cost-vs-income chart from billing)
- **Sparkline** — compact inline trend line with gradient fill

### Internals

- `ChartTooltip` — shared surface used by every chart; renders inside `bg-surface-container` with `border-outline-variant/40`
- `chart-defaults.ts` — shared axis / grid / margin / value-formatting constants so all four cartesian charts stay visually consistent
- All defaults resolve to MD3 tokens via CSS variables (`var(--color-primary)`, `var(--color-error)`, etc.); every chart accepts explicit color props for overrides

### Dependencies

- Adds **recharts ~2.15** as a runtime dep
- Adds a no-op **ResizeObserver polyfill** in `vitest.setup.ts` so tests can render Recharts' `ResponsiveContainer` under jsdom

### Versioning

Bumps to **0.2.10** (pre-1.0 patch). Tagged `release`.

### Out of scope

PR-A5 will swap web-applications consumers (`/dev/module/[slug]/service` and `/dev/module/[slug]/billing`) over to these components and delete the hand-rolled SVG primitives.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — new LineChart smoke tests pass (7 tests). Pre-existing ThemeProvider failures are unrelated to this PR (jsdom localStorage issue on main)
- [x] `pnpm build` produces dist artifacts
- [ ] Verify Storybook renders each chart cleanly in light + dark themes (`pnpm storybook`)
- [ ] Verify visual fidelity against the originals in web-applications service + billing pages