### PR TITLE
feat(chart): DonutChart

### DIFF
--- a/src/components/ui/chart/donut-chart/DonutChart.stories.tsx
+++ b/src/components/ui/chart/donut-chart/DonutChart.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { DonutChart } from "./DonutChart";
+
+const TRAFFIC = [
+  { label: "Direct", value: 3800 },
+  { label: "Search", value: 3000 },
+  { label: "Social", value: 2300 },
+  { label: "Referral", value: 1700 },
+  { label: "Email", value: 1300 },
+];
+const total = TRAFFIC.reduce((s, d) => s + d.value, 0);
+
+const meta: Meta<typeof DonutChart> = {
+  title: "UI/Chart/DonutChart",
+  component: DonutChart,
+  args: { data: TRAFFIC, size: 200, legend: true },
+  argTypes: { size: { control: { type: "range", min: 120, max: 320, step: 10 } } },
+};
+
+export default meta;
+type Story = StoryObj<typeof DonutChart>;
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div className="bg-background p-6">
+    <div className="inline-block rounded-2xl border border-outline-variant p-5">{children}</div>
+  </div>
+);
+
+/** A ring with a centre total + a legend; hover a segment (or its legend row)
+ *  for a chip. */
+export const Playground: Story = {
+  render: (args) => (
+    <Frame>
+      <DonutChart {...args} centerLabel={total.toLocaleString()} centerSub="sessions" />
+    </Frame>
+  ),
+};
+
+/** `legend={false}` drops the list — just the ring (and centre text). */
+export const Standalone: Story = {
+  render: () => (
+    <Frame>
+      <DonutChart data={TRAFFIC} size={160} legend={false} centerLabel={`${(total / 1000).toFixed(1)}k`} centerSub="sessions" />
+    </Frame>
+  ),
+};
+
+/** Per-datum `color` + a `formatValue` (here, currency). */
+export const CustomColours: Story = {
+  render: () => (
+    <Frame>
+      <DonutChart
+        size={200}
+        centerLabel="$9.7k"
+        centerSub="MRR"
+        formatValue={(v) => `$${(v / 1000).toFixed(1)}k`}
+        data={[
+          { label: "Pro", value: 4500, color: "var(--color-primary)" },
+          { label: "Team", value: 2900, color: "var(--color-tertiary)" },
+          { label: "Free → paid", value: 1300, color: "var(--color-success)" },
+          { label: "Add-ons", value: 1000, color: "var(--color-warning)" },
+        ]}
+      />
+    </Frame>
+  ),
+};

