### PR TITLE
feat(data): MetricBlock

### DIFF
--- a/src/components/ui/data/metric-block/MetricBlock.stories.tsx
+++ b/src/components/ui/data/metric-block/MetricBlock.stories.tsx
@@ -1,0 +1,180 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { MetricBlock } from "./MetricBlock";
+
+const meta: Meta<typeof MetricBlock> = {
+  title: "UI/Notch/Blocks/Metric",
+  component: MetricBlock,
+  args: {
+    icon: "apps",
+    label: "Installs",
+    value: "1,240",
+    delta: "+18%",
+    tone: "surface",
+  },
+  argTypes: {
+    tone: { control: "inline-radio", options: ["surface", "primary"] },
+    deltaTrend: { control: "inline-radio", options: [undefined, "up", "down"] },
+    icon: { control: "text" },
+    delta: { control: "text" },
+    hint: { control: "text" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MetricBlock>;
+
+/** Standalone, in a 96px (`size-24`) box — the natural 1×1 footprint. */
+export const Playground: Story = {
+  render: (args) => (
+    <div className="bg-background p-6">
+      <div className="size-24 rounded-2xl bg-surface-container-low p-4">
+        <MetricBlock {...args} />
+      </div>
+    </div>
+  ),
+};
+
+// Build a sparkline from real values: bar heights are scaled to the max, and
+// each point carries a label so hovering shows the actual figure.
+const spark = (values: number[], label: (v: number, week: number) => string) => {
+  const max = Math.max(...values);
+  return values.map((v, i) => ({ value: Math.round((v / max) * 100), label: label(v, i + 1) }));
+};
+const INSTALLS = spark(
+  [470, 760, 600, 950, 680, 870, 1100, 740, 920, 1180, 1050, 1240],
+  (v, w) => `Wk ${w} · ${v.toLocaleString()} installs`,
+);
+const REVENUE = spark(
+  [3.8, 5.1, 4.4, 6.8, 5.2, 7.0, 9.2, 6.1, 7.8, 9.9, 8.7, 12.4],
+  (v, w) => `Wk ${w} · $${v}k`,
+);
+const REQ_MIN = spark(
+  [1.2, 1.6, 1.4, 1.9, 1.7, 2.0, 1.8, 2.3, 2.0, 2.5, 2.2, 2.1],
+  (v, w) => `Wk ${w} · ${v}k req/min`,
+);
+
+// A 96px-cell grid that mirrors the NotchGrid sizing the component targets.
+// (Replaced with plain CSS Grid here so the demo doesn't depend on NotchGrid.)
+const Cell = ({
+  cols = 1,
+  rows = 1,
+  pad = 4,
+  tone = "surface",
+  children,
+}: {
+  cols?: number;
+  rows?: number;
+  pad?: 4 | 6;
+  tone?: "surface" | "primary";
+  children: React.ReactNode;
+}) => (
+  <div
+    className={`rounded-2xl ${tone === "primary" ? "bg-primary-container" : "bg-surface-container-low"} ${pad === 6 ? "p-6" : "p-4"}`}
+    style={{ gridColumn: `span ${cols}`, gridRow: `span ${rows}` }}
+  >
+    {children}
+  </div>
+);
+
+/** Every footprint side by side: 1×1 tiles, a 1×2 (`chart` fills the extra
+ *  height), a 2×1 (`layout="wide"`, no room for a chart), a 3×1 (`wide` +
+ *  sparkline on the right), a 2×2 (`layout="card"`), and a 3×2 (`bigcard` —
+ *  header, big value beside the sparkline, sub-stats row). */
+export const Sizes: Story = {
+  render: () => (
+    <div className="bg-background p-6">
+      <div className="grid auto-rows-[96px] grid-cols-[repeat(6,96px)] gap-2">
+        {/* 3×2 — bigcard: header · big number · chart · sub-stats */}
+        <Cell cols={3} rows={2} pad={6} tone="primary">
+          <MetricBlock
+            layout="bigcard"
+            icon="apps"
+            label="Installs"
+            value="1,240"
+            delta="+18%"
+            chart={INSTALLS}
+            stats={[
+              { label: "This week", value: "1,240", delta: "+18%" },
+              { label: "MTD", value: "4,180", delta: "+11%" },
+              { label: "Conversion", value: "3.2%", delta: "-0.4%" },
+            ]}
+            tone="primary"
+          />
+        </Cell>
+        {/* 2×2 — card: header + big value + chart filling the rest */}
+        <Cell cols={2} rows={2} pad={6}>
+          <MetricBlock layout="card" icon="payments" label="Revenue" value="$12.4k" delta="+22%" hint="vs $10.2k / 30d ago" chart={REVENUE} />
+        </Cell>
+        {/* 3×1 — wide with the sparkline on the right */}
+        <Cell cols={3}>
+          <MetricBlock layout="wide" icon="speed" label="Throughput" value="2.1k/s" delta="+9%" chart={REQ_MIN} />
+        </Cell>
+        {/* 1×1 */}
+        <Cell>
+          <MetricBlock icon="error" label="Churn" value="3" delta="-12%" />
+        </Cell>
+        {/* 2×1 — wide, no chart: delta sits next to the label */}
+        <Cell cols={2}>
+          <MetricBlock layout="wide" icon="schedule" label="Avg latency" value="142ms" delta="-8%" hint="p99 312ms" />
+        </Cell>
+        {/* 1×2 — sparkline fills the second row */}
+        <Cell rows={2}>
+          <MetricBlock icon="trending_up" label="Req / min" value="2.1k" delta="+9%" chart={REQ_MIN} />
+        </Cell>
+        <Cell>
+          <MetricBlock icon="groups" label="Tenants" value="37" delta="+2" />
+        </Cell>
+        <Cell>
+          <MetricBlock icon="bolt" label="Cold starts" value="3" delta="-1" />
+        </Cell>
+        <Cell>
+          <MetricBlock icon="new_releases" label="Version" value="v0.3.1" />
+        </Cell>
+      </div>
+    </div>
+  ),
+};
+
+/** `layout="chart"` for 3×3 and larger — chart-led: header (label · trend), a
+ *  full-width sparkline filling the middle, and a stats row underneath. No big
+ *  value — the chart and stats carry it. Hover a bar for its labelled value. */
+export const BigCard: Story = {
+  render: () => (
+    <div className="bg-background p-6">
+      <div className="grid auto-rows-[96px] grid-cols-[repeat(7,96px)] gap-2">
+        {/* 3×3 */}
+        <Cell cols={3} rows={3} pad={6}>
+          <MetricBlock
+            layout="chart"
+            icon="payments"
+            label="Revenue"
+            delta="+22%"
+            chart={REVENUE}
+            stats={[
+              { label: "This week", value: "$12.4k", delta: "+22%" },
+              { label: "MTD", value: "$41.8k", delta: "+9%" },
+              { label: "ARPU", value: "$8.40", delta: "+3%" },
+            ]}
+          />
+        </Cell>
+        {/* 4×3 */}
+        <Cell cols={4} rows={3} pad={6} tone="primary">
+          <MetricBlock
+            layout="chart"
+            icon="apps"
+            label="Installs"
+            delta="+18%"
+            chart={INSTALLS}
+            stats={[
+              { label: "This week", value: "1,240", delta: "+18%" },
+              { label: "Month-to-date", value: "4,180", delta: "+11%" },
+              { label: "Conversion", value: "3.2%", delta: "-0.4%" },
+              { label: "Per tenant", value: "33.5", delta: "+2%" },
+            ]}
+            tone="primary"
+          />
+        </Cell>
+      </div>
+    </div>
+  ),
+};

--- a/src/components/ui/data/metric-block/MetricBlock.test.tsx
+++ b/src/components/ui/data/metric-block/MetricBlock.test.tsx
@@ -1,0 +1,159 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { MetricBlock } from "./MetricBlock";
+
+afterEach(cleanup);
+
+describe("MetricBlock", () => {
+  it("renders the icon, label, and value", () => {
+    const { container, getByText } = render(
+      <MetricBlock icon="apps" label="Installs" value="1,240" />,
+    );
+    expect(getByText("Installs")).toBeInTheDocument();
+    expect(getByText("1,240")).toBeInTheDocument();
+    expect(container.querySelector(".material-symbols-rounded")?.textContent).toBe("apps");
+  });
+
+  it("omits the icon when none is given", () => {
+    const { container } = render(<MetricBlock label="x" value="1" />);
+    expect(container.querySelector(".material-symbols-rounded")).toBeNull();
+  });
+
+  it("renders the optional hint line", () => {
+    const { getByText, queryByText, rerender } = render(<MetricBlock label="x" value="1" />);
+    expect(queryByText("2 pending")).toBeNull();
+    rerender(<MetricBlock label="x" value="1" hint="2 pending" />);
+    expect(getByText("2 pending")).toBeInTheDocument();
+  });
+
+  it("colours the delta chip with the success/error tokens by trend", () => {
+    const { getByText, rerender } = render(<MetricBlock label="x" value="1" delta="+18%" />);
+    expect(getByText("+18%").className).toContain("text-success"); // inferred up
+    rerender(<MetricBlock label="x" value="1" delta="-12%" />);
+    expect(getByText("-12%").className).toContain("text-error"); // inferred down from leading "-"
+    rerender(<MetricBlock label="x" value="1" delta="big" deltaTrend="down" />);
+    expect(getByText("big").className).toContain("text-error"); // explicit override
+  });
+
+  it("renders a sparkline that fills the height only when `chart` is given", () => {
+    const { container, rerender } = render(<MetricBlock label="x" value="1" />);
+    expect(container.querySelector(".flex-1")).toBeNull(); // no chart ⇒ no growing section
+    rerender(<MetricBlock label="x" value="1" chart={[10, 50, 130, -5]} />);
+    const bars = container.querySelectorAll<HTMLElement>(".flex-1 > div");
+    expect(bars).toHaveLength(4);
+    expect(bars[1].style.height).toBe("50%");
+    expect(bars[2].style.height).toBe("100%"); // clamped to 100
+    expect(bars[3].style.height).toBe("0%"); // clamped to 0
+  });
+
+  it("gives each bar a hover tooltip — the per-point label when given, else the value", () => {
+    const { container } = render(
+      <MetricBlock label="x" value="1" chart={[42, { value: 80, label: "Wk 3 · 920" }]} />,
+    );
+    const bars = container.querySelectorAll<HTMLElement>(".flex-1 > div");
+    expect(bars[0].title).toBe("42");
+    expect(bars[1].title).toBe("Wk 3 · 920");
+    expect(bars[1].style.height).toBe("80%");
+  });
+
+  it("shows a floating chip (portaled, so it isn't clipped) on the hovered bar", () => {
+    const { container } = render(
+      <MetricBlock label="x" value="1" chart={[42, { value: 80, label: "Wk 3 · 920" }]} />,
+    );
+    expect(screen.queryByText("Wk 3 · 920")).toBeNull(); // hidden until hovered
+    const chart = container.querySelector(".flex-1")!;
+    fireEvent.pointerEnter(chart.querySelectorAll("div")[1]);
+    expect(screen.getByText("Wk 3 · 920")).toBeInTheDocument(); // rendered into <body>
+    fireEvent.pointerLeave(chart);
+    expect(screen.queryByText("Wk 3 · 920")).toBeNull(); // gone on leave
+  });
+
+  it("places the delta in the top row (stacked) — not under the value", () => {
+    const { container } = render(<MetricBlock icon="apps" label="Lbl" value="42" delta="+1%" />);
+    const root = container.querySelector("div.h-full")!;
+    expect(root.firstElementChild!.textContent).toContain("+1%"); // top row (icon + delta)
+    expect(root.firstElementChild!.querySelector(".material-symbols-rounded")).not.toBeNull();
+    expect(root.lastElementChild!.textContent).not.toContain("+1%"); // label / value / hint block
+  });
+
+  it("uses a card layout — header row + big value — when `layout=\"card\"`", () => {
+    const { container, getByText } = render(
+      <MetricBlock layout="card" icon="apps" label="Installs" value="1,240" delta="+18%" chart={[10, 90]} />,
+    );
+    expect(getByText("1,240").className).toContain("text-3xl"); // the big number
+    const header = getByText("Installs").parentElement!;
+    expect(header.textContent).toContain("+18%"); // icon · label · delta share the header
+    expect(header.querySelector(".material-symbols-rounded")).not.toBeNull();
+    expect(container.querySelectorAll(".flex-1 > div")).toHaveLength(2); // chart below
+  });
+
+  it("renders a bigcard — big value, sparkline, and a sub-stats row — when `layout=\"bigcard\"`", () => {
+    const { container, getByText } = render(
+      <MetricBlock
+        layout="bigcard"
+        icon="apps"
+        label="Installs"
+        value="VAL"
+        delta="DELTA"
+        chart={[10, 90, 50]}
+        stats={[
+          { label: "WTD", value: "WTD_V", delta: "WTD_D" },
+          { label: "MTD", value: "MTD_V" },
+        ]}
+      />,
+    );
+    expect(getByText("VAL").className).toContain("text-3xl");
+    expect(getByText("WTD")).toBeInTheDocument();
+    expect(getByText("WTD_V")).toBeInTheDocument();
+    expect(getByText("WTD_D").className).toContain("text-success"); // up-trend (no leading "-")
+    expect(getByText("MTD_V")).toBeInTheDocument();
+    expect(container.querySelectorAll("[title]")).toHaveLength(3); // 3 sparkline bars
+  });
+
+  it("renders a chart-led card — no big value, full-width sparkline — when `layout=\"chart\"`", () => {
+    const { container, getByText, queryByText } = render(
+      <MetricBlock
+        layout="chart"
+        icon="payments"
+        label="Revenue"
+        value="$12.4k"
+        delta="+22%"
+        chart={[10, 90, 50, 70]}
+        stats={[{ label: "WTD", value: "WTD_V" }]}
+      />,
+    );
+    expect(queryByText("$12.4k")).toBeNull(); // headline value intentionally not shown
+    expect(getByText("Revenue")).toBeInTheDocument();
+    expect(getByText("WTD")).toBeInTheDocument();
+    expect(getByText("WTD_V")).toBeInTheDocument();
+    expect(container.querySelectorAll("[title]")).toHaveLength(4); // sparkline fills the middle
+  });
+
+  it("uses a horizontal layout when `layout=\"wide\"`", () => {
+    const { container, getByText, queryByText, rerender } = render(
+      <MetricBlock layout="wide" icon="payments" label="Revenue" value="$12k" delta="+22%" />,
+    );
+    const root = container.querySelector("div.h-full") as HTMLElement;
+    expect(root.className).toContain("items-center"); // a row, not flex-col
+    expect(root.className).not.toContain("flex-col");
+    // delta sits inline with the label (not in a separate top row)
+    expect(getByText("Revenue").parentElement!.textContent).toContain("+22%");
+
+    // a wide sparkline replaces the inline delta when `chart` is given
+    rerender(<MetricBlock layout="wide" label="x" value="1" delta="+22%" chart={[10, 90]} />);
+    expect(queryByText("+22%")).toBeNull();
+    expect(container.querySelectorAll(".w-\\[42\\%\\] > div")).toHaveLength(2);
+  });
+
+  it("fills its container (h-full) so it fits a grid cell", () => {
+    const { container } = render(<MetricBlock label="x" value="1" />);
+    expect(container.firstElementChild).toHaveClass("h-full");
+  });
+
+  it("switches text tone for non-surface backgrounds", () => {
+    const { getByText, rerender } = render(<MetricBlock label="Lbl" value="42" />);
+    expect(getByText("42").className).toContain("text-on-surface");
+    rerender(<MetricBlock label="Lbl" value="42" tone="primary" />);
+    expect(getByText("42").className).toContain("text-on-primary-container");
+  });
+});

--- a/src/components/ui/data/metric-block/MetricBlock.tsx
+++ b/src/components/ui/data/metric-block/MetricBlock.tsx
@@ -1,0 +1,218 @@
+import type { ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
+import type { ComponentMeta } from "@/types/component-meta";
+import { Icon } from "@/components/ui/media/icon/Icon";
+import { Sparkline, type SparklinePoint } from "@/components/ui/chart/sparkline/Sparkline";
+
+export const meta: ComponentMeta = {
+  name: "MetricBlock",
+  description:
+    "A metric tile sized for a NotchGrid cell — icon, trend chip, label, value, optional sparkline + sub-stats. Pick a `layout` for the cell shape: stacked (1×1/1×2), wide (2×1/3×1), card (2×2), bigcard (3×2), chart (3×3+ — chart-led, no big value).",
+};
+
+/** Text-colour tone — must match the surface the block sits on. */
+export type MetricBlockTone = "surface" | "primary";
+
+/** Direction of the trend chip — `up` reads green, `down` reads as an error. */
+export type MetricTrend = "up" | "down";
+
+/** `stacked` = 1×1 / 1×2; `wide` = 2×1 / 3×1; `card` = 2×2; `bigcard` = 3×2;
+ *  `chart` = 3×3 and up (chart-led — full-width sparkline, no big value). */
+export type MetricBlockLayout = "stacked" | "wide" | "card" | "bigcard" | "chart";
+
+const TONE: Record<
+  MetricBlockTone,
+  { icon: string; label: string; value: string; bar: string; barActive: string; divider: string }
+> = {
+  surface: {
+    icon: "text-primary",
+    label: "text-on-surface-variant",
+    value: "text-on-surface",
+    bar: "bg-primary/30 hover:bg-primary/60",
+    barActive: "bg-primary/60",
+    divider: "border-outline-variant",
+  },
+  primary: {
+    icon: "text-on-primary-container",
+    label: "text-on-primary-container/70",
+    value: "text-on-primary-container",
+    bar: "bg-on-primary-container/25 hover:bg-on-primary-container/55",
+    barActive: "bg-on-primary-container/55",
+    divider: "border-on-primary-container/20",
+  },
+};
+
+// Semantic accent tokens — they flip with the theme, so the chip stays legible
+// in light and dark mode on any tone.
+const TREND_TEXT: Record<MetricTrend, string> = {
+  up: "text-success",
+  down: "text-error",
+};
+
+const inferTrend = (delta: ReactNode, explicit?: MetricTrend): MetricTrend =>
+  explicit ?? (typeof delta === "string" && /^[-−]/.test(delta.trim()) ? "down" : "up");
+
+export interface MetricStat {
+  label: ReactNode;
+  value: ReactNode;
+  delta?: ReactNode;
+  deltaTrend?: MetricTrend;
+}
+
+export interface MetricBlockProps {
+  /** Material Symbols Rounded icon name (e.g. `"apps"`). Omit for no icon. */
+  icon?: string;
+  label: ReactNode;
+  /** The headline value. Not shown in `layout="chart"` (the chart + stats carry it). */
+  value?: ReactNode;
+  /** A trend / delta chip (e.g. `"+18%"`). Top-right when stacked, in the header
+   *  when card, beside the label when wide. Coloured by {@link deltaTrend}. */
+  delta?: ReactNode;
+  /** `up` ⇒ green, `down` ⇒ error red. When omitted and `delta` is a string,
+   *  inferred from a leading `-` / `−`. */
+  deltaTrend?: MetricTrend;
+  /** Optional neutral line under the value — a unit, count, timestamp, etc.
+   *  Hidden when {@link stats} is shown (bigcard). */
+  hint?: ReactNode;
+  /** Sparkline points (heights 0–100, optional per-bar `label` for the hover
+   *  chip — see {@link SparklinePoint}). Fills the spare height (stacked / card
+   *  / bigcard / chart) or sits on the right (wide). A 2×1 hasn't the room. */
+  chart?: ReadonlyArray<SparklinePoint>;
+  /** A row of mini sub-stats below the chart — rendered in `layout="bigcard"`
+   *  and `layout="chart"`. */
+  stats?: ReadonlyArray<MetricStat>;
+  /** Pick a layout for the cell shape (see {@link MetricBlockLayout}). Default `"stacked"`. */
+  layout?: MetricBlockLayout;
+  /** Pick the tone that contrasts with the block's background. Default `"surface"`. */
+  tone?: MetricBlockTone;
+  className?: string;
+}
+
+export function MetricBlock({
+  icon,
+  label,
+  value,
+  delta,
+  deltaTrend,
+  hint,
+  chart,
+  stats,
+  layout = "stacked",
+  tone = "surface",
+  className,
+}: MetricBlockProps) {
+  if (isDev && label == null && value == null) {
+    console.warn("[MetricBlock] both `label` and `value` are empty — nothing to show");
+  }
+  const c = TONE[tone];
+  const trend = inferTrend(delta, deltaTrend);
+  const hasChart = !!chart && chart.length > 0;
+  const deltaChip = delta != null && (
+    <span className={cn("shrink-0 text-xs font-medium", TREND_TEXT[trend])}>{delta}</span>
+  );
+  const sparkline = (cls: string) =>
+    hasChart ? (
+      <Sparkline data={chart!} barClassName={c.bar} barActiveClassName={c.barActive} className={cls} />
+    ) : null;
+  const hintLine = (extra?: string) =>
+    hint != null ? <p className={cn("truncate text-xs", c.label, extra)}>{hint}</p> : null;
+  const hasStats = !!stats && stats.length > 0;
+  const statsRow = hasStats ? (
+    <div className={cn("flex gap-3 border-t pt-2", c.divider)}>
+      {stats!.map((s, i) => {
+        const t = inferTrend(s.delta, s.deltaTrend);
+        return (
+          <div key={i} className="min-w-0 flex-1">
+            <p className={cn("truncate text-[10px]", c.label)}>{s.label}</p>
+            <p className={cn("truncate text-sm font-medium", c.value)}>
+              {s.value}
+              {s.delta != null && (
+                <span className={cn("ml-1 text-[10px] font-medium", TREND_TEXT[t])}>{s.delta}</span>
+              )}
+            </p>
+          </div>
+        );
+      })}
+    </div>
+  ) : null;
+
+  const valueLine = (cls: string) =>
+    value != null ? <p className={cn(cls, c.value)}>{value}</p> : null;
+
+  let body: ReactNode;
+  if (layout === "wide") {
+    body = (
+      <div className={cn("flex h-full items-center gap-3", className)}>
+        {icon ? <Icon name={icon} size={24} className={c.icon} /> : null}
+        <div className="min-w-0">
+          <div className="flex items-baseline gap-2">
+            <p className={cn("truncate text-xs", c.label)}>{label}</p>
+            {!hasChart && deltaChip}
+          </div>
+          {valueLine("text-2xl font-semibold leading-tight")}
+          {hintLine()}
+        </div>
+        {sparkline("ml-auto h-2/3 w-[42%] self-center")}
+      </div>
+    );
+  } else if (layout === "chart") {
+    body = (
+      <div className={cn("flex h-full flex-col gap-2", className)}>
+        <div className="flex items-center gap-2">
+          {icon ? <Icon name={icon} size={20} className={c.icon} /> : null}
+          <p className={cn("min-w-0 flex-1 truncate text-sm font-medium", c.label)}>{label}</p>
+          {deltaChip}
+        </div>
+        {sparkline("flex-1")}
+        {hasStats ? statsRow : hintLine("mt-auto")}
+      </div>
+    );
+  } else if (layout === "bigcard") {
+    body = (
+      <div className={cn("flex h-full flex-col gap-2", className)}>
+        <div className="flex items-center gap-2">
+          {icon ? <Icon name={icon} size={20} className={c.icon} /> : null}
+          <p className={cn("min-w-0 flex-1 truncate text-sm font-medium", c.label)}>{label}</p>
+          {deltaChip}
+        </div>
+        {/* big value beside the sparkline — uses the horizontal room a 3×2+ has */}
+        <div className="flex flex-1 items-end gap-3">
+          {valueLine("shrink-0 text-3xl font-semibold leading-none")}
+          {sparkline("h-full flex-1")}
+        </div>
+        {hasStats ? statsRow : hintLine("mt-auto")}
+      </div>
+    );
+  } else if (layout === "card") {
+    body = (
+      <div className={cn("flex h-full flex-col gap-2", className)}>
+        <div className="flex items-center gap-2">
+          {icon ? <Icon name={icon} size={20} className={c.icon} /> : null}
+          <p className={cn("min-w-0 flex-1 truncate text-sm font-medium", c.label)}>{label}</p>
+          {deltaChip}
+        </div>
+        {valueLine("text-3xl font-semibold leading-none")}
+        {sparkline("mt-1 flex-1")}
+        {hintLine(hasChart ? undefined : "mt-auto")}
+      </div>
+    );
+  } else {
+    body = (
+      <div className={cn("flex h-full flex-col gap-2", className)}>
+        <div className="flex items-center justify-between gap-2">
+          {icon ? <Icon name={icon} size={18} className={c.icon} /> : <span aria-hidden="true" />}
+          {deltaChip}
+        </div>
+        {sparkline("flex-1")}
+        <div className={hasChart ? undefined : "mt-auto"}>
+          <p className={cn("text-xs", c.label)}>{label}</p>
+          {valueLine("text-lg font-medium leading-tight")}
+          {hintLine("mt-0.5")}
+        </div>
+      </div>
+    );
+  }
+
+  return body;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,3 +246,11 @@ export {
   type SparklineProps,
   type SparklinePoint,
 } from "./components/ui/chart/sparkline/Sparkline";
+export {
+  MetricBlock,
+  type MetricBlockProps,
+  type MetricBlockTone,
+  type MetricBlockLayout,
+  type MetricTrend,
+  type MetricStat,
+} from "./components/ui/data/metric-block/MetricBlock";


### PR DESCRIPTION
Adds **`MetricBlock`** — a metric tile sized for a `NotchGrid` cell: icon, trend chip, label, value, optional sparkline + sub-stats.

- `layout` picks the regime for the cell shape: `stacked` (1×1 / 1×2), `wide` (2×1 / 3×1 — sparkline on the right), `card` (2×2), `bigcard` (3×2 — value beside the sparkline + stats row), `chart` (3×3+ — chart-led, full-width sparkline, no big value)
- trend chip top-right (or beside the label / in the header per layout), green for up / error-red for down, **theme-token colours** so it stays legible in dark mode on any tone
- `tone="surface" | "primary"` to contrast with the block's background; bigger padding on the larger sizes
- composes **`<Sparkline>`** (#180) for the chart; `stats` as `MetricStat[]`
- Story `UI/Notch/Blocks/Metric` (Playground, Sizes, BigCard); 14 tests
- Reviewed with `/simplify`

Stacked on #180 (Sparkline) because it composes it; re-targets to `main` once Sparkline merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)