### PR TITLE
feat(chart): BarChart

### DIFF
--- a/src/components/ui/chart/bar-chart/BarChart.stories.tsx
+++ b/src/components/ui/chart/bar-chart/BarChart.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { BarChart } from "./BarChart";
+
+const seed = (n: number) => {
+  const x = Math.sin(n + 1) * 10_000;
+  return x - Math.floor(x);
+};
+const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+const DATA = months.map((label, i) => ({ label, value: Math.round(80 + seed(i) * 320 + i * 18) }));
+
+const meta: Meta<typeof BarChart> = {
+  title: "UI/Chart/BarChart",
+  component: BarChart,
+  args: { data: DATA, height: 150 },
+  argTypes: {
+    height: { control: { type: "range", min: 80, max: 280, step: 10 } },
+    highlightIndex: { control: { type: "number" } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BarChart>;
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div className="bg-background p-6">
+    <div className="max-w-lg rounded-2xl border border-outline-variant p-4">{children}</div>
+  </div>
+);
+
+/** The last bar is highlighted by default; hover a bar for its label + value chip. */
+export const Playground: Story = {
+  render: (args) => (
+    <Frame>
+      <BarChart {...args} />
+    </Frame>
+  ),
+};
+
+/** `unitPrefix` / `precision` for the Y axis (e.g. dollars), and a chosen
+ *  `highlightIndex`. */
+export const Money: Story = {
+  render: () => (
+    <Frame>
+      <BarChart
+        data={months.map((label, i) => ({ label, value: Math.round((2 + seed(i) * 8 + i) * 100) / 100 }))}
+        unitPrefix="$"
+        precision={2}
+        highlightIndex={9}
+        height={150}
+      />
+    </Frame>
+  ),
+};

--- a/src/components/ui/chart/bar-chart/BarChart.test.tsx
+++ b/src/components/ui/chart/bar-chart/BarChart.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { BarChart } from "./BarChart";
+
+afterEach(cleanup);
+
+const DATA = [
+  { label: "a", value: 10 },
+  { label: "b", value: 30 },
+  { label: "c", value: 20 },
+];
+
+describe("BarChart", () => {
+  it("renders one bar (with a title) per datum", () => {
+    const { container } = render(<BarChart data={DATA} />);
+    const rects = [...container.querySelectorAll("rect")];
+    expect(rects).toHaveLength(3);
+    expect(rects[1].querySelector("title")?.textContent).toBe("b: 30");
+  });
+
+  it("renders the x-axis label for each datum", () => {
+    const { container } = render(<BarChart data={DATA} />);
+    const texts = [...container.querySelectorAll("text")].map((t) => t.textContent);
+    expect(texts).toEqual(expect.arrayContaining(["a", "b", "c"]));
+  });
+
+  it("highlights the last bar by default; `highlightIndex` overrides it; `-1` highlights none", () => {
+    const fills = (data: typeof DATA, hi?: number) => {
+      const { container } = render(<BarChart data={data} highlightIndex={hi} />);
+      // the highlighted bar gets `fill="url(...)"`, others a plain colour
+      return [...container.querySelectorAll("rect")].map((r) => r.getAttribute("fill")?.startsWith("url("));
+    };
+    expect(fills(DATA)).toEqual([false, false, true]); // default = last
+    cleanup();
+    expect(fills(DATA, 0)).toEqual([true, false, false]);
+    cleanup();
+    expect(fills(DATA, -1)).toEqual([false, false, false]);
+  });
+
+  it("prefixes / rounds the Y-axis ticks", () => {
+    const { container } = render(<BarChart data={[{ label: "x", value: 50 }]} unitPrefix="$" precision={2} />);
+    const texts = [...container.querySelectorAll("text")].map((t) => t.textContent);
+    // max = 50 * 1.2 = 60 ⇒ ticks at 0, 30, 60 → "$0.00", "$30.00", "$60.00"
+    expect(texts).toEqual(expect.arrayContaining(["$0.00", "$30.00", "$60.00"]));
+  });
+
+  it("pops a portaled chip on the hovered bar and clears it on leave", () => {
+    const { container } = render(<BarChart data={DATA} unitPrefix="$" />);
+    const rects = [...container.querySelectorAll("rect")];
+    expect(screen.queryByText("b · $30")).toBeNull();
+    fireEvent.pointerEnter(rects[1]);
+    expect(screen.getByText("b · $30")).toBeInTheDocument(); // rendered into <body>
+    fireEvent.pointerLeave(container.querySelector("svg")!);
+    expect(screen.queryByText("b · $30")).toBeNull();
+  });
+
+  it("renders nothing weird for empty data (just the axis)", () => {
+    const { container } = render(<BarChart data={[]} />);
+    expect(container.querySelector("svg")).not.toBeNull();
+    expect(container.querySelectorAll("rect")).toHaveLength(0);
+  });
+});

--- a/src/components/ui/chart/bar-chart/BarChart.tsx
+++ b/src/components/ui/chart/bar-chart/BarChart.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useId, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "BarChart",
+  description:
+    "A responsive vertical bar chart with a Y scale and x-axis labels; one bar (the last by default) is highlighted. Hovering a bar shows its label + value in a chip portaled to the body so it isn't clipped. Fills its container's width.",
+};
+
+const PAD = { top: 8, right: 4, bottom: 20, left: 36 } as const;
+
+export interface BarChartDatum {
+  label: string;
+  value: number;
+}
+
+export interface BarChartProps {
+  data: ReadonlyArray<BarChartDatum>;
+  /** CSS colour for the bars. Default `var(--color-primary)`. */
+  color?: string;
+  /** SVG height in px (width fills the container). Default 120. */
+  height?: number;
+  /** Index of the bar to highlight (full colour + gradient). Default: the last
+   *  bar. Pass `-1` for none. */
+  highlightIndex?: number;
+  /** Prefix on the Y-axis tick labels and the hover chip (e.g. `"$"`). */
+  unitPrefix?: string;
+  /** Decimal places on the Y-axis ticks. Default 0. */
+  precision?: number;
+  /** Classes for the floating hover chip. Default `"bg-on-surface text-surface"`. */
+  chipClassName?: string;
+  className?: string;
+}
+
+export function BarChart({
+  data,
+  color = "var(--color-primary)",
+  height = 120,
+  highlightIndex,
+  unitPrefix = "",
+  precision = 0,
+  chipClassName,
+  className,
+}: BarChartProps) {
+  const reactId = useId();
+  const fillId = `bar-chart-${reactId.replace(/[^a-zA-Z0-9_-]/g, "")}`;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [w, setW] = useState(400);
+  // The chip is portaled to <body> so a clipping/overflow-hidden ancestor can't
+  // cut it off — it floats above the bar.
+  const [hover, setHover] = useState<{ index: number; rect: DOMRect } | null>(null);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    setW(el.getBoundingClientRect().width || 400);
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(([entry]) => {
+      const next = Math.round(entry.contentRect.width);
+      if (next > 0) setW((prev) => (prev === next ? prev : next));
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const max = Math.max(0, ...data.map((d) => d.value)) * 1.2 || 1;
+  const chartW = w - PAD.left - PAD.right;
+  const chartH = height - PAD.top - PAD.bottom;
+  const slot = data.length > 0 ? chartW / data.length : chartW;
+  const barW = Math.max(4, slot * 0.5);
+  const hi = highlightIndex ?? data.length - 1;
+  const yTicks = [0, 0.5, 1].map((t) => ({ v: max * t, y: PAD.top + (1 - t) * chartH }));
+
+  const hovered = hover != null ? data[hover.index] : undefined;
+  const chip =
+    hovered !== undefined && typeof document !== "undefined"
+      ? createPortal(
+          <span
+            className={cn(
+              "pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded px-1.5 py-0.5 text-[10px] font-medium shadow-md",
+              chipClassName ?? "bg-on-surface text-surface",
+            )}
+            style={{ left: hover!.rect.left + hover!.rect.width / 2, top: hover!.rect.top - 4 }}
+          >
+            {hovered.label} · {unitPrefix}
+            {hovered.value}
+          </span>,
+          document.body,
+        )
+      : null;
+
+  return (
+    <div ref={containerRef} className={cn("w-full", className)}>
+      <svg viewBox={`0 0 ${w} ${height}`} width={w} height={height} onPointerLeave={() => setHover(null)}>
+        <defs>
+          <linearGradient id={fillId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity="0.9" />
+            <stop offset="100%" stopColor={color} stopOpacity="0.5" />
+          </linearGradient>
+        </defs>
+        {yTicks.map((t) => (
+          <g key={t.v}>
+            <line x1={PAD.left} y1={t.y} x2={w - PAD.right} y2={t.y} stroke="currentColor" strokeOpacity="0.08" strokeWidth="1" />
+            <text x={PAD.left - 4} y={t.y + 4} textAnchor="end" fontSize="9" fill="currentColor" fillOpacity="0.45">
+              {unitPrefix}
+              {t.v.toFixed(precision)}
+            </text>
+          </g>
+        ))}
+        {data.map((d, i) => {
+          const x = PAD.left + slot * i + slot / 2 - barW / 2;
+          const barH = Math.max(0, (d.value / max) * chartH);
+          const highlighted = i === hi;
+          const onEnter = (e: ReactPointerEvent<SVGRectElement>) =>
+            setHover({ index: i, rect: e.currentTarget.getBoundingClientRect() });
+          return (
+            <g key={`${d.label}-${i}`}>
+              <rect
+                x={x}
+                y={PAD.top + chartH - barH}
+                width={barW}
+                height={barH}
+                rx={Math.min(6, barW * 0.35)}
+                className="cursor-default"
+                fill={highlighted ? `url(#${fillId})` : color}
+                fillOpacity={highlighted ? 1 : hover?.index === i ? 0.6 : 0.35}
+                onPointerEnter={onEnter}
+              >
+                <title>{`${d.label}: ${unitPrefix}${d.value}`}</title>
+              </rect>
+              <text x={x + barW / 2} y={height - 4} textAnchor="middle" fontSize="9" fill="currentColor" fillOpacity="0.45">
+                {d.label}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+      {chip}
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -251,3 +251,8 @@ export {
   type LineChartProps,
   type LineChartOverlay,
 } from "./components/ui/chart/line-chart/LineChart";
+export {
+  BarChart,
+  type BarChartProps,
+  type BarChartDatum,
+} from "./components/ui/chart/bar-chart/BarChart";


### PR DESCRIPTION
Adds **`BarChart`** — a responsive vertical bar chart that fills its container's width:

- Y scale (3 ticks, `unitPrefix` / `precision`) + per-bar x-axis labels
- one bar highlighted (the last by default, or `highlightIndex`; `-1` for none)
- hover a bar → `label · value` chip portaled to `document.body`; bars also carry a native `<title>`
- rounded bar corners (`rx` scales with bar width)
- `color` defaults to `var(--color-primary)`; `chipClassName` for theming
- Story `UI/Chart/BarChart` (Playground, Money); 6 tests
- Reviewed with `/simplify`

Part of the chart-component stack; re-targets to `main` as the earlier ones merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)