--- a/src/components/ui/chart/donut-chart/DonutChart.test.tsx
+++ b/src/components/ui/chart/donut-chart/DonutChart.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { DonutChart } from "./DonutChart";
+
+afterEach(cleanup);
+
+const DATA = [
+  { label: "A", value: 50 },
+  { label: "B", value: 30 },
+  { label: "C", value: 20 },
+];
+
+const segPaths = (el: HTMLElement) => [...el.querySelectorAll("path")];
+
+describe("DonutChart", () => {
+  it("renders a track circle plus one segment path per datum", () => {
+    const { container } = render(<DonutChart data={DATA} legend={false} />);
+    expect(container.querySelectorAll("circle")).toHaveLength(1); // the faint track
+    expect(segPaths(container)).toHaveLength(3);
+  });
+
+  it("draws each segment as a non-empty arc path", () => {
+    const { container } = render(<DonutChart data={DATA} legend={false} />);
+    for (const p of segPaths(container)) {
+      const d = p.getAttribute("d") ?? "";
+      expect(d.startsWith("M")).toBe(true);
+      expect(d).toContain("A");
+    }
+  });
+
+  it("keeps a path slot for a zero-value datum without crashing", () => {
+    const { container } = render(<DonutChart data={[{ label: "z", value: 0 }, { label: "y", value: 5 }]} legend={false} />);
+    const paths = segPaths(container);
+    expect(paths).toHaveLength(2);
+    expect(paths[1].getAttribute("d")).toContain("A"); // "y" still drawn
+  });
+
+  it("renders the centre label + sub", () => {
+    render(<DonutChart data={DATA} centerLabel="100" centerSub="total" legend={false} />);
+    expect(screen.getByText("100")).toBeInTheDocument();
+    expect(screen.getByText("total")).toBeInTheDocument();
+  });
+
+  it("renders a legend row (label / value / %) per datum, formatting the value", () => {
+    render(<DonutChart data={DATA} formatValue={(v) => `${v}u`} />);
+    expect(screen.getByText("A")).toBeInTheDocument();
+    expect(screen.getByText("50u")).toBeInTheDocument();
+    expect(screen.getByText("50%")).toBeInTheDocument(); // A = 50/100
+    expect(screen.getByText("20%")).toBeInTheDocument();
+  });
+
+  it("pops a portaled hover chip on a segment and clears it on leave", () => {
+    const { container } = render(<DonutChart data={DATA} legend={false} />);
+    expect(screen.queryByText(/^A · /)).toBeNull();
+    fireEvent.pointerEnter(segPaths(container)[0], { clientX: 10, clientY: 10 });
+    expect(screen.getByText("A · 50 · 50%")).toBeInTheDocument(); // rendered into <body>
+    fireEvent.pointerLeave(container.querySelector("svg")!);
+    expect(screen.queryByText(/^A · /)).toBeNull();
+  });
+
+  it("renders just the track circle for empty data", () => {
+    const { container } = render(<DonutChart data={[]} legend={false} />);
+    expect(container.querySelectorAll("circle")).toHaveLength(1);
+    expect(segPaths(container)).toHaveLength(0);
+  });
+});

