### PR TITLE
feat(chart): NightingaleChart

### DIFF
--- a/src/components/ui/chart/nightingale-chart/NightingaleChart.stories.tsx
+++ b/src/components/ui/chart/nightingale-chart/NightingaleChart.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { NightingaleChart } from "./NightingaleChart";
+
+const WEEKDAYS = [
+  { label: "Mon", value: 320 },
+  { label: "Tue", value: 410 },
+  { label: "Wed", value: 480 },
+  { label: "Thu", value: 390 },
+  { label: "Fri", value: 520 },
+  { label: "Sat", value: 180 },
+  { label: "Sun", value: 140 },
+];
+
+const meta: Meta<typeof NightingaleChart> = {
+  title: "UI/Chart/NightingaleChart",
+  component: NightingaleChart,
+  args: { data: WEEKDAYS, size: 220, scale: "area", legend: true },
+  argTypes: {
+    size: { control: { type: "range", min: 140, max: 320, step: 10 } },
+    scale: { control: { type: "inline-radio" }, options: ["area", "radius"] },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof NightingaleChart>;
+
+const Frame = ({ children }: { children: React.ReactNode }) => (
+  <div className="bg-background p-6">
+    <div className="inline-block rounded-2xl border border-outline-variant p-5">{children}</div>
+  </div>
+);
+
+/** Equal-angle sectors, radius ∝ √value (so area tracks the value). Hover a
+ *  sector for a chip. */
+export const Playground: Story = {
+  render: (args) => (
+    <Frame>
+      <NightingaleChart {...args} />
+    </Frame>
+  ),
+};
+
+/** `scale="radius"` makes the radius linear in the value — differences read
+ *  bigger. */
+export const RadiusScale: Story = {
+  render: () => (
+    <Frame>
+      <NightingaleChart data={WEEKDAYS} size={220} scale="radius" />
+    </Frame>
+  ),
+};
+
+/** `legend={false}` with custom per-datum colours. */
+export const Bare: Story = {
+  render: () => (
+    <Frame>
+      <NightingaleChart
+        size={200}
+        legend={false}
+        data={[
+          { label: "Compute", value: 62, color: "var(--color-primary)" },
+          { label: "Storage", value: 28, color: "var(--color-tertiary)" },
+          { label: "Egress", value: 41, color: "var(--color-secondary)" },
+          { label: "DB", value: 19, color: "var(--color-success)" },
+          { label: "Other", value: 8, color: "var(--color-warning)" },
+        ]}
+      />
+    </Frame>
+  ),
+};

--- a/src/components/ui/chart/nightingale-chart/NightingaleChart.test.tsx
+++ b/src/components/ui/chart/nightingale-chart/NightingaleChart.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { NightingaleChart } from "./NightingaleChart";
+
+afterEach(cleanup);
+
+const DATA = [
+  { label: "Mon", value: 4 },
+  { label: "Tue", value: 9 },
+  { label: "Wed", value: 1 },
+];
+
+describe("NightingaleChart", () => {
+  it("renders one sector path per datum", () => {
+    const { container } = render(<NightingaleChart data={DATA} legend={false} />);
+    expect(container.querySelectorAll("path")).toHaveLength(3);
+  });
+
+  it("produces different geometry for the area vs radius scales", () => {
+    const firstPath = (scale: "area" | "radius") => {
+      const { container } = render(<NightingaleChart data={DATA} scale={scale} legend={false} />);
+      return [...container.querySelectorAll("path")][0].getAttribute("d");
+    };
+    const area = firstPath("area");
+    cleanup();
+    const radius = firstPath("radius");
+    expect(area).toBeTruthy();
+    expect(area).not.toBe(radius);
+  });
+
+  it("draws a full disc (no line-to) for a single datum", () => {
+    const { container } = render(<NightingaleChart data={[{ label: "All", value: 7 }]} legend={false} />);
+    const paths = [...container.querySelectorAll("path")];
+    expect(paths).toHaveLength(1);
+    expect(paths[0].getAttribute("d")).not.toContain("L"); // a sector wedge would have a "L"
+  });
+
+  it("renders a legend row per datum with the formatted value", () => {
+    render(<NightingaleChart data={DATA} formatValue={(v) => `${v}h`} />);
+    expect(screen.getByText("Tue")).toBeInTheDocument();
+    expect(screen.getByText("9h")).toBeInTheDocument();
+  });
+
+  it("pops a portaled hover chip on a sector and clears it on leave", () => {
+    const { container } = render(<NightingaleChart data={DATA} legend={false} />);
+    const sector = [...container.querySelectorAll("path")][1]; // "Tue"
+    expect(screen.queryByText("Tue · 9")).toBeNull();
+    fireEvent.pointerEnter(sector, { clientX: 5, clientY: 5 });
+    expect(screen.getByText("Tue · 9")).toBeInTheDocument();
+    fireEvent.pointerLeave(container.querySelector("svg")!);
+    expect(screen.queryByText("Tue · 9")).toBeNull();
+  });
+
+  it("renders no sectors for empty data", () => {
+    const { container } = render(<NightingaleChart data={[]} legend={false} />);
+    expect(container.querySelectorAll("path")).toHaveLength(0);
+  });
+});

--- a/src/components/ui/chart/nightingale-chart/NightingaleChart.tsx
+++ b/src/components/ui/chart/nightingale-chart/NightingaleChart.tsx
@@ -1,0 +1,139 @@
+import { useMemo, useState, type PointerEvent as ReactPointerEvent, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/utils/cn";
+import { paletteColor, roundedDonutSegmentPath, wedgePath } from "@/utils/chart-arc";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "NightingaleChart",
+  description:
+    "A Nightingale rose (polar-area / coxcomb) chart — equal-angle rounded sectors, around a small centre hole, whose radius encodes the value (by sector area, the default, or linearly). An optional legend and a hover chip that follows the cursor. Colours come from a theme palette unless given per datum.",
+};
+
+export interface NightingaleChartDatum {
+  label: string;
+  value: number;
+  /** CSS colour for the sector. Defaults to a cycling theme-palette colour. */
+  color?: string;
+}
+
+export interface NightingaleChartProps {
+  data: ReadonlyArray<NightingaleChartDatum>;
+  /** Width / height in px. Default 200. */
+  size?: number;
+  /** `"area"` (default) — radius ∝ √value, so a sector's *area* tracks the value.
+   *  `"radius"` — radius ∝ value (exaggerates differences). */
+  scale?: "area" | "radius";
+  /** Show a colour / label / value legend beside the chart. Default true. */
+  legend?: boolean;
+  /** Format a value for the legend + hover chip. Default `value.toLocaleString()`. */
+  formatValue?: (value: number, datum: NightingaleChartDatum) => ReactNode;
+  /** Classes for the floating hover chip. Default `"bg-on-surface text-surface"`. */
+  chipClassName?: string;
+  className?: string;
+}
+
+export function NightingaleChart({
+  data,
+  size = 200,
+  scale = "area",
+  legend = true,
+  formatValue,
+  chipClassName,
+  className,
+}: NightingaleChartProps) {
+  // The chip is portaled to <body> so a clipping ancestor can't cut it off; it
+  // tracks the cursor since a sector's bounding box overstates its extent.
+  const [hover, setHover] = useState<{ index: number; x: number; y: number } | null>(null);
+  const fmt = (v: number, d: NightingaleChartDatum): ReactNode => (formatValue ? formatValue(v, d) : v.toLocaleString());
+
+  const sectors = useMemo(() => {
+    const c = size / 2;
+    const rMax = c - 2;
+    const rInner = rMax * 0.14; // a small centre hole
+    const single = data.length === 1;
+    const sliceDeg = data.length > 0 ? 360 / data.length : 360;
+    const maxV = Math.max(0, ...data.map((d) => d.value)) || 1;
+    // An angular gap between sectors, matching the kit's spacing aesthetic.
+    const padDeg = data.length > 1 ? 4 : 0;
+    return data.map((d, i) => {
+      const frac = Math.max(0, d.value) / maxV;
+      const rOuter = rInner + (rMax - rInner) * (scale === "radius" ? frac : Math.sqrt(frac));
+      return {
+        d,
+        i,
+        color: d.color ?? paletteColor(i),
+        path: single
+          ? wedgePath(c, c, rOuter, 0, 360)
+          : roundedDonutSegmentPath(c, c, rInner, rOuter, i * sliceDeg + padDeg / 2, (i + 1) * sliceDeg - padDeg / 2, rOuter * 0.09),
+      };
+    });
+  }, [data, size, scale]);
+
+  const hovered = hover != null ? sectors[hover.index] : undefined;
+  const chip =
+    hovered !== undefined && typeof document !== "undefined"
+      ? createPortal(
+          <span
+            className={cn(
+              "pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded px-1.5 py-0.5 text-[10px] font-medium shadow-md",
+              chipClassName ?? "bg-on-surface text-surface",
+            )}
+            style={{ left: hover!.x || 0, top: (hover!.y || 0) - 10 }}
+          >
+            {hovered.d.label} · {fmt(hovered.d.value, hovered.d)}
+          </span>,
+          document.body,
+        )
+      : null;
+
+  const track = (i: number) => (e: ReactPointerEvent) => setHover({ index: i, x: e.clientX, y: e.clientY });
+
+  const chartEl = (
+    <svg viewBox={`0 0 ${size} ${size}`} width={size} height={size} onPointerLeave={() => setHover(null)} className="shrink-0">
+      {sectors.map((s) => (
+        <path
+          key={s.i}
+          d={s.path}
+          fill={s.color}
+          fillOpacity={hover != null && hover.index !== s.i ? 0.4 : 1}
+          className="cursor-default transition-[fill-opacity]"
+          onPointerEnter={track(s.i)}
+          onPointerMove={track(s.i)}
+        >
+          <title>{`${s.d.label}: ${s.d.value}`}</title>
+        </path>
+      ))}
+    </svg>
+  );
+
+  if (!legend)
+    return (
+      <div className={cn("inline-flex", className)}>
+        {chartEl}
+        {chip}
+      </div>
+    );
+
+  return (
+    <div className={cn("flex items-center gap-4", className)}>
+      {chartEl}
+      <ul className="flex min-w-0 flex-col gap-1.5 text-xs">
+        {sectors.map((s) => (
+          <li
+            key={s.i}
+            className="flex items-center gap-2"
+            onPointerEnter={(e) => setHover({ index: s.i, x: e.clientX, y: e.clientY })}
+            onPointerMove={(e) => setHover({ index: s.i, x: e.clientX, y: e.clientY })}
+            onPointerLeave={() => setHover(null)}
+          >
+            <span className="size-2.5 shrink-0 rounded-sm" style={{ backgroundColor: s.color }} />
+            <span className="min-w-0 flex-1 truncate text-on-surface-variant">{s.d.label}</span>
+            <span className="shrink-0 font-medium tabular-nums text-on-surface">{fmt(s.d.value, s.d)}</span>
+          </li>
+        ))}
+      </ul>
+      {chip}
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,3 +262,8 @@ export {
   type DonutChartDatum,
 } from "./components/ui/chart/donut-chart/DonutChart";
 export { CHART_PALETTE, paletteColor } from "./utils/chart-arc";
+export {
+  NightingaleChart,
+  type NightingaleChartProps,
+  type NightingaleChartDatum,
+} from "./components/ui/chart/nightingale-chart/NightingaleChart";


### PR DESCRIPTION
Adds **`NightingaleChart`** — a Nightingale rose / polar-area / coxcomb chart:

- equal-angle **rounded sectors** around a small centre hole; sector radius encodes the value — `scale="area"` (default, radius ∝ √value, so *area* tracks the value) or `scale="radius"` (linear)
- a small angular gap between sectors; single-datum renders a full disc
- optional `legend` (swatch / label / value); hover a sector → `label · value` chip portaled to `document.body`
- colours from the theme palette unless given per datum; `formatValue`, `chipClassName` knobs
- builds on `src/utils/chart-arc.ts` (introduced in the DonutChart PR — hence the stack)
- Story `UI/Chart/NightingaleChart` (Playground, RadiusScale, Bare); 6 tests
- Reviewed with `/simplify`

Stacked on #183 (DonutChart) for the shared `chart-arc` helper; re-targets to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)