### PR TITLE
feat(chart): Sparkline

### DIFF
--- a/src/components/ui/chart/sparkline/Sparkline.stories.tsx
+++ b/src/components/ui/chart/sparkline/Sparkline.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Sparkline } from "./Sparkline";
+
+const meta: Meta<typeof Sparkline> = {
+  title: "UI/Chart/Sparkline",
+  component: Sparkline,
+  args: { data: [38, 62, 50, 78, 55, 70, 90, 60, 75, 95, 85, 100] },
+  argTypes: { data: { control: "object" } },
+};
+
+export default meta;
+type Story = StoryObj<typeof Sparkline>;
+
+const LABELLED = [470, 760, 600, 950, 680, 870, 1100, 740, 920, 1180, 1050, 1240].map(
+  (n, i) => ({ value: Math.round((n / 1240) * 100), label: `Wk ${i + 1} · ${n.toLocaleString()}` }),
+);
+
+/** A `Sparkline` fills its container — drop it in any sized box. Hover a bar. */
+export const Playground: Story = {
+  render: (args) => (
+    <div className="bg-background p-6">
+      <div className="h-28 w-64 rounded-2xl border border-outline-variant p-3">
+        <Sparkline {...args} className="h-full" />
+      </div>
+    </div>
+  ),
+};
+
+/** Bar / hover colours are passed via `barClassName` / `barActiveClassName`, so
+ *  a sparkline reads well on whatever surface it sits on. (Give it a height —
+ *  it fills its container; here via `className="h-full"`.) */
+export const Tones: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-start gap-6 bg-background p-6">
+      <div className="h-24 w-64 rounded-2xl bg-surface-container-low p-3">
+        <Sparkline data={LABELLED} className="h-full" />
+      </div>
+      <div className="h-24 w-64 rounded-2xl bg-primary-container p-3">
+        <Sparkline
+          data={LABELLED}
+          className="h-full"
+          barClassName="bg-on-primary-container/25"
+          barActiveClassName="bg-on-primary-container/55"
+        />
+      </div>
+      <div className="h-40 w-80 rounded-2xl bg-surface-container p-4">
+        <Sparkline data={LABELLED} className="h-full" barClassName="bg-primary/40" barActiveClassName="bg-primary/70" />
+      </div>
+    </div>
+  ),
+};