--- a/src/components/ui/chart/donut-chart/DonutChart.tsx
+++ b/src/components/ui/chart/donut-chart/DonutChart.tsx
@@ -1,0 +1,158 @@
+import { useMemo, useState, type PointerEvent as ReactPointerEvent, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/utils/cn";
+import { paletteColor, roundedDonutSegmentPath } from "@/utils/chart-arc";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "DonutChart",
+  description:
+    "A ring / pie chart — segments sized by value with rounded ends and a small gap between them, an optional centre label, an optional legend, and a hover chip that follows the cursor. Segment colours come from a theme palette unless given per datum.",
+};
+
+export interface DonutChartDatum {
+  label: string;
+  value: number;
+  /** CSS colour for the segment. Defaults to a cycling theme-palette colour. */
+  color?: string;
+}
+
+export interface DonutChartProps {
+  data: ReadonlyArray<DonutChartDatum>;
+  /** Diameter in px. Default 180. */
+  size?: number;
+  /** Ring thickness in px. Default `size * 0.18` (clamped to always leave a hole). */
+  thickness?: number;
+  /** Large text shown in the centre (e.g. the total). */
+  centerLabel?: ReactNode;
+  /** Small text under {@link centerLabel}. */
+  centerSub?: ReactNode;
+  /** Show a colour / label / value / % legend beside the ring. Default true. */
+  legend?: boolean;
+  /** Format a value for the legend + hover chip. Default `value.toLocaleString()`. */
+  formatValue?: (value: number, datum: DonutChartDatum) => ReactNode;
+  /** Classes for the floating hover chip. Default `"bg-on-surface text-surface"`. */
+  chipClassName?: string;
+  className?: string;
+}
+
+const pct = (n: number) => `${n.toFixed(n > 0 && n < 10 ? 1 : 0)}%`;
+
+export function DonutChart({
+  data,
+  size = 180,
+  thickness,
+  centerLabel,
+  centerSub,
+  legend = true,
+  formatValue,
+  chipClassName,
+  className,
+}: DonutChartProps) {
+  // The chip is portaled to <body> so a clipping ancestor can't cut it off; it
+  // tracks the cursor since a segment's bounding box overstates its extent.
+  const [hover, setHover] = useState<{ index: number; x: number; y: number } | null>(null);
+  const fmt = (v: number, d: DonutChartDatum): ReactNode => (formatValue ? formatValue(v, d) : v.toLocaleString());
+
+  const { segments, c, rInner, rOuter, ring } = useMemo(() => {
+    const c = size / 2;
+    const rOuter = c;
+    const ring = Math.min(thickness ?? size * 0.18, rOuter * 0.9); // always leave a hole
+    const rInner = rOuter - ring;
+    const cornerR = ring * 0.22; // softening of the segment corners
+    const total = data.reduce((s, d) => s + Math.max(0, d.value), 0) || 1;
+    const gapDeg = data.length > 1 ? 3 : 0;
+    let acc = 0; // running fraction of the total
+    const segments = data.map((d, i) => {
+      const frac = Math.max(0, d.value) / total;
+      const start = acc * 360 + gapDeg / 2;
+      const end = (acc + frac) * 360 - gapDeg / 2;
+      acc += frac;
+      return {
+        d,
+        i,
+        color: d.color ?? paletteColor(i),
+        pct: frac * 100,
+        path: roundedDonutSegmentPath(c, c, rInner, rOuter, start, end, cornerR),
+      };
+    });
+    return { segments, c, rInner, rOuter, ring };
+  }, [data, size, thickness]);
+
+  const hovered = hover != null ? segments[hover.index] : undefined;
+  const chip =
+    hovered !== undefined && typeof document !== "undefined"
+      ? createPortal(
+          <span
+            className={cn(
+              "pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded px-1.5 py-0.5 text-[10px] font-medium shadow-md",
+              chipClassName ?? "bg-on-surface text-surface",
+            )}
+            style={{ left: hover!.x || 0, top: (hover!.y || 0) - 10 }}
+          >
+            {hovered.d.label} · {fmt(hovered.d.value, hovered.d)} · {pct(hovered.pct)}
+          </span>,
+          document.body,
+        )
+      : null;
+
+  const track = (i: number) => (e: ReactPointerEvent) => setHover({ index: i, x: e.clientX, y: e.clientY });
+
+  const ringEl = (
+    <div className="relative shrink-0" style={{ width: size, height: size }}>
+      <svg viewBox={`0 0 ${size} ${size}`} width={size} height={size} onPointerLeave={() => setHover(null)}>
+        <circle cx={c} cy={c} r={(rInner + rOuter) / 2} fill="none" stroke="currentColor" strokeOpacity="0.08" strokeWidth={ring} />
+        {segments.map((s) => (
+          <path
+            key={s.i}
+            d={s.path}
+            fill={s.color}
+            fillOpacity={hover != null && hover.index !== s.i ? 0.4 : 1}
+            className="cursor-default transition-[fill-opacity]"
+            onPointerEnter={track(s.i)}
+            onPointerMove={track(s.i)}
+          >
+            <title>{`${s.d.label}: ${s.d.value}`}</title>
+          </path>
+        ))}
+      </svg>
+      {(centerLabel != null || centerSub != null) && (
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center text-center leading-tight">
+          {centerLabel != null && <span className="text-lg font-semibold text-on-surface">{centerLabel}</span>}
+          {centerSub != null && <span className="text-[11px] text-on-surface-variant">{centerSub}</span>}
+        </div>
+      )}
+    </div>
+  );
+
+  if (!legend)
+    return (
+      <div className={cn("inline-flex", className)}>
+        {ringEl}
+        {chip}
+      </div>
+    );
+
+  return (
+    <div className={cn("flex items-center gap-4", className)}>
+      {ringEl}
+      <ul className="flex min-w-0 flex-col gap-1.5 text-xs">
+        {segments.map((s) => (
+          <li
+            key={s.i}
+            className="flex items-center gap-2"
+            onPointerEnter={(e) => setHover({ index: s.i, x: e.clientX, y: e.clientY })}
+            onPointerMove={(e) => setHover({ index: s.i, x: e.clientX, y: e.clientY })}
+            onPointerLeave={() => setHover(null)}
+          >
+            <span className="size-2.5 shrink-0 rounded-sm" style={{ backgroundColor: s.color }} />
+            <span className="min-w-0 flex-1 truncate text-on-surface-variant">{s.d.label}</span>
+            <span className="shrink-0 font-medium tabular-nums text-on-surface">{fmt(s.d.value, s.d)}</span>
+            <span className="shrink-0 tabular-nums text-on-surface-variant/70">{pct(s.pct)}</span>
+          </li>
+        ))}
+      </ul>
+      {chip}
+    </div>
+  );
+}