--- a/src/components/ui/chart/sparkline/Sparkline.test.tsx
+++ b/src/components/ui/chart/sparkline/Sparkline.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Sparkline } from "./Sparkline";
+
+afterEach(cleanup);
+
+/** The bar elements are the direct children of the sparkline root (the hover
+ *  chip is portaled to <body>, not a child). */
+const bars = (container: HTMLElement) =>
+  [...(container.firstElementChild?.children ?? [])] as HTMLElement[];
+
+describe("Sparkline", () => {
+  it("renders one bar per point, heights clamped to 0–100", () => {
+    const { container } = render(<Sparkline data={[10, 50, 130, -5]} />);
+    const b = bars(container);
+    expect(b).toHaveLength(4);
+    expect(b[0].style.height).toBe("10%");
+    expect(b[2].style.height).toBe("100%");
+    expect(b[3].style.height).toBe("0%");
+  });
+
+  it("renders nothing for empty data", () => {
+    const { container } = render(<Sparkline data={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("titles each bar with its label, falling back to the value", () => {
+    const { container } = render(<Sparkline data={[42, { value: 80, label: "Wk 3 · 920" }]} />);
+    const b = bars(container);
+    expect(b[0].title).toBe("42");
+    expect(b[1].title).toBe("Wk 3 · 920");
+    expect(b[1].style.height).toBe("80%");
+  });
+
+  it("pops a portaled chip on the hovered bar and clears it on leave", () => {
+    const { container } = render(<Sparkline data={[42, { value: 80, label: "Wk 3 · 920" }]} />);
+    expect(screen.queryByText("Wk 3 · 920")).toBeNull();
+    fireEvent.pointerEnter(bars(container)[1]);
+    expect(screen.getByText("Wk 3 · 920")).toBeInTheDocument(); // rendered into <body>
+    fireEvent.pointerLeave(container.firstElementChild!);
+    expect(screen.queryByText("Wk 3 · 920")).toBeNull();
+  });
+
+  it("swaps `barClassName` for `barActiveClassName` on the hovered bar", () => {
+    const { container } = render(
+      <Sparkline data={[1, 2, 3]} barClassName="bg-rest" barActiveClassName="bg-active" />,
+    );
+    expect(bars(container)[1].className).toContain("bg-rest");
+    fireEvent.pointerEnter(bars(container)[1]);
+    expect(bars(container)[1].className).toContain("bg-active");
+    expect(bars(container)[1].className).not.toContain("bg-rest");
+  });
+});

--- a/src/components/ui/chart/sparkline/Sparkline.tsx
+++ b/src/components/ui/chart/sparkline/Sparkline.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "Sparkline",
+  description:
+    "A tiny bar chart that fills its container — give it a height (a flex parent, `h-full`, etc.) and bars grow from the bottom. Hovering a bar shows its (labelled) value in a chip portaled to the body so it isn't clipped.",
+};
+
+/** A bar: a height as a percentage (0–100), optionally with a `label` for the
+ *  hover chip (defaults to the value). */
+export type SparklinePoint = number | { value: number; label?: string };
+
+const pointValue = (p: SparklinePoint) => (typeof p === "number" ? p : p.value);
+const pointLabel = (p: SparklinePoint) =>
+  typeof p === "number" ? String(p) : (p.label ?? String(p.value));
+const clampPct = (n: number) => Math.max(0, Math.min(100, n));
+
+export interface SparklineProps {
+  /** Bars, as heights `0–100` (or `{ value, label }` for a labelled hover chip). */
+  data: ReadonlyArray<SparklinePoint>;
+  /** Tailwind classes for the bars. Default `"bg-primary/30"`. */
+  barClassName?: string;
+  /** Classes for the bar under the pointer. Defaults to {@link barClassName}. */
+  barActiveClassName?: string;
+  /** Classes for the floating hover chip. Default `"bg-on-surface text-surface"`. */
+  chipClassName?: string;
+  className?: string;
+}
+
+export function Sparkline({
+  data,
+  barClassName = "bg-primary/30",
+  barActiveClassName,
+  chipClassName,
+  className,
+}: SparklineProps) {
+  // The chip is portaled to <body> so a clipping/overflow-hidden ancestor
+  // (e.g. a NotchGrid cell) can't cut it off — it floats above the bar.
+  const [hover, setHover] = useState<{ index: number; rect: DOMRect } | null>(null);
+  if (data.length === 0) return null;
+  const hovered = hover != null ? data[hover.index] : undefined;
+  const chip =
+    hovered !== undefined && typeof document !== "undefined"
+      ? createPortal(
+          <span
+            className={cn(
+              "pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded px-1.5 py-0.5 text-[10px] font-medium shadow-md",
+              chipClassName ?? "bg-on-surface text-surface",
+            )}
+            style={{ left: hover!.rect.left + hover!.rect.width / 2, top: hover!.rect.top - 4 }}
+          >
+            {pointLabel(hovered)}
+          </span>,
+          document.body,
+        )
+      : null;
+
+  return (
+    <div
+      className={cn("flex items-end gap-0.5", className)}
+      aria-hidden="true"
+      onPointerLeave={() => setHover(null)}
+    >
+      {data.map((point, i) => (
+        <div
+          key={i}
+          title={pointLabel(point)}
+          onPointerEnter={(e) =>
+            setHover({ index: i, rect: e.currentTarget.getBoundingClientRect() })
+          }
+          className={cn(
+            "min-h-px flex-1 cursor-default rounded transition-colors",
+            i === hover?.index ? (barActiveClassName ?? barClassName) : barClassName,
+          )}
+          style={{ height: `${clampPct(pointValue(point))}%` }}
+        />
+      ))}
+      {chip}
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,3 +241,8 @@ export {
   AppShell,
   type AppShellProps,
 } from "./components/layout/app-shell/app-shell/AppShell";
+export {
+  Sparkline,
+  type SparklineProps,
+  type SparklinePoint,
+} from "./components/ui/chart/sparkline/Sparkline";


### PR DESCRIPTION
Adds **`Sparkline`** — a tiny bar chart that fills its container; bars grow from the bottom; hovering a bar shows its value (with an optional per-bar label) in a chip portaled to `document.body` so a clipping/`overflow-hidden` ancestor (e.g. a NotchGrid cell) can't cut it off.

- `data`: `ReadonlyArray<number | { value, label }>` (heights 0–100)
- `barClassName` / `barActiveClassName` / `chipClassName` for theming on any surface
- Story `UI/Chart/Sparkline` (Playground, Tones); 5 tests
- Reviewed with `/simplify` (along with the rest of the new chart/metric/notch batch)

First in a stack of chart PRs: `MetricBlock` builds on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)