--- a/src/components/ui/chart/nightingale-chart/NightingaleChart.stories.tsx
+++ b/src/components/ui/chart/nightingale-chart/NightingaleChart.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { NightingaleChart } from "./NightingaleChart";
+
+const WEEKDAYS = [
+  { label: "Mon", value: 320 },
+  { label: "Tue", value: 410 },
+  { label: "Wed", value: 480 },
+  { label: "Thu", value: 390 },
+  { label: "Fri", value: 520 },
+  { label: "Sat", value: 180 },
+  { label: "Sun", value: 140 },
+];
+
+const meta: Meta<typeof NightingaleChart> = {
+  title: "UI/Chart/NightingaleChart",
+  component: NightingaleChart,
+  args: { data: WEEKDAYS, size: 220, scale: "area", legend: true },
+  argTypes: {
+    size: { control: { type: "range", min: 140, max: 320, step: 10 } },
+    scale: { control: { type: "inline-radio" }, options: ["area", "radius"] },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof NightingaleChart>;
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div className="bg-background p-6">
+    <div className="inline-block rounded-2xl border border-outline-variant p-5">{children}</div>
+  </div>
+);
+
+/** Equal-angle sectors, radius ∝ √value (so area tracks the value). Hover a
+ *  sector for a chip. */
+export const Playground: Story = {
+  render: (args) => (
+    <Frame>
+      <NightingaleChart {...args} />
+    </Frame>
+  ),
+};
+
+/** `scale="radius"` makes the radius linear in the value — differences read
+ *  bigger. */
+export const RadiusScale: Story = {
+  render: () => (
+    <Frame>
+      <NightingaleChart data={WEEKDAYS} size={220} scale="radius" />
+    </Frame>
+  ),
+};
+
+/** `legend={false}` with custom per-datum colours. */
+export const Bare: Story = {
+  render: () => (
+    <Frame>
+      <NightingaleChart
+        size={200}
+        legend={false}
+        data={[
+          { label: "Compute", value: 62, color: "var(--color-primary)" },
+          { label: "Storage", value: 28, color: "var(--color-tertiary)" },
+          { label: "Egress", value: 41, color: "var(--color-secondary)" },
+          { label: "DB", value: 19, color: "var(--color-success)" },
+          { label: "Other", value: 8, color: "var(--color-warning)" },
+        ]}
+      />
+    </Frame>
+  ),
+};

--- a/src/components/ui/chart/nightingale-chart/NightingaleChart.test.tsx
+++ b/src/components/ui/chart/nightingale-chart/NightingaleChart.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { NightingaleChart } from "./NightingaleChart";
+
+afterEach(cleanup);
+
+const DATA = [
+  { label: "Mon", value: 4 },
+  { label: "Tue", value: 9 },
+  { label: "Wed", value: 1 },
+];
+
+describe("NightingaleChart", () => {
+  it("renders one sector path per datum", () => {
+    const { container } = render(<NightingaleChart data={DATA} legend={false} />);
+    expect(container.querySelectorAll("path")).toHaveLength(3);
+  });
+
+  it("produces different geometry for the area vs radius scales", () => {
+    const firstPath = (scale: "area" | "radius") => {
+      const { container } = render(<NightingaleChart data={DATA} scale={scale} legend={false} />);
+      return [...container.querySelectorAll("path")][0].getAttribute("d");
+    };
+    const area = firstPath("area");
+    cleanup();
+    const radius = firstPath("radius");
+    expect(area).toBeTruthy();
+    expect(area).not.toBe(radius);
+  });
+
+  it("draws a full disc (no line-to) for a single datum", () => {
+    const { container } = render(<NightingaleChart data={[{ label: "All", value: 7 }]} legend={false} />);
+    const paths = [...container.querySelectorAll("path")];
+    expect(paths).toHaveLength(1);
+    expect(paths[0].getAttribute("d")).not.toContain("L"); // a sector wedge would have a "L"
+  });
+
+  it("renders a legend row per datum with the formatted value", () => {
+    render(<NightingaleChart data={DATA} formatValue={(v) => `${v}h`} />);
+    expect(screen.getByText("Tue")).toBeInTheDocument();
+    expect(screen.getByText("9h")).toBeInTheDocument();
+  });
+
+  it("pops a portaled hover chip on a sector and clears it on leave", () => {
+    const { container } = render(<NightingaleChart data={DATA} legend={false} />);
+    const sector = [...container.querySelectorAll("path")][1]; // "Tue"
+    expect(screen.queryByText("Tue · 9")).toBeNull();
+    fireEvent.pointerEnter(sector, { clientX: 5, clientY: 5 });
+    expect(screen.getByText("Tue · 9")).toBeInTheDocument();
+    fireEvent.pointerLeave(container.querySelector("svg")!);
+    expect(screen.queryByText("Tue · 9")).toBeNull();
+  });
+
+  it("renders no sectors for empty data", () => {
+    const { container } = render(<NightingaleChart data={[]} legend={false} />);
+    expect(container.querySelectorAll("path")).toHaveLength(0);
+  });
+});

--- a/src/components/ui/chart/nightingale-chart/NightingaleChart.tsx
+++ b/src/components/ui/chart/nightingale-chart/NightingaleChart.tsx
@@ -1,0 +1,139 @@
+import { useMemo, useState, type PointerEvent as ReactPointerEvent, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/utils/cn";
+import { paletteColor, roundedDonutSegmentPath, wedgePath } from "@/utils/chart-arc";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "NightingaleChart",
+  description:
+    "A Nightingale rose (polar-area / coxcomb) chart — equal-angle rounded sectors, around a small centre hole, whose radius encodes the value (by sector area, the default, or linearly). An optional legend and a hover chip that follows the cursor. Colours come from a theme palette unless given per datum.",
+};
+
+export interface NightingaleChartDatum {
+  label: string;
+  value: number;
+  /** CSS colour for the sector. Defaults to a cycling theme-palette colour. */
+  color?: string;
+}
+
+export interface NightingaleChartProps {
+  data: ReadonlyArray<NightingaleChartDatum>;
+  /** Width / height in px. Default 200. */
+  size?: number;
+  /** `"area"` (default) — radius ∝ √value, so a sector's *area* tracks the value.
+   *  `"radius"` — radius ∝ value (exaggerates differences). */
+  scale?: "area" | "radius";
+  /** Show a colour / label / value legend beside the chart. Default true. */
+  legend?: boolean;
+  /** Format a value for the legend + hover chip. Default `value.toLocaleString()`. */
+  formatValue?: (value: number, datum: NightingaleChartDatum) => ReactNode;
+  /** Classes for the floating hover chip. Default `"bg-on-surface text-surface"`. */
+  chipClassName?: string;
+  className?: string;
+}
+
+export function NightingaleChart({
+  data,
+  size = 200,
+  scale = "area",
+  legend = true,
+  formatValue,
+  chipClassName,
+  className,
+}: NightingaleChartProps) {
+  // The chip is portaled to <body> so a clipping ancestor can't cut it off; it
+  // tracks the cursor since a sector's bounding box overstates its extent.
+  const [hover, setHover] = useState<{ index: number; x: number; y: number } | null>(null);
+  const fmt = (v: number, d: NightingaleChartDatum): ReactNode => (formatValue ? formatValue(v, d) : v.toLocaleString());
+
+  const sectors = useMemo(() => {
+    const c = size / 2;
+    const rMax = c - 2;
+    const rInner = rMax * 0.14; // a small centre hole
+    const single = data.length === 1;
+    const sliceDeg = data.length > 0 ? 360 / data.length : 360;
+    const maxV = Math.max(0, ...data.map((d) => d.value)) || 1;
+    // An angular gap between sectors, matching the kit's spacing aesthetic.
+    const padDeg = data.length > 1 ? 4 : 0;
+    return data.map((d, i) => {
+      const frac = Math.max(0, d.value) / maxV;
+      const rOuter = rInner + (rMax - rInner) * (scale === "radius" ? frac : Math.sqrt(frac));
+      return {
+        d,
+        i,
+        color: d.color ?? paletteColor(i),
+        path: single
+          ? wedgePath(c, c, rOuter, 0, 360)
+          : roundedDonutSegmentPath(c, c, rInner, rOuter, i * sliceDeg + padDeg / 2, (i + 1) * sliceDeg - padDeg / 2, rOuter * 0.09),
+      };
+    });
+  }, [data, size, scale]);
+
+  const hovered = hover != null ? sectors[hover.index] : undefined;
+  const chip =
+    hovered !== undefined && typeof document !== "undefined"
+      ? createPortal(
+          <span
+            className={cn(
+              "pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded px-1.5 py-0.5 text-[10px] font-medium shadow-md",
+              chipClassName ?? "bg-on-surface text-surface",
+            )}
+            style={{ left: hover!.x || 0, top: (hover!.y || 0) - 10 }}
+          >
+            {hovered.d.label} · {fmt(hovered.d.value, hovered.d)}
+          </span>,
+          document.body,
+        )
+      : null;
+
+  const track = (i: number) => (e: ReactPointerEvent) => setHover({ index: i, x: e.clientX, y: e.clientY });
+
+  const chartEl = (
+    <svg viewBox={`0 0 ${size} ${size}`} width={size} height={size} onPointerLeave={() => setHover(null)} className="shrink-0">
+      {sectors.map((s) => (
+        <path
+          key={s.i}
+          d={s.path}
+          fill={s.color}
+          fillOpacity={hover != null && hover.index !== s.i ? 0.4 : 1}
+          className="cursor-default transition-[fill-opacity]"
+          onPointerEnter={track(s.i)}
+          onPointerMove={track(s.i)}
+        >
+          <title>{`${s.d.label}: ${s.d.value}`}</title>
+        </path>
+      ))}
+    </svg>
+  );
+
+  if (!legend)
+    return (
+      <div className={cn("inline-flex", className)}>
+        {chartEl}
+        {chip}
+      </div>
+    );
+
+  return (
+    <div className={cn("flex items-center gap-4", className)}>
+      {chartEl}
+      <ul className="flex min-w-0 flex-col gap-1.5 text-xs">
+        {sectors.map((s) => (
+          <li
+            key={s.i}
+            className="flex items-center gap-2"
+            onPointerEnter={(e) => setHover({ index: s.i, x: e.clientX, y: e.clientY })}
+            onPointerMove={(e) => setHover({ index: s.i, x: e.clientX, y: e.clientY })}
+            onPointerLeave={() => setHover(null)}
+          >
+            <span className="size-2.5 shrink-0 rounded-sm" style={{ backgroundColor: s.color }} />
+            <span className="min-w-0 flex-1 truncate text-on-surface-variant">{s.d.label}</span>
+            <span className="shrink-0 font-medium tabular-nums text-on-surface">{fmt(s.d.value, s.d)}</span>
+          </li>
+        ))}
+      </ul>
+      {chip}
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -256,3 +256,9 @@ export {
   type BarChartProps,
   type BarChartDatum,
 } from "./components/ui/chart/bar-chart/BarChart";
+export {
+  DonutChart,
+  type DonutChartProps,
+  type DonutChartDatum,
+} from "./components/ui/chart/donut-chart/DonutChart";
+export { CHART_PALETTE, paletteColor } from "./utils/chart-arc";

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,3 +262,8 @@ export {
   type DonutChartDatum,
 } from "./components/ui/chart/donut-chart/DonutChart";
 export { CHART_PALETTE, paletteColor } from "./utils/chart-arc";
+export {
+  NightingaleChart,
+  type NightingaleChartProps,
+  type NightingaleChartDatum,
+} from "./components/ui/chart/nightingale-chart/NightingaleChart";

--- a/src/utils/chart-arc.ts
+++ b/src/utils/chart-arc.ts
@@ -1,0 +1,94 @@
+/** A categorical palette of theme colour tokens for multi-series charts;
+ *  {@link paletteColor} cycles through it for longer series. */
+export const CHART_PALETTE = [
+  "var(--color-primary)",
+  "var(--color-tertiary)",
+  "var(--color-secondary)",
+  "var(--color-success)",
+  "var(--color-warning)",
+  "var(--color-info)",
+  "var(--color-error)",
+] as const;
+
+/** A palette colour for series index `i` (wraps for `i >= CHART_PALETTE.length`). */
+export const paletteColor = (i: number) =>
+  CHART_PALETTE[((i % CHART_PALETTE.length) + CHART_PALETTE.length) % CHART_PALETTE.length];
+
+/** A point on a circle. Angle in degrees, `0°` = 12 o'clock, increasing clockwise. */
+export function polarPoint(cx: number, cy: number, r: number, angleDeg: number): readonly [number, number] {
+  const a = ((angleDeg - 90) * Math.PI) / 180;
+  return [cx + r * Math.cos(a), cy + r * Math.sin(a)];
+}
+
+/** SVG path for a pie wedge from `startDeg` to `endDeg` (clockwise) centred at
+ *  `(cx, cy)`. A sweep of ≥ 360° draws a full disc. */
+export function wedgePath(cx: number, cy: number, r: number, startDeg: number, endDeg: number): string {
+  const sweep = endDeg - startDeg;
+  if (sweep <= 0 || r <= 0) return "";
+  const f = (n: number) => n.toFixed(2);
+  if (sweep >= 360) {
+    const [tx, ty] = polarPoint(cx, cy, r, 0);
+    const [bx, by] = polarPoint(cx, cy, r, 180);
+    return `M${f(tx)},${f(ty)} A${f(r)},${f(r)} 0 1 1 ${f(bx)},${f(by)} A${f(r)},${f(r)} 0 1 1 ${f(tx)},${f(ty)} Z`;
+  }
+  const [x1, y1] = polarPoint(cx, cy, r, startDeg);
+  const [x2, y2] = polarPoint(cx, cy, r, endDeg);
+  return `M${f(cx)},${f(cy)} L${f(x1)},${f(y1)} A${f(r)},${f(r)} 0 ${sweep > 180 ? 1 : 0} 1 ${f(x2)},${f(y2)} Z`;
+}
+
+/** SVG path for a donut segment — an annular sector from `startDeg` to `endDeg`
+ *  (clockwise) between radii `rInner` and `rOuter` — with all four corners
+ *  rounded by up to `cornerR` px (clamped so they never self-intersect, so a
+ *  short segment degrades to a stubby pill rather than a blob). */
+export function roundedDonutSegmentPath(
+  cx: number,
+  cy: number,
+  rInner: number,
+  rOuter: number,
+  startDeg: number,
+  endDeg: number,
+  cornerR: number,
+): string {
+  if (endDeg - startDeg <= 0 || rOuter <= 0 || rInner < 0 || rOuter <= rInner) return "";
+  const toRad = (d: number) => ((d - 90) * Math.PI) / 180;
+  const t0 = toRad(startDeg);
+  const t1 = toRad(endDeg);
+  const dt = t1 - t0;
+  const f = (n: number) => n.toFixed(2);
+  const P = (radius: number, t: number) => `${f(cx + radius * Math.cos(t))},${f(cy + radius * Math.sin(t))}`;
+
+  // Largest corner that fits: ≤ half the ring, and small enough that the two
+  // corners on the (shorter) inner arc don't overlap.
+  const halfSin = Math.sin(dt / 2);
+  const innerLimit = halfSin >= 1 || rInner === 0 ? Number.POSITIVE_INFINITY : (rInner * halfSin) / (1 - halfSin);
+  const rc = Math.max(0, Math.min(cornerR, (rOuter - rInner) / 2, innerLimit));
+
+  if (rc < 0.5) {
+    const large = dt > Math.PI ? 1 : 0;
+    return `M${P(rOuter, t0)} A${f(rOuter)},${f(rOuter)} 0 ${large} 1 ${P(rOuter, t1)} L${P(rInner, t1)} A${f(rInner)},${f(rInner)} 0 ${large} 0 ${P(rInner, t0)} Z`;
+  }
+
+  const phiO = Math.asin(rc / (rOuter - rc));
+  const phiI = Math.asin(rc / (rInner + rc));
+  const aO0 = t0 + phiO;
+  const aO1 = t1 - phiO;
+  const aI0 = t0 + phiI;
+  const aI1 = t1 - phiI;
+  const dO = (rOuter - rc) * Math.cos(phiO); // radius of the tangent point on a radial edge (outer side)
+  const dI = (rInner + rc) * Math.cos(phiI); // ...and the inner side
+  const largeO = aO1 - aO0 > Math.PI ? 1 : 0;
+  const largeI = aI1 - aI0 > Math.PI ? 1 : 0;
+
+  return [
+    `M${P(rOuter, aO0)}`,
+    `A${f(rOuter)},${f(rOuter)} 0 ${largeO} 1 ${P(rOuter, aO1)}`, // outer arc
+    `A${f(rc)},${f(rc)} 0 0 1 ${P(dO, t1)}`, // outer corner at the end
+    `L${P(dI, t1)}`, // down the end radial edge
+    `A${f(rc)},${f(rc)} 0 0 1 ${P(rInner, aI1)}`, // inner corner at the end
+    `A${f(rInner)},${f(rInner)} 0 ${largeI} 0 ${P(rInner, aI0)}`, // inner arc (back toward the start)
+    `A${f(rc)},${f(rc)} 0 0 1 ${P(dI, t0)}`, // inner corner at the start
+    `L${P(dO, t0)}`, // up the start radial edge
+    `A${f(rc)},${f(rc)} 0 0 1 ${P(rOuter, aO0)}`, // outer corner at the start
+    "Z",
+  ].join(" ");
+}


### PR DESCRIPTION
Adds **`DonutChart`** — a ring chart:

- segments sized by value, drawn as **rounded-corner annular sectors** with a small gap between them (the corner radius auto-clamps so a short slice degrades to a stubby slice, never a blob); zero-value data handled
- optional centre `centerLabel` / `centerSub`; optional `legend` (swatch / label / value / %)
- hover a segment (or its legend row) → `label · value · %` chip portaled to `document.body`
- segment colours from a cycling theme palette (`paletteColor`) unless given per datum; `thickness`, `formatValue`, `chipClassName` knobs
- introduces **`src/utils/chart-arc.ts`** — `CHART_PALETTE`, `paletteColor`, `polarPoint`, `wedgePath`, `roundedDonutSegmentPath` (also used by the Nightingale PR that stacks on this)
- Story `UI/Chart/DonutChart` (Playground, Standalone, CustomColours); 7 tests
- Reviewed with `/simplify`

🤖 Generated with [Claude Code](https://claude.com/claude-code)