### PR TITLE
feat(surfaces): NotchGrid notched-layout system

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/owo/Documents/MirrorStack-AI-V2/web-ui-kit/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/owo/Documents/MirrorStack-AI-V2/web-ui-kit/node_modules

--- a/src/components/ui/surfaces/notch-grid/BlockShape.stories.tsx
+++ b/src/components/ui/surfaces/notch-grid/BlockShape.stories.tsx
@@ -1,0 +1,139 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Icon } from "@/components/ui/media/icon/Icon";
+import { BlockShape } from "./BlockShape";
+
+const meta: Meta<typeof BlockShape> = {
+  title: "UI/Notch/BlockShape",
+  component: BlockShape,
+  args: {
+    shape: [
+      [0, 1, 1, 1],
+      [1, 1, 1, 1],
+      [1, 1, 1, 0],
+    ],
+    tier: 1,
+    block: 96,
+    gap: 0,
+    radius: 24,
+    inverseRadius: 32,
+    strokeWidth: 1,
+  },
+  argTypes: {
+    shape: { control: "object" },
+    tier: { control: { type: "range", min: 1, max: 4, step: 1 } },
+    block: { control: { type: "range", min: 40, max: 140, step: 4 } },
+    gap: { control: { type: "range", min: 0, max: 40, step: 2 } },
+    radius: { control: { type: "range", min: 0, max: 44, step: 1 } },
+    inverseRadius: { control: { type: "range", min: 0, max: 48, step: 1 } },
+    strokeWidth: { control: { type: "range", min: 0, max: 4, step: 0.5 } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BlockShape>;
+
+export const Playground: Story = {
+  render: (args) => (
+    <BlockShape {...args}>
+      <div className="flex h-full flex-col justify-between text-on-surface">
+        <Icon name="dashboard" size={20} className="text-primary" />
+        <div>
+          <p className="text-xs text-on-surface-variant">Edit the `shape` matrix</p>
+          <p className="text-lg font-medium">Notched block</p>
+        </div>
+      </div>
+    </BlockShape>
+  ),
+};
+
+const SHAPES: Record<string, number[][]> = {
+  Rect: [
+    [1, 1, 1],
+    [1, 1, 1],
+  ],
+  "User example": [
+    [0, 1, 1, 1],
+    [1, 1, 1, 1],
+    [1, 1, 1, 0],
+  ],
+  "L-shape": [
+    [1, 0, 0],
+    [1, 0, 0],
+    [1, 1, 1],
+  ],
+  Plus: [
+    [0, 1, 0],
+    [1, 1, 1],
+    [0, 1, 0],
+  ],
+  "Edge notch": [
+    [1, 1, 1, 1],
+    [1, 1, 0, 0],
+    [1, 1, 1, 1],
+  ],
+  Donut: [
+    [1, 1, 1],
+    [1, 0, 1],
+    [1, 1, 1],
+  ],
+  Staircase: [
+    [1, 0, 0],
+    [1, 1, 0],
+    [0, 1, 1],
+    [0, 0, 1],
+  ],
+};
+
+export const Gallery: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-start gap-8 p-4">
+      {Object.entries(SHAPES).map(([name, shape]) => (
+        <div key={name} className="flex flex-col items-center gap-2">
+          <BlockShape shape={shape}>
+            <span className="text-xs text-on-surface-variant">{name}</span>
+          </BlockShape>
+          <p className="text-xs text-on-surface-variant">{name}</p>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const Outlined: Story = {
+  args: {
+    fill: "none",
+    stroke: "var(--color-primary)",
+    strokeWidth: 1.5,
+  },
+};
+
+export const FilledNoStroke: Story = {
+  args: {
+    stroke: "none",
+    fill: "var(--color-primary-container)",
+  },
+};
+
+/** Same shape rendered at each tier — cells marked 2 / 3 join as space unlocks. */
+export const ResponsiveTiers: Story = {
+  render: () => {
+    const shape = [
+      [0, 1, 1, 2, 2],
+      [1, 1, 1, 2, 2],
+      [1, 1, 1, 3, 3],
+      [0, 1, 1, 3, 3],
+    ];
+    return (
+      <div className="flex flex-wrap items-start gap-10 p-4">
+        {[1, 2, 3].map((tier) => (
+          <div key={tier} className="flex flex-col items-center gap-2">
+            <BlockShape shape={shape} tier={tier} block={72}>
+              <span className="text-xs text-on-surface-variant">tier {tier}</span>
+            </BlockShape>
+            <p className="text-xs text-on-surface-variant">tier = {tier}</p>
+          </div>
+        ))}
+      </div>
+    );
+  },
+};

--- a/src/components/ui/surfaces/notch-grid/BlockShape.test.tsx
+++ b/src/components/ui/surfaces/notch-grid/BlockShape.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { BlockShape, BLOCK_SIZE } from "./BlockShape";
+
+afterEach(cleanup);
+
+const SHAPE = [
+  [0, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 0],
+];
+
+describe("BlockShape", () => {
+  it("sizes the wrapper to cols×rows blocks", () => {
+    const { container } = render(<BlockShape shape={SHAPE} block={50} />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.width).toBe(`${4 * 50}px`);
+    expect(root.style.height).toBe(`${3 * 50}px`);
+  });
+
+  it("defaults the block size to BLOCK_SIZE (96px)", () => {
+    const { container } = render(<BlockShape shape={[[1]]} />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.width).toBe(`${BLOCK_SIZE}px`);
+    expect(BLOCK_SIZE).toBe(96);
+  });
+
+  it("renders an SVG outline path", () => {
+    const { container } = render(<BlockShape shape={SHAPE} />);
+    const path = container.querySelector("svg path[fill]");
+    expect(path).not.toBeNull();
+    expect(path!.getAttribute("d")!.startsWith("M ")).toBe(true);
+    expect(path!.getAttribute("fill-rule")).toBe("evenodd");
+  });
+
+  it("grows the shape with the tier — a tier-2 cell is empty at tier 1", () => {
+    const tiered = [
+      [1, 2],
+      [1, 1],
+    ];
+    const { container: c1 } = render(<BlockShape shape={tiered} tier={1} block={40} />);
+    const { container: c2 } = render(<BlockShape shape={tiered} tier={2} block={40} />);
+    const d1 = c1.querySelector("svg path[fill]")!.getAttribute("d")!;
+    const d2 = c2.querySelector("svg path[fill]")!.getAttribute("d")!;
+    // tier 1 = an L-shape (6 corners); tier 2 = a full 2×2 square (4 corners).
+    expect((d1.match(/ A /g) ?? []).length).toBe(6);
+    expect((d2.match(/ A /g) ?? []).length).toBe(4);
+  });
+
+  it("renders content on top of the shape", () => {
+    const { getByText } = render(
+      <BlockShape shape={[[1]]}>
+        <span>hello</span>
+      </BlockShape>,
+    );
+    expect(getByText("hello")).toBeInTheDocument();
+  });
+
+  it("clips the content layer to the outline by default; noClip removes it", () => {
+    const { container, rerender } = render(<BlockShape shape={[[1]]}>x</BlockShape>);
+    const content = () =>
+      (container.firstElementChild as HTMLElement).lastElementChild as HTMLElement;
+    expect(content().style.clipPath).toMatch(/^url\(#block-shape-clip-/);
+    rerender(
+      <BlockShape shape={[[1]]} noClip>
+        x
+      </BlockShape>,
+    );
+    expect(content().style.clipPath).toBe("");
+  });
+});

--- a/src/components/ui/surfaces/notch-grid/BlockShape.tsx
+++ b/src/components/ui/surfaces/notch-grid/BlockShape.tsx
@@ -117,7 +117,7 @@ export function BlockShape({
         />
       </svg>
       <div
-        className="absolute inset-0 overflow-hidden"
+        className={cn("absolute inset-0", !noClip && "overflow-hidden")}
         style={{
           padding: pad,
           clipPath: noClip ? undefined : `url(#${clipId})`,

--- a/src/components/ui/surfaces/notch-grid/BlockShape.tsx
+++ b/src/components/ui/surfaces/notch-grid/BlockShape.tsx
@@ -1,0 +1,130 @@
+import { useId, useMemo, type CSSProperties, type ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
+import type { ComponentMeta } from "@/types/component-meta";
+import {
+  gridOutlinePath,
+  maskCols,
+  maskFromShape,
+} from "@/utils/grid-outline";
+
+export const meta: ComponentMeta = {
+  name: "BlockShape",
+  description:
+    "A notched surface whose outline follows a grid of 96px blocks, with content layered on top",
+};
+
+/** Default block edge in px — matches Tailwind's `w-24` / `h-24` (6rem). */
+export const BLOCK_SIZE = 96;
+
+export interface BlockShapeProps {
+  /**
+   * Footprint matrix. Cell values:
+   *  - `0`  — always empty (a notch / hole)
+   *  - `1`  — part of the shape at every size tier
+   *  - `2+` — joins the shape only once that tier is reached (responsive growth)
+   *
+   * e.g. `[[0,1,1,1],[1,1,1,1],[1,1,1,0]]` — a base shape with two corners cut.
+   */
+  shape: ReadonlyArray<ReadonlyArray<number>>;
+  /** Active size tier (>= 1). Cells whose value exceeds `tier` render as empty. */
+  tier?: number;
+  /** Block edge length in px. Default {@link BLOCK_SIZE}. */
+  block?: number;
+  /** Erode the outline by `gap / 2` px (outer edges in, notch holes out) so
+   *  neighbours / nested items leave a `gap`-px space. Footprint size is
+   *  unchanged. Normally set by the parent `NotchGrid`; default 0. */
+  gap?: number;
+  /** Convex corner radius (px). Default 24. */
+  radius?: number;
+  /** Concave / notch corner radius (px). Default 32. */
+  inverseRadius?: number;
+  /** Outline fill — a CSS color, or `"none"` to disable. */
+  fill?: string;
+  /** Outline stroke — a CSS color, or `"none"` to disable. */
+  stroke?: string;
+  strokeWidth?: number;
+  /** Content rendered on top of the shape (clipped to the shape's outline). */
+  children?: ReactNode;
+  /** Padding (px) on the content layer. Default 16. */
+  pad?: number;
+  /** Skip clipping the content layer to the outline. */
+  noClip?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export function BlockShape({
+  shape,
+  tier = 1,
+  block = BLOCK_SIZE,
+  gap = 0,
+  radius = 24,
+  inverseRadius = 32,
+  fill = "var(--color-surface-container-low)",
+  stroke = "var(--color-outline-variant)",
+  strokeWidth = 1,
+  children,
+  pad = 16,
+  noClip = false,
+  className,
+  style,
+}: BlockShapeProps) {
+  const reactId = useId();
+  const clipId = `block-shape-clip-${reactId.replace(/[^a-zA-Z0-9_-]/g, "")}`;
+
+  const rows = shape.length;
+  const cols = maskCols(shape);
+  if (isDev && (rows === 0 || cols === 0)) {
+    console.warn("[BlockShape] empty shape matrix — nothing to render");
+  }
+
+  const mask = useMemo(() => maskFromShape(shape, tier), [shape, tier]);
+  const w = cols * block;
+  const h = rows * block;
+  const pathD = useMemo(
+    () => gridOutlinePath(mask, { cell: block, gap, radius, inverseRadius }),
+    [mask, block, gap, radius, inverseRadius],
+  );
+  const inset = strokeWidth / 2;
+
+  return (
+    <div
+      className={cn("relative", className)}
+      style={{ width: w, height: h, ...style }}
+    >
+      <svg
+        width={w}
+        height={h}
+        viewBox={`${-inset} ${-inset} ${w + strokeWidth} ${h + strokeWidth}`}
+        className="pointer-events-none absolute inset-0"
+        aria-hidden="true"
+      >
+        {!noClip && (
+          <defs>
+            <clipPath id={clipId} clipPathUnits="userSpaceOnUse">
+              <path d={pathD} />
+            </clipPath>
+          </defs>
+        )}
+        <path
+          d={pathD}
+          fill={fill}
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+          vectorEffect="non-scaling-stroke"
+          fillRule="evenodd"
+        />
+      </svg>
+      <div
+        className="absolute inset-0 overflow-hidden"
+        style={{
+          padding: pad,
+          clipPath: noClip ? undefined : `url(#${clipId})`,
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
@@ -1,0 +1,293 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Icon } from "@/components/ui/media/icon/Icon";
+import { NotchGrid } from "./NotchGrid";
+import { NotchGridItem } from "./NotchGridItem";
+
+const meta: Meta<typeof NotchGrid> = {
+  title: "UI/Notch/NotchGrid",
+  component: NotchGrid,
+  parameters: { layout: "fullscreen" },
+  args: { block: 96 },
+  argTypes: {
+    cols: { control: { type: "number", min: 1, max: 12 } },
+    block: { control: { type: "range", min: 56, max: 140, step: 4 } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof NotchGrid>;
+
+function Tile({ icon, label, value }: { icon: string; label: string; value: string }) {
+  return (
+    <div className="flex h-full flex-col justify-between">
+      <Icon name={icon} size={18} className="text-primary" />
+      <div>
+        <p className="text-xs text-on-surface-variant">{label}</p>
+        <p className="text-lg font-medium text-on-surface">{value}</p>
+      </div>
+    </div>
+  );
+}
+
+function PrimaryTile({ icon, label, value }: { icon: string; label: string; value: string }) {
+  return (
+    <div className="flex h-full flex-col justify-between">
+      <Icon name={icon} size={16} className="text-on-primary-container" />
+      <div>
+        <p className="text-xs text-on-primary-container/70">{label}</p>
+        <p className="text-base font-medium text-on-primary-container">{value}</p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * An overview page laid out by hand (explicit `col`/`row`) so the notched
+ * pieces interlock cleanly: 1×1 tiles drop into the L-hero's notch and into all
+ * four of the plus's corners and the chart's notch; the `subItems={[[1,1],[2,2]]}`
+ * panel is an L of its own. `nest` (default) keeps notches fillable — nothing
+ * reserves empty corners — and `draggable` lets you re-arrange it.
+ */
+export const OverviewPage: Story = {
+  render: () => (
+    <div className="bg-background p-6">
+      <NotchGrid cols={7} draggable>
+        {/* L-shaped ("knife") hero: 3×3 with the bottom-right block notched out. */}
+        <NotchGridItem
+          col={0}
+          row={0}
+          shape={[
+            [1, 1, 1],
+            [1, 1, 1],
+            [1, 1, 0],
+          ]}
+          fill="var(--color-primary-container)"
+          stroke="none"
+        >
+          <div className="flex h-full flex-col justify-between">
+            <Icon name="extension" size={22} className="text-on-primary-container" />
+            <div>
+              <p className="text-xs text-on-primary-container/70">Module</p>
+              <p className="text-xl font-medium text-on-primary-container">identity-federated</p>
+              <p className="text-xs text-on-primary-container/70">@me/identity-federated · v0.3.1</p>
+            </div>
+          </div>
+        </NotchGridItem>
+        {/* drops into the hero's bottom-right notch */}
+        <NotchGridItem col={2} row={2} shape={[[1]]}>
+          <Tile icon="apps" label="Installs" value="1,240" />
+        </NotchGridItem>
+
+        {/* Plus — its four notch corners get filled by 1×1 tiles. */}
+        <NotchGridItem
+          col={3}
+          row={0}
+          shape={[
+            [0, 1, 0],
+            [1, 1, 1],
+            [0, 1, 0],
+          ]}
+        >
+          <div className="flex h-full flex-col items-center justify-center text-center">
+            <Icon name="bolt" size={18} className="text-primary" />
+            <p className="mt-1 text-sm font-medium text-on-surface">Status</p>
+            <p className="text-xs text-on-surface-variant">live · healthy</p>
+          </div>
+        </NotchGridItem>
+        <NotchGridItem col={3} row={0} shape={[[1]]} fill="var(--color-primary-container)" stroke="none">
+          <PrimaryTile icon="payments" label="Earned" value="$84" />
+        </NotchGridItem>
+        <NotchGridItem col={5} row={0} shape={[[1]]}><Tile icon="new_releases" label="Version" value="v0.3.1" /></NotchGridItem>
+        <NotchGridItem col={3} row={2} shape={[[1]]}><Tile icon="groups" label="Tenants" value="37" /></NotchGridItem>
+        <NotchGridItem col={5} row={2} shape={[[1]]}><Tile icon="schedule" label="Pending" value="1" /></NotchGridItem>
+
+        {/* Tall recent-activity list. */}
+        <NotchGridItem col={6} row={0} shape={[[1], [1], [1]]}>
+          <div className="flex h-full flex-col gap-2">
+            <p className="text-sm font-medium text-on-surface">Recent</p>
+            {["v0.3.1 published", "installed by @anna", "deps reviewed", "tunnel up 4h"].map((t) => (
+              <p key={t} className="text-xs text-on-surface-variant">{t}</p>
+            ))}
+          </div>
+        </NotchGridItem>
+
+        {/* 4×2 chart with a notch in its top-right corner. */}
+        <NotchGridItem
+          col={0}
+          row={3}
+          shape={[
+            [1, 1, 1, 0],
+            [1, 1, 1, 1],
+          ]}
+        >
+          <div className="flex h-full flex-col">
+            <p className="text-sm font-medium text-on-surface">Usage — last 30 days</p>
+            <div className="mt-2 flex flex-1 items-end gap-1">
+              {[40, 65, 50, 80, 55, 70, 90, 60, 75, 95, 85, 100].map((h, i) => (
+                <div key={i} className="flex-1 rounded-t bg-primary/60" style={{ height: `${h}%` }} />
+              ))}
+            </div>
+          </div>
+        </NotchGridItem>
+        {/* drops into the chart's notch */}
+        <NotchGridItem col={3} row={3} shape={[[1]]}><Tile icon="build" label="Builds" value="312" /></NotchGridItem>
+
+        {/* A component made of a 1×1 + a 2×2 sub-item — `subItems={[[1,1],[2,2]]}`;
+            the two pack into the panel's own L footprint. Theme set once on the panel. */}
+        <NotchGridItem
+          col={4}
+          row={3}
+          fill="var(--color-primary-container)"
+          subItems={[
+            { cost: [1, 1], content: <PrimaryTile icon="schedule" label="Cron" value="6×" /> },
+            { cost: [2, 2], content: <PrimaryTile icon="insights" label="Calls / day" value="128k" /> },
+          ]}
+        />
+      </NotchGrid>
+    </div>
+  ),
+};
+
+/** A component built from sub-items, each with a `[cols, rows]` block cost —
+ *  the panel's notched footprint is the union of where the grid packs them.
+ *  e.g. `subItems={[[1,1],[2,2]]}` → a 1×1 widget beside a 2×2 one. */
+export const SubItemPanels: Story = {
+  args: { cols: 7 },
+  render: (args) => (
+    <div className="bg-background p-6">
+      <NotchGrid {...args}>
+        {/* [[2,2],[1,1]] → a 2×2 chart with a 1×1 stat tucked under it (L-shape).
+            Theme set once on the panel; both sub-items inherit it. */}
+        <NotchGridItem
+          fill="var(--color-primary-container)"
+          stroke="none"
+          subItems={[
+            {
+              cost: [2, 2],
+              content: (
+                <div className="flex h-full flex-col">
+                  <p className="text-sm font-medium text-on-primary-container">Usage</p>
+                  <div className="mt-2 flex flex-1 items-end gap-1">
+                    {[40, 70, 55, 85, 60, 95, 75].map((h, i) => (
+                      <div key={i} className="flex-1 rounded-t bg-on-primary-container/35" style={{ height: `${h}%` }} />
+                    ))}
+                  </div>
+                </div>
+              ),
+            },
+            { cost: [1, 1], content: <PrimaryTile icon="payments" label="Earned" value="$84" /> },
+          ]}
+        />
+        {/* [[1,1],[1,1],[2,1]] → two stat tiles over a wide 2×1 footer. */}
+        <NotchGridItem
+          subItems={[
+            { cost: [1, 1], content: <Tile icon="apps" label="Installs" value="1,240" /> },
+            { cost: [1, 1], content: <Tile icon="new_releases" label="Version" value="v0.3.1" /> },
+            {
+              cost: [2, 1],
+              content: (
+                <div className="flex h-full items-center gap-2">
+                  <Icon name="bolt" size={16} className="text-primary" />
+                  <span className="text-xs text-on-surface-variant">tunnel up · 2.1k req/min · p99 142ms</span>
+                </div>
+              ),
+            },
+          ]}
+        />
+        {/* [[1,2],[1,1],[1,1]] → a tall list beside two stacked tiles. */}
+        <NotchGridItem
+          subItems={[
+            {
+              cost: [1, 2],
+              content: (
+                <div className="flex h-full flex-col gap-1.5">
+                  <p className="text-sm font-medium text-on-surface">Recent</p>
+                  {["v0.3.1 published", "installed by @anna", "deps reviewed", "tunnel up 4h"].map((t) => (
+                    <p key={t} className="text-xs text-on-surface-variant">{t}</p>
+                  ))}
+                </div>
+              ),
+            },
+            { cost: [1, 1], content: <Tile icon="groups" label="Tenants" value="37" /> },
+            { cost: [1, 1], content: <Tile icon="schedule" label="Pending" value="1" /> },
+          ]}
+          subCols={2}
+        />
+      </NotchGrid>
+    </div>
+  ),
+};
+
+/** `draggable` — grab any tile and drop it onto a different block cell; it
+ *  becomes pinned there and the rest re-flow around it (and into its notches). */
+export const Draggable: Story = {
+  args: { cols: 6, draggable: true },
+  render: (args) => (
+    <div className="bg-background p-6">
+      <NotchGrid {...args}>
+        <NotchGridItem
+          shape={[
+            [1, 1, 1],
+            [1, 1, 0],
+          ]}
+          fill="var(--color-primary-container)"
+          stroke="none"
+        >
+          <Tile icon="drag_indicator" label="Drag me" value="hero" />
+        </NotchGridItem>
+        <NotchGridItem shape={[[1]]}><Tile icon="apps" label="Installs" value="1,240" /></NotchGridItem>
+        <NotchGridItem shape={[[1]]}><Tile icon="payments" label="Earned" value="$84" /></NotchGridItem>
+        <NotchGridItem shape={[[1, 1]]}>
+          <div className="flex h-full items-center gap-2">
+            <Icon name="bolt" size={16} className="text-primary" />
+            <span className="text-xs text-on-surface-variant">live · 2.1k req/min</span>
+          </div>
+        </NotchGridItem>
+        <NotchGridItem shape={[[1], [1]]}>
+          <div className="flex h-full flex-col gap-1">
+            <p className="text-sm font-medium text-on-surface">Recent</p>
+            <p className="text-xs text-on-surface-variant">v0.3.1 published</p>
+            <p className="text-xs text-on-surface-variant">installed by @anna</p>
+          </div>
+        </NotchGridItem>
+        <NotchGridItem shape={[[1]]}><Tile icon="calendar_today" label="Created" value="May" /></NotchGridItem>
+      </NotchGrid>
+    </div>
+  ),
+};
+
+/** Items declare candidate `[cols, rows]` block costs — `{ sizes: [...] }` —
+ *  and the grid auto-picks the largest that fits as you drag the width. */
+export const BlockCostSizes: Story = {
+  render: () => (
+    <div className="bg-background p-6">
+      <div
+        className="resize-x overflow-auto rounded-2xl border border-dashed border-outline-variant p-2"
+        style={{ width: 720, minWidth: 220, maxWidth: "100%" }}
+      >
+        <NotchGrid>
+          <NotchGridItem
+            shape={{ sizes: [[1, 1], [2, 2], [3, 2]] }}
+            fill="var(--color-primary-container)"
+            stroke="none"
+          >
+            <Tile icon="dashboard" label="Hero" value="1·1 → 2·2 → 3·2" />
+          </NotchGridItem>
+          <NotchGridItem shape={{ sizes: [[1, 1], [2, 1]] }}>
+            <Tile icon="apps" label="Installs" value="1·1 → 2·1" />
+          </NotchGridItem>
+          <NotchGridItem shape={{ sizes: [[1, 1]] }}>
+            <Tile icon="payments" label="Earned" value="1·1" />
+          </NotchGridItem>
+          <NotchGridItem shape={{ sizes: [[1, 1], [1, 2]] }}>
+            <Tile icon="new_releases" label="Version" value="1·1 → 1·2" />
+          </NotchGridItem>
+          <NotchGridItem shape={{ sizes: [[1, 1], [2, 1]] }}>
+            <Tile icon="history" label="Activity" value="1·1 → 2·1" />
+          </NotchGridItem>
+        </NotchGrid>
+      </div>
+    </div>
+  ),
+};
+

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.test.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.test.tsx
@@ -1,0 +1,128 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { NotchGrid } from "./NotchGrid";
+import { NotchGridItem } from "./NotchGridItem";
+
+afterEach(cleanup);
+
+/** Each placed item is wrapped in `<div class="absolute" style="left/top">`
+ *  (BlockShape's own internal `.absolute` content layer has no `left`). */
+const positioned = (container: HTMLElement) =>
+  [...container.querySelectorAll<HTMLElement>("div.absolute")]
+    .filter((el) => el.style.left !== "")
+    .map((el) => ({ left: el.style.left, top: el.style.top }));
+
+describe("NotchGrid", () => {
+  it("renders one positioned BlockShape per NotchGridItem child", () => {
+    const { container } = render(
+      <NotchGrid cols={2} block={50} gap={0}>
+        <NotchGridItem shape={[[1]]}>a</NotchGridItem>
+        <NotchGridItem shape={[[1]]}>b</NotchGridItem>
+        <NotchGridItem shape={[[1]]}>c</NotchGridItem>
+      </NotchGrid>,
+    );
+    expect(positioned(container)).toEqual([
+      { left: "0px", top: "0px" },
+      { left: "50px", top: "0px" },
+      { left: "0px", top: "50px" }, // wrapped to row 1
+    ]);
+  });
+
+  it("applies `gap` by eroding each item's outline, not by moving items", () => {
+    const grid = (gap: number) =>
+      render(
+        <NotchGrid cols={1} block={100} gap={gap}>
+          <NotchGridItem shape={[[1]]}>x</NotchGridItem>
+        </NotchGrid>,
+      );
+    const path = (c: HTMLElement) =>
+      c.querySelector("svg path[fill]")!.getAttribute("d")!;
+
+    const a = grid(0);
+    const b = grid(20);
+    // Same position + footprint either way…
+    expect(positioned(a.container)).toEqual(positioned(b.container));
+    expect((a.container.querySelector("div.relative") as HTMLElement).style.width).toBe(
+      (b.container.querySelector("div.relative") as HTMLElement).style.width,
+    );
+    // …but the gap=20 outline is the eroded (smaller) one.
+    expect(path(a.container)).not.toBe(path(b.container));
+  });
+
+  it("honours explicit { col, row } placement", () => {
+    const { container } = render(
+      <NotchGrid cols={3} block={40} gap={0}>
+        <NotchGridItem shape={[[1]]} col={2} row={1}>
+          pinned
+        </NotchGridItem>
+        <NotchGridItem shape={[[1]]}>flow</NotchGridItem>
+      </NotchGrid>,
+    );
+    const pos = positioned(container);
+    expect(pos).toContainEqual({ left: "80px", top: "40px" }); // pinned at (2,1)
+    expect(pos).toContainEqual({ left: "0px", top: "0px" }); // flow lands at (0,0)
+  });
+
+  it("sizes the inner grid box to cols×rows blocks", () => {
+    const { container } = render(
+      <NotchGrid cols={2} block={50} gap={0}>
+        <NotchGridItem shape={[[1]]}>a</NotchGridItem>
+        <NotchGridItem shape={[[1]]}>b</NotchGridItem>
+        <NotchGridItem shape={[[1]]}>c</NotchGridItem>
+      </NotchGrid>,
+    );
+    const box = container.querySelector("div.relative") as HTMLElement;
+    expect(box.style.width).toBe("100px"); // 2 cols × 50
+    expect(box.style.height).toBe("100px"); // 2 rows × 50
+  });
+
+  it("accepts items via the `items` prop too", () => {
+    const { container } = render(
+      <NotchGrid cols={4} block={30} items={[{ shape: [[1]] }, { shape: [[1]] }]} />,
+    );
+    expect(positioned(container)).toHaveLength(2);
+  });
+
+  it("renders the content passed to each item", () => {
+    const { getByText } = render(
+      <NotchGrid cols={2}>
+        <NotchGridItem shape={[[1]]}>
+          <span>hello grid</span>
+        </NotchGridItem>
+      </NotchGrid>,
+    );
+    expect(getByText("hello grid")).toBeInTheDocument();
+  });
+
+  it("renders a panel item as positioned sub-item regions", () => {
+    const { container, getByText } = render(
+      <NotchGrid cols={6} block={40}>
+        <NotchGridItem
+          subItems={[
+            { cost: [2, 2], content: <span>big</span> },
+            { cost: [1, 1], content: <span>small</span> },
+          ]}
+        />
+      </NotchGrid>,
+    );
+    expect(getByText("big")).toBeInTheDocument();
+    expect(getByText("small")).toBeInTheDocument();
+    // Aims for a square-ish panel: subCols = max(2, ceil(√5)) = 3 ⇒
+    // 2×2 at (0,0), 1×1 at (col 2, row 0). Sub-wrappers are at panel-relative px.
+    const subPositions = positioned(container).map((p) => `${p.left},${p.top}`);
+    expect(subPositions).toContain("0px,0px"); // 2×2 sub
+    expect(subPositions).toContain("80px,0px"); // 1×1 sub beside it (col 2 × 40)
+  });
+
+  it("resolves a responsive shape to its base variant when width is unmeasured", () => {
+    // jsdom has no ResizeObserver / layout, so width stays 0 ⇒ `base`.
+    const { container } = render(
+      <NotchGrid cols={4} block={20}>
+        <NotchGridItem shape={{ base: [[1]], md: [[1, 1], [1, 1]] }}>x</NotchGridItem>
+      </NotchGrid>,
+    );
+    const box = container.querySelector("div.relative") as HTMLElement;
+    // base = 1×1 ⇒ grid is at least 4 cols wide (the requested colCount) × 1 row.
+    expect(box.style.height).toBe("20px");
+  });
+});

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.test.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.test.tsx
@@ -108,10 +108,11 @@ describe("NotchGrid", () => {
     expect(getByText("big")).toBeInTheDocument();
     expect(getByText("small")).toBeInTheDocument();
     // Aims for a square-ish panel: subCols = max(2, ceil(√5)) = 3 ⇒
-    // 2×2 at (0,0), 1×1 at (col 2, row 0). Sub-wrappers are at panel-relative px.
+    // 2×2 at (0,0), 1×1 at (col 2, row 0). Each sub is inset by `gap/2 = 4px`
+    // so adjacent ones sit `gap` apart and read as bounded rounded rects.
     const subPositions = positioned(container).map((p) => `${p.left},${p.top}`);
-    expect(subPositions).toContain("0px,0px"); // 2×2 sub
-    expect(subPositions).toContain("80px,0px"); // 1×1 sub beside it (col 2 × 40)
+    expect(subPositions).toContain("4px,4px"); // 2×2 sub
+    expect(subPositions).toContain("84px,4px"); // 1×1 sub beside it (col 2 × 40 + 4px inset)
   });
 
   it("resolves a responsive shape to its base variant when width is unmeasured", () => {

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.test.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.test.tsx
@@ -107,12 +107,13 @@ describe("NotchGrid", () => {
     );
     expect(getByText("big")).toBeInTheDocument();
     expect(getByText("small")).toBeInTheDocument();
-    // Aims for a square-ish panel: subCols = max(2, ceil(√5)) = 3 ⇒
-    // 2×2 at (0,0), 1×1 at (col 2, row 0). Each sub is inset by `gap/2 = 4px`
-    // so adjacent ones sit `gap` apart and read as bounded rounded rects.
+    // Aims for a square-ish panel: subCols = max(2, ⌈√(5·1.6)⌉) = 3. The
+    // biggest sub-item packs first (anchors `(0,0)`) and the rest land at
+    // the diagonally opposite cell — 2×2 at `(0,0)`, 1×1 at `(2,2)`.
+    // Each sub is inset by `gap/2 = 4px` for the rounded-square look.
     const subPositions = positioned(container).map((p) => `${p.left},${p.top}`);
-    expect(subPositions).toContain("4px,4px"); // 2×2 sub
-    expect(subPositions).toContain("84px,4px"); // 1×1 sub beside it (col 2 × 40 + 4px inset)
+    expect(subPositions).toContain("4px,4px"); // 2×2 sub at (0,0)
+    expect(subPositions).toContain("84px,84px"); // 1×1 sub at the diagonal corner (2,2)
   });
 
   it("resolves a responsive shape to its base variant when width is unmeasured", () => {

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -1,0 +1,372 @@
+import {
+  Children,
+  isValidElement,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type Key,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
+import type { ComponentMeta } from "@/types/component-meta";
+import { maskCols, maskFromShape, maxTier } from "@/utils/grid-outline";
+import { BlockShape, BLOCK_SIZE } from "./BlockShape";
+import {
+  NOTCH_BREAKPOINTS,
+  rectMatrix,
+  resolveShapeMatrix,
+  type NotchBreakpoints,
+} from "./breakpoints";
+import {
+  optimalPlacement,
+  packItems,
+  placementToMask,
+  rectMask,
+  type LayoutInput,
+} from "./layout";
+import {
+  asSubItem,
+  NotchGridItem,
+  type NotchGridItemProps,
+  type NotchSubItem,
+} from "./NotchGridItem";
+
+export const meta: ComponentMeta = {
+  name: "NotchGrid",
+  description:
+    "Responsive block-aligned layout of notched BlockShapes — measures its width, picks each item's breakpoint shape (or packs its sub-items), and lays them out",
+};
+
+export interface NotchGridProps {
+  /** Fixed column count. Omit to auto-fit `floor(width / block)`. */
+  cols?: number;
+  /** Block edge in px. Default {@link BLOCK_SIZE} (96). */
+  block?: number;
+  /** Gap (px) between items — each item's outline is eroded by `gap / 2`, so
+   *  the spacing is the same whether items sit edge-to-edge or one nestles into
+   *  another's notch. Default 8. */
+  gap?: number;
+  /** Override / extend the Tailwind-style breakpoint thresholds (min container
+   *  width in px) used to resolve each item's responsive `shape`. */
+  breakpoints?: NotchBreakpoints;
+  /** Default corner radius forwarded to every item. */
+  radius?: number;
+  /** Default notch corner radius forwarded to every item. */
+  inverseRadius?: number;
+  fill?: string;
+  stroke?: string;
+  strokeWidth?: number;
+  pad?: number;
+  /** When `true` (default), an item reserves only its *filled* cells, so a
+   *  complementary shape can nestle into another's notch (interlocking layout).
+   *  Set `false` to reserve each item's whole bounding box — boxes never
+   *  overlap, at the cost of notches staying empty. */
+  nest?: boolean;
+  /** Items as data (in addition to / instead of `<NotchGridItem>` children). */
+  items?: NotchGridItemProps[];
+  /** Let the user drag items onto a different block cell. Dropped items become
+   *  pinned and the rest re-flow around them. */
+  draggable?: boolean;
+  /** Called after a drag drops an item, with its new block position. */
+  onItemMove?: (key: Key, col: number, row: number) => void;
+  children?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+/** Clamp a value to a whole block count `>= 1`. */
+const blocks = (n: number) => Math.max(1, Math.floor(n));
+
+interface DragState {
+  key: Key;
+  pointerId: number;
+  startX: number;
+  startY: number;
+  originCol: number;
+  originRow: number;
+  /** The dragged item's footprint width in blocks (to clamp the drop column). */
+  originCols: number;
+  dx: number;
+  dy: number;
+}
+
+/** Measure an element's content-box width (whole px), re-measuring on resize.
+ *  Returns 0 until first layout (and stays 0 where `ResizeObserver` is
+ *  unavailable, e.g. jsdom / SSR — pass `cols` there for a deterministic
+ *  layout). Rounds to an integer and skips no-op updates so sub-pixel layout
+ *  churn doesn't trigger re-renders. */
+function useMeasuredWidth(ref: RefObject<HTMLElement | null>): number {
+  const [width, setWidth] = useState(0);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const read = () => {
+      const w = Math.round(el.getBoundingClientRect().width);
+      setWidth((prev) => (prev === w ? prev : w));
+    };
+    read();
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(read);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [ref]);
+  return width;
+}
+
+interface PlacedSub {
+  sub: NotchSubItem;
+  key: Key;
+  col: number;
+  row: number;
+}
+
+interface ResolvedItem {
+  props: NotchGridItemProps;
+  key: Key;
+  matrix: number[][];
+  tier: number;
+  /** Packed sub-items when this item is a panel; otherwise undefined. */
+  subPlaced?: PlacedSub[];
+}
+
+export function NotchGrid({
+  cols,
+  block = BLOCK_SIZE,
+  gap = 8,
+  breakpoints,
+  radius,
+  inverseRadius,
+  fill,
+  stroke,
+  strokeWidth,
+  pad,
+  nest = true,
+  items,
+  draggable = false,
+  onItemMove,
+  children,
+  className,
+  style,
+}: NotchGridProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const width = useMeasuredWidth(ref);
+  const bps = useMemo(
+    () => (breakpoints ? { ...NOTCH_BREAKPOINTS, ...breakpoints } : NOTCH_BREAKPOINTS),
+    [breakpoints],
+  );
+  // Items sit on a plain `block` lattice; `gap` is applied by eroding each
+  // item's outline, so the column count is just `floor(width / block)`.
+  const colCount = cols ?? Math.max(1, Math.floor(width / block));
+
+  // Drag-to-place: positions the user has dropped items at (pinned), plus the
+  // live drag offset for visual feedback.
+  const [overrides, setOverrides] = useState<Map<Key, { col: number; row: number }>>(new Map());
+  const [drag, setDrag] = useState<DragState | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+  dragRef.current = drag;
+
+  const handlePointerMove = useCallback((e: ReactPointerEvent) => {
+    const d = dragRef.current;
+    if (!d || e.pointerId !== d.pointerId) return;
+    setDrag({ ...d, dx: e.clientX - d.startX, dy: e.clientY - d.startY });
+  }, []);
+
+  const endDrag = useCallback(
+    (e: ReactPointerEvent) => {
+      const d = dragRef.current;
+      if (!d || e.pointerId !== d.pointerId) return;
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        /* pointer may already be released */
+      }
+      const maxCol = Math.max(0, colCount - d.originCols);
+      const nextCol = Math.min(maxCol, Math.max(0, d.originCol + Math.round(d.dx / block)));
+      const nextRow = Math.max(0, d.originRow + Math.round(d.dy / block));
+      setDrag(null);
+      setOverrides((prev) => new Map(prev).set(d.key, { col: nextCol, row: nextRow }));
+      onItemMove?.(d.key, nextCol, nextRow);
+    },
+    [block, colCount, onItemMove],
+  );
+
+  const { placed, gridCols, gridRows } = useMemo(() => {
+    // Gather item configs: `<NotchGridItem>` children, then the `items` prop.
+    const configs: { props: NotchGridItemProps; key: Key }[] = [];
+    Children.forEach(children, (child, i) => {
+      if (isValidElement(child) && child.type === NotchGridItem) {
+        configs.push({ props: child.props as NotchGridItemProps, key: child.key ?? `c${i}` });
+      } else if (isDev && child != null && child !== false) {
+        console.warn("[NotchGrid] children must be <NotchGridItem> — other nodes are ignored");
+      }
+    });
+    (items ?? []).forEach((p, i) => configs.push({ props: p, key: p.key ?? `i${i}` }));
+
+    const resolved: ResolvedItem[] = configs.map(({ props, key }) => {
+      if (props.subItems && props.subItems.length > 0) {
+        const subs = props.subItems.map((s, i) => ({ ...asSubItem(s), _i: i }));
+        const cw = (s: { cost: readonly [number, number] }) => Math.max(1, Math.floor(s.cost[0]));
+        const maxSubW = Math.max(1, ...subs.map(cw));
+        const subInputs: LayoutInput<{ sub: NotchSubItem; key: Key }>[] = subs.map((sub) => ({
+          item: { sub, key: sub.key ?? `s${sub._i}` },
+          mask: rectMask(sub.cost[0], sub.cost[1]),
+          col: sub.col,
+          row: sub.row,
+        }));
+        // When `subCols` is pinned, pack at exactly that width; otherwise search
+        // column counts × orderings for the most compact arrangement.
+        const subPlaced = (
+          props.subCols != null
+            ? packItems(subInputs, props.subCols)
+            : optimalPlacement(subInputs, {
+                maxCols: Math.max(maxSubW, colCount),
+                minCols: maxSubW,
+                targetAspect: props.subAspect,
+              })
+        ).placed;
+        const matrix = placementToMask(subPlaced).map((row) => row.map((b) => (b ? 1 : 0)));
+        return {
+          props,
+          key,
+          matrix,
+          tier: 1,
+          subPlaced: subPlaced.map((p) => ({ sub: p.item.sub, key: p.item.key, col: p.col, row: p.row })),
+        };
+      }
+      const matrix = resolveShapeMatrix(props.shape ?? [[1]], {
+        width,
+        columns: colCount,
+        breakpoints: bps,
+      });
+      return { props, key, matrix, tier: props.tier ?? maxTier(matrix) };
+    });
+
+    const toInput = (r: ResolvedItem): LayoutInput<ResolvedItem> => {
+      const pinned = overrides.get(r.key);
+      return {
+        item: r,
+        // `nest`: reserve only the shape's filled cells (lets others sit in the
+        // notches); otherwise reserve the whole bounding box (no overlaps).
+        mask: nest
+          ? maskFromShape(r.matrix, r.tier)
+          : rectMask(Math.max(1, maskCols(r.matrix)), Math.max(1, r.matrix.length)),
+        col: pinned?.col ?? r.props.col,
+        row: pinned?.row ?? r.props.row,
+      };
+    };
+    // Drag-dropped (overridden) items are packed first so they win their cell;
+    // anything they'd overlap re-flows around them.
+    const inputs: LayoutInput<ResolvedItem>[] = [
+      ...resolved.filter((r) => overrides.has(r.key)).map(toInput),
+      ...resolved.filter((r) => !overrides.has(r.key)).map(toInput),
+    ];
+    const packed = packItems(inputs, colCount);
+    if (isDev && packed.overflowed.length > 0) {
+      console.warn(
+        `[NotchGrid] ${packed.overflowed.length} item(s) have a footprint wider than ${colCount} column(s) — overflowing`,
+      );
+    }
+    return { placed: packed.placed, gridCols: packed.cols, gridRows: packed.rows };
+  }, [children, items, width, colCount, bps, nest, overrides]);
+
+  return (
+    <div ref={ref} className={cn("w-full", className)} style={style}>
+      <div
+        className="relative"
+        style={{ width: gridCols * block, height: gridRows * block }}
+      >
+        {placed.map(({ item, col, row, cols: itemCols }) => {
+          const { props, key, matrix, tier, subPlaced } = item;
+          const itemBlock = props.block ?? block;
+          const dragging = drag?.key === key;
+
+          // A panel's content is its sub-item regions positioned at their cells
+          // (the panel's BlockShape outline is the union of those footprints);
+          // a plain item just renders its own children.
+          const content = subPlaced
+            ? subPlaced.map(({ sub, key: subKey, col: sc, row: sr }) => (
+                <div
+                  key={subKey}
+                  className={cn("absolute overflow-hidden", sub.className)}
+                  style={{
+                    left: sc * itemBlock,
+                    top: sr * itemBlock,
+                    width: blocks(sub.cost[0]) * itemBlock,
+                    height: blocks(sub.cost[1]) * itemBlock,
+                    padding: sub.pad ?? props.pad ?? pad ?? 16,
+                    borderRadius: (sub.radius ?? props.radius ?? radius ?? 24) * 0.75,
+                    background: sub.fill && sub.fill !== "none" ? sub.fill : undefined,
+                    ...sub.style,
+                  }}
+                >
+                  {sub.content}
+                </div>
+              ))
+            : props.children;
+
+          const dragHandlers = draggable
+            ? {
+                onPointerDown: (e: ReactPointerEvent) => {
+                  if (e.button !== 0) return;
+                  e.currentTarget.setPointerCapture(e.pointerId);
+                  setDrag({
+                    key,
+                    pointerId: e.pointerId,
+                    startX: e.clientX,
+                    startY: e.clientY,
+                    originCol: col,
+                    originRow: row,
+                    originCols: itemCols,
+                    dx: 0,
+                    dy: 0,
+                  });
+                },
+                onPointerMove: handlePointerMove,
+                onPointerUp: endDrag,
+                onPointerCancel: endDrag,
+              }
+            : undefined;
+
+          return (
+            <div
+              key={key}
+              {...dragHandlers}
+              className={cn("absolute", draggable && "select-none touch-none")}
+              style={{
+                left: col * block,
+                top: row * block,
+                transform: dragging ? `translate(${drag.dx}px, ${drag.dy}px)` : undefined,
+                zIndex: dragging ? 20 : overrides.has(key) ? 10 : undefined,
+                cursor: draggable ? (dragging ? "grabbing" : "grab") : undefined,
+              }}
+            >
+              <BlockShape
+                shape={matrix}
+                tier={tier}
+                block={itemBlock}
+                gap={gap}
+                radius={props.radius ?? radius}
+                inverseRadius={props.inverseRadius ?? inverseRadius}
+                fill={props.fill ?? fill}
+                stroke={props.stroke ?? stroke}
+                strokeWidth={props.strokeWidth ?? strokeWidth}
+                pad={subPlaced ? 0 : props.pad ?? pad}
+                noClip={subPlaced ? undefined : props.noClip}
+                className={props.className}
+                style={props.style}
+              >
+                {content}
+              </BlockShape>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -16,7 +16,6 @@ import { cn } from "@/utils/cn";
 import { isDev } from "@/utils/env";
 import type { ComponentMeta } from "@/types/component-meta";
 import { maskCols, maskFromShape, maxTier } from "@/utils/grid-outline";
-import { Icon } from "@/components/ui/media/icon/Icon";
 import { BlockShape, BLOCK_SIZE } from "./BlockShape";
 import {
   NOTCH_BREAKPOINTS,
@@ -415,10 +414,14 @@ export function NotchGrid({
                       sub.className,
                     )}
                     style={{
-                      left: sc * itemBlock,
-                      top: sr * itemBlock,
-                      width: blocks(sub.cost[0]) * itemBlock,
-                      height: blocks(sub.cost[1]) * itemBlock,
+                      // Inset by `gap / 2` on all sides so each sub-item is a
+                      // bounded rounded rect — adjacent ones sit `gap` apart and
+                      // the panel's chrome-background shows through, giving the
+                      // user something to grab to drag the whole panel.
+                      left: sc * itemBlock + gap / 2,
+                      top: sr * itemBlock + gap / 2,
+                      width: blocks(sub.cost[0]) * itemBlock - gap,
+                      height: blocks(sub.cost[1]) * itemBlock - gap,
                       padding: sub.pad ?? props.pad ?? pad ?? 16,
                       borderRadius: (sub.radius ?? props.radius ?? radius ?? 24) * 0.75,
                       background: sub.fill && sub.fill !== "none" ? sub.fill : undefined,
@@ -433,60 +436,33 @@ export function NotchGrid({
               })
             : props.children;
 
-          // Whole-item drag handlers — applied to the outer div only when the
-          // item has no sub-items. Panel items get a dedicated handle (below)
-          // so that pointer-down on a sub-item moves the sub-item, not the
-          // panel.
-          const dragHandlers =
-            draggable && !isPanel
-              ? {
-                  onPointerDown: (e: ReactPointerEvent) => {
-                    if (e.button !== 0) return;
-                    e.currentTarget.setPointerCapture(e.pointerId);
-                    setDrag({
-                      key,
-                      pointerId: e.pointerId,
-                      startX: e.clientX,
-                      startY: e.clientY,
-                      originCol: col,
-                      originRow: row,
-                      originCols: itemCols,
-                      dx: 0,
-                      dy: 0,
-                    });
-                  },
-                  onPointerMove: handlePointerMove,
-                  onPointerUp: endDrag,
-                  onPointerCancel: endDrag,
-                }
-              : undefined;
-
-          // Panel-only handle: dedicated drag target so the panel can be moved
-          // even when its sub-items fill it.
-          const panelHandleProps =
-            draggable && isPanel
-              ? {
-                  onPointerDown: (e: ReactPointerEvent<HTMLButtonElement>) => {
-                    if (e.button !== 0) return;
-                    e.stopPropagation();
-                    e.currentTarget.setPointerCapture(e.pointerId);
-                    setDrag({
-                      key,
-                      pointerId: e.pointerId,
-                      startX: e.clientX,
-                      startY: e.clientY,
-                      originCol: col,
-                      originRow: row,
-                      originCols: itemCols,
-                      dx: 0,
-                      dy: 0,
-                    });
-                  },
-                  onPointerMove: handlePointerMove,
-                  onPointerUp: endDrag,
-                  onPointerCancel: endDrag,
-                }
-              : null;
+          // Whole-item drag — for plain items, pointer-down anywhere on the tile
+          // drags it; for panels, pointer-down on the panel's chrome (the gap
+          // regions between sub-items, or any spot not covered by a sub-item)
+          // drags the panel, while pointer-down on a sub-item stops propagation
+          // and starts a sub-item drag instead.
+          const dragHandlers = draggable
+            ? {
+                onPointerDown: (e: ReactPointerEvent) => {
+                  if (e.button !== 0) return;
+                  e.currentTarget.setPointerCapture(e.pointerId);
+                  setDrag({
+                    key,
+                    pointerId: e.pointerId,
+                    startX: e.clientX,
+                    startY: e.clientY,
+                    originCol: col,
+                    originRow: row,
+                    originCols: itemCols,
+                    dx: 0,
+                    dy: 0,
+                  });
+                },
+                onPointerMove: handlePointerMove,
+                onPointerUp: endDrag,
+                onPointerCancel: endDrag,
+              }
+            : undefined;
 
           return (
             <div
@@ -494,8 +470,8 @@ export function NotchGrid({
               {...dragHandlers}
               className={cn(
                 "absolute",
-                draggable && !isPanel && "select-none touch-none",
-                draggable && !isPanel && (dragging ? "cursor-grabbing" : "cursor-grab"),
+                draggable && "select-none touch-none",
+                draggable && (dragging ? "cursor-grabbing" : "cursor-grab"),
               )}
               style={{
                 left: col * block,
@@ -521,19 +497,6 @@ export function NotchGrid({
               >
                 {content}
               </BlockShape>
-              {panelHandleProps && (
-                <button
-                  type="button"
-                  aria-label="Drag panel"
-                  {...panelHandleProps}
-                  className={cn(
-                    "absolute top-1.5 right-1.5 z-10 flex size-6 cursor-grab touch-none items-center justify-center rounded-md bg-surface-container-low/70 text-on-surface-variant opacity-70 transition-opacity hover:bg-surface-container-high hover:opacity-100",
-                    dragging && "cursor-grabbing opacity-100",
-                  )}
-                >
-                  <Icon name="drag_indicator" size={16} />
-                </button>
-              )}
             </div>
           );
         })}

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -395,6 +395,22 @@ export function NotchGrid({
                         if (e.button !== 0) return;
                         e.stopPropagation();
                         e.currentTarget.setPointerCapture(e.pointerId);
+                        // Pin every sibling at its current cell, so dragging
+                        // one sub-item doesn't shuffle the rest (the packer's
+                        // first-fit would otherwise re-flow them as the cell
+                        // under the cursor opens up). Idempotent — siblings
+                        // already in `subOverrides` keep their values.
+                        setSubOverrides((prev) => {
+                          const next = new Map(prev);
+                          const inner = new Map(next.get(key) ?? new Map());
+                          for (const sib of subPlaced!) {
+                            if (sib.key !== subKey && !inner.has(sib.key)) {
+                              inner.set(sib.key, { col: sib.col, row: sib.row });
+                            }
+                          }
+                          next.set(key, inner);
+                          return next;
+                        });
                         setSubDrag({
                           parentKey: key,
                           subKey,

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -642,6 +642,12 @@ export function NotchGrid({
             .map((p) => String(p.item.key))
             .sort()
             .join("|");
+          // Drop the chrome's clip while a sub-item in this component is being
+          // dragged so the cursor-follow visual isn't chopped at the parent's
+          // outline. The in-chrome tile is opacity:0 during the drag so no
+          // visible artifact appears at the cell that was clipping it before.
+          const isDraggingInComp =
+            !!subDrag && comp.some((p) => p.item.key === subDrag.parentKey);
           const isPlainSingleton = comp.length === 1 && !lead.item.subPlaced;
           // Drag handlers for a plain (no-sub-items) outer-grid singleton —
           // wraps the whole tile so pointer-down anywhere on it starts the
@@ -881,7 +887,7 @@ export function NotchGrid({
                 stroke={leadProps.stroke ?? stroke}
                 strokeWidth={leadProps.strokeWidth ?? strokeWidth}
                 pad={isPlainSingleton ? leadProps.pad ?? pad : 0}
-                noClip={isPlainSingleton ? leadProps.noClip : undefined}
+                noClip={isDraggingInComp || (isPlainSingleton ? leadProps.noClip : undefined)}
                 className={isPlainSingleton ? leadProps.className : undefined}
                 style={isPlainSingleton ? leadProps.style : undefined}
               >
@@ -892,6 +898,7 @@ export function NotchGrid({
         })}
         {subDrag && (
           <div
+            key={`ghost:${String(subDrag.parentKey)}/${String(subDrag.subKey)}`}
             aria-hidden
             className="pointer-events-none absolute"
             style={{

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -892,8 +892,12 @@ export function NotchGrid({
                     className={cn(
                       "absolute overflow-hidden transition-colors",
                       draggable && "cursor-grab select-none touch-none",
-                      subBeingDragged && "cursor-grabbing",
-                      subHovered && !subBeingDragged && "bg-on-surface/10",
+                      // Show grabbing on this tile when it's the one being
+                      // dragged *or* when the whole linked component is being
+                      // dragged from its chrome bridge (every member shifts
+                      // together — they should all read as 'in drag').
+                      (subBeingDragged || wrapperDragging) && "cursor-grabbing",
+                      subHovered && !subBeingDragged && !wrapperDragging && "bg-on-surface/10",
                       sub.className,
                     )}
                     style={{
@@ -966,7 +970,9 @@ export function NotchGrid({
                   className={cn(
                     "absolute overflow-hidden transition-[filter] duration-150",
                     draggable && !isPlainSingleton && "cursor-grab select-none touch-none",
-                    draggingThis && "cursor-grabbing",
+                    // Match the sub-item rule: this tile, or the whole
+                    // component (wrapper drag), in active drag → grabbing.
+                    (draggingThis || wrapperDragging) && "cursor-grabbing",
                     // Standalone member tiles have an inline background
                     // (inherited from the parent's `fill` so the cursor-
                     // follow visual stays themed when dragged past the
@@ -974,7 +980,7 @@ export function NotchGrid({
                     // overridden by that inline background, so use a filter
                     // here — same affordance as sub-items, just applied
                     // through brightness instead of an overlay.
-                    memberHovered && !draggingThis && "brightness-95",
+                    memberHovered && !draggingThis && !wrapperDragging && "brightness-95",
                     mProps.className,
                   )}
                   style={{

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/utils/cn";
 import { isDev } from "@/utils/env";
 import type { ComponentMeta } from "@/types/component-meta";
 import { maskCols, maskFromShape, maxTier } from "@/utils/grid-outline";
+import { Icon } from "@/components/ui/media/icon/Icon";
 import { BlockShape, BLOCK_SIZE } from "./BlockShape";
 import {
   NOTCH_BREAKPOINTS,
@@ -75,6 +76,10 @@ export interface NotchGridProps {
   draggable?: boolean;
   /** Called after a drag drops an item, with its new block position. */
   onItemMove?: (key: Key, col: number, row: number) => void;
+  /** Called after a sub-item drag drops on a new sub-grid cell. The panel
+   *  re-packs around the new position; if the move would change the panel's
+   *  notched footprint, neighbouring items in the outer grid re-flow too. */
+  onSubItemMove?: (parentKey: Key, subKey: Key, col: number, row: number) => void;
   children?: ReactNode;
   className?: string;
   style?: CSSProperties;
@@ -92,6 +97,25 @@ interface DragState {
   originRow: number;
   /** The dragged item's footprint width in blocks (to clamp the drop column). */
   originCols: number;
+  dx: number;
+  dy: number;
+}
+
+interface SubDragState {
+  parentKey: Key;
+  subKey: Key;
+  pointerId: number;
+  startX: number;
+  startY: number;
+  originCol: number;
+  originRow: number;
+  /** The sub-item's footprint in sub-grid cells. */
+  cost: readonly [number, number];
+  /** The parent panel's sub-grid extent (cols × rows), captured at drag start. */
+  parentSubCols: number;
+  parentSubRows: number;
+  /** Sub-grid block size in px (so we can convert pointer-px to cells). */
+  itemBlock: number;
   dx: number;
   dy: number;
 }
@@ -150,6 +174,7 @@ export function NotchGrid({
   items,
   draggable = false,
   onItemMove,
+  onSubItemMove,
   children,
   className,
   style,
@@ -196,6 +221,45 @@ export function NotchGrid({
     [block, colCount, onItemMove],
   );
 
+  // Sub-item drag — same shape as panel drag, but inside one panel's sub-grid.
+  const [subOverrides, setSubOverrides] = useState<Map<Key, Map<Key, { col: number; row: number }>>>(new Map());
+  const [subDrag, setSubDrag] = useState<SubDragState | null>(null);
+  const subDragRef = useRef<SubDragState | null>(null);
+  subDragRef.current = subDrag;
+  const [hoveredSub, setHoveredSub] = useState<{ parentKey: Key; subKey: Key } | null>(null);
+
+  const handleSubPointerMove = useCallback((e: ReactPointerEvent) => {
+    const s = subDragRef.current;
+    if (!s || e.pointerId !== s.pointerId) return;
+    setSubDrag({ ...s, dx: e.clientX - s.startX, dy: e.clientY - s.startY });
+  }, []);
+
+  const endSubDrag = useCallback(
+    (e: ReactPointerEvent) => {
+      const s = subDragRef.current;
+      if (!s || e.pointerId !== s.pointerId) return;
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        /* pointer may already be released */
+      }
+      const maxCol = Math.max(0, s.parentSubCols - s.cost[0]);
+      const maxRow = Math.max(0, s.parentSubRows - s.cost[1]);
+      const nextCol = Math.min(maxCol, Math.max(0, s.originCol + Math.round(s.dx / s.itemBlock)));
+      const nextRow = Math.min(maxRow, Math.max(0, s.originRow + Math.round(s.dy / s.itemBlock)));
+      setSubDrag(null);
+      setSubOverrides((prev) => {
+        const next = new Map(prev);
+        const inner = new Map(next.get(s.parentKey) ?? new Map());
+        inner.set(s.subKey, { col: nextCol, row: nextRow });
+        next.set(s.parentKey, inner);
+        return next;
+      });
+      onSubItemMove?.(s.parentKey, s.subKey, nextCol, nextRow);
+    },
+    [onSubItemMove],
+  );
+
   const { placed, gridCols, gridRows } = useMemo(() => {
     // Gather item configs: `<NotchGridItem>` children, then the `items` prop.
     const configs: { props: NotchGridItemProps; key: Key }[] = [];
@@ -213,12 +277,17 @@ export function NotchGrid({
         const subs = props.subItems.map((s, i) => ({ ...asSubItem(s), _i: i }));
         const cw = (s: { cost: readonly [number, number] }) => Math.max(1, Math.floor(s.cost[0]));
         const maxSubW = Math.max(1, ...subs.map(cw));
-        const subInputs: LayoutInput<{ sub: NotchSubItem; key: Key }>[] = subs.map((sub) => ({
-          item: { sub, key: sub.key ?? `s${sub._i}` },
-          mask: rectMask(sub.cost[0], sub.cost[1]),
-          col: sub.col,
-          row: sub.row,
-        }));
+        const subOver = subOverrides.get(key);
+        const subInputs: LayoutInput<{ sub: NotchSubItem; key: Key }>[] = subs.map((sub) => {
+          const subKey = sub.key ?? `s${sub._i}`;
+          const pinned = subOver?.get(subKey);
+          return {
+            item: { sub, key: subKey },
+            mask: rectMask(sub.cost[0], sub.cost[1]),
+            col: pinned?.col ?? sub.col,
+            row: pinned?.row ?? sub.row,
+          };
+        });
         // When `subCols` is pinned, pack at exactly that width; otherwise search
         // column counts × orderings for the most compact arrangement.
         const subPlaced = (
@@ -273,7 +342,7 @@ export function NotchGrid({
       );
     }
     return { placed: packed.placed, gridCols: packed.cols, gridRows: packed.rows };
-  }, [children, items, width, colCount, bps, nest, overrides]);
+  }, [children, items, width, colCount, bps, nest, overrides, subOverrides]);
 
   return (
     <div ref={ref} className={cn("w-full", className)} style={style}>
@@ -285,65 +354,154 @@ export function NotchGrid({
           const { props, key, matrix, tier, subPlaced } = item;
           const itemBlock = props.block ?? block;
           const dragging = drag?.key === key;
+          const isPanel = !!subPlaced;
+          // Panel sub-grid extent — used to clamp sub-item drops.
+          const parentSubCols = isPanel
+            ? Math.max(1, ...subPlaced.map((p) => p.col + Math.max(1, p.sub.cost[0])))
+            : 0;
+          const parentSubRows = isPanel
+            ? Math.max(1, ...subPlaced.map((p) => p.row + Math.max(1, p.sub.cost[1])))
+            : 0;
 
           // A panel's content is its sub-item regions positioned at their cells
           // (the panel's BlockShape outline is the union of those footprints);
           // a plain item just renders its own children.
           const content = subPlaced
-            ? subPlaced.map(({ sub, key: subKey, col: sc, row: sr }) => (
-                <div
-                  key={subKey}
-                  className={cn("absolute overflow-hidden", sub.className)}
-                  style={{
-                    left: sc * itemBlock,
-                    top: sr * itemBlock,
-                    width: blocks(sub.cost[0]) * itemBlock,
-                    height: blocks(sub.cost[1]) * itemBlock,
-                    padding: sub.pad ?? props.pad ?? pad ?? 16,
-                    borderRadius: (sub.radius ?? props.radius ?? radius ?? 24) * 0.75,
-                    background: sub.fill && sub.fill !== "none" ? sub.fill : undefined,
-                    ...sub.style,
-                  }}
-                >
-                  {sub.content}
-                </div>
-              ))
+            ? subPlaced.map(({ sub, key: subKey, col: sc, row: sr }) => {
+                const subBeingDragged = subDrag?.parentKey === key && subDrag.subKey === subKey;
+                const subHovered = hoveredSub?.parentKey === key && hoveredSub.subKey === subKey;
+                const subHandlers = draggable
+                  ? {
+                      onPointerEnter: () => setHoveredSub({ parentKey: key, subKey }),
+                      onPointerLeave: () =>
+                        setHoveredSub((prev) =>
+                          prev?.parentKey === key && prev.subKey === subKey ? null : prev,
+                        ),
+                      onPointerDown: (e: ReactPointerEvent) => {
+                        if (e.button !== 0) return;
+                        e.stopPropagation();
+                        e.currentTarget.setPointerCapture(e.pointerId);
+                        setSubDrag({
+                          parentKey: key,
+                          subKey,
+                          pointerId: e.pointerId,
+                          startX: e.clientX,
+                          startY: e.clientY,
+                          originCol: sc,
+                          originRow: sr,
+                          cost: sub.cost,
+                          parentSubCols,
+                          parentSubRows,
+                          itemBlock,
+                          dx: 0,
+                          dy: 0,
+                        });
+                      },
+                      onPointerMove: handleSubPointerMove,
+                      onPointerUp: endSubDrag,
+                      onPointerCancel: endSubDrag,
+                    }
+                  : undefined;
+                return (
+                  <div
+                    key={subKey}
+                    {...subHandlers}
+                    className={cn(
+                      "absolute overflow-hidden transition-colors",
+                      draggable && "cursor-grab select-none touch-none",
+                      subBeingDragged && "cursor-grabbing",
+                      // Slight tonal lift on hover — sub-item reads as interactive.
+                      subHovered && !subBeingDragged && "bg-on-surface/10",
+                      sub.className,
+                    )}
+                    style={{
+                      left: sc * itemBlock,
+                      top: sr * itemBlock,
+                      width: blocks(sub.cost[0]) * itemBlock,
+                      height: blocks(sub.cost[1]) * itemBlock,
+                      padding: sub.pad ?? props.pad ?? pad ?? 16,
+                      borderRadius: (sub.radius ?? props.radius ?? radius ?? 24) * 0.75,
+                      background: sub.fill && sub.fill !== "none" ? sub.fill : undefined,
+                      transform: subBeingDragged ? `translate(${subDrag.dx}px, ${subDrag.dy}px)` : undefined,
+                      zIndex: subBeingDragged ? 30 : undefined,
+                      ...sub.style,
+                    }}
+                  >
+                    {sub.content}
+                  </div>
+                );
+              })
             : props.children;
 
-          const dragHandlers = draggable
-            ? {
-                onPointerDown: (e: ReactPointerEvent) => {
-                  if (e.button !== 0) return;
-                  e.currentTarget.setPointerCapture(e.pointerId);
-                  setDrag({
-                    key,
-                    pointerId: e.pointerId,
-                    startX: e.clientX,
-                    startY: e.clientY,
-                    originCol: col,
-                    originRow: row,
-                    originCols: itemCols,
-                    dx: 0,
-                    dy: 0,
-                  });
-                },
-                onPointerMove: handlePointerMove,
-                onPointerUp: endDrag,
-                onPointerCancel: endDrag,
-              }
-            : undefined;
+          // Whole-item drag handlers — applied to the outer div only when the
+          // item has no sub-items. Panel items get a dedicated handle (below)
+          // so that pointer-down on a sub-item moves the sub-item, not the
+          // panel.
+          const dragHandlers =
+            draggable && !isPanel
+              ? {
+                  onPointerDown: (e: ReactPointerEvent) => {
+                    if (e.button !== 0) return;
+                    e.currentTarget.setPointerCapture(e.pointerId);
+                    setDrag({
+                      key,
+                      pointerId: e.pointerId,
+                      startX: e.clientX,
+                      startY: e.clientY,
+                      originCol: col,
+                      originRow: row,
+                      originCols: itemCols,
+                      dx: 0,
+                      dy: 0,
+                    });
+                  },
+                  onPointerMove: handlePointerMove,
+                  onPointerUp: endDrag,
+                  onPointerCancel: endDrag,
+                }
+              : undefined;
+
+          // Panel-only handle: dedicated drag target so the panel can be moved
+          // even when its sub-items fill it.
+          const panelHandleProps =
+            draggable && isPanel
+              ? {
+                  onPointerDown: (e: ReactPointerEvent<HTMLButtonElement>) => {
+                    if (e.button !== 0) return;
+                    e.stopPropagation();
+                    e.currentTarget.setPointerCapture(e.pointerId);
+                    setDrag({
+                      key,
+                      pointerId: e.pointerId,
+                      startX: e.clientX,
+                      startY: e.clientY,
+                      originCol: col,
+                      originRow: row,
+                      originCols: itemCols,
+                      dx: 0,
+                      dy: 0,
+                    });
+                  },
+                  onPointerMove: handlePointerMove,
+                  onPointerUp: endDrag,
+                  onPointerCancel: endDrag,
+                }
+              : null;
 
           return (
             <div
               key={key}
               {...dragHandlers}
-              className={cn("absolute", draggable && "select-none touch-none")}
+              className={cn(
+                "absolute",
+                draggable && !isPanel && "select-none touch-none",
+                draggable && !isPanel && (dragging ? "cursor-grabbing" : "cursor-grab"),
+              )}
               style={{
                 left: col * block,
                 top: row * block,
                 transform: dragging ? `translate(${drag.dx}px, ${drag.dy}px)` : undefined,
                 zIndex: dragging ? 20 : overrides.has(key) ? 10 : undefined,
-                cursor: draggable ? (dragging ? "grabbing" : "grab") : undefined,
               }}
             >
               <BlockShape
@@ -363,6 +521,19 @@ export function NotchGrid({
               >
                 {content}
               </BlockShape>
+              {panelHandleProps && (
+                <button
+                  type="button"
+                  aria-label="Drag panel"
+                  {...panelHandleProps}
+                  className={cn(
+                    "absolute top-1.5 right-1.5 z-10 flex size-6 cursor-grab touch-none items-center justify-center rounded-md bg-surface-container-low/70 text-on-surface-variant opacity-70 transition-opacity hover:bg-surface-container-high hover:opacity-100",
+                    dragging && "cursor-grabbing opacity-100",
+                  )}
+                >
+                  <Icon name="drag_indicator" size={16} />
+                </button>
+              )}
             </div>
           );
         })}

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -102,6 +102,10 @@ interface DragState {
 interface SubDragState {
   parentKey: Key;
   subKey: Key;
+  /** The sub-item being dragged (cost, content, etc.) — kept so a drop outside
+   *  the parent panel can promote it to a standalone outer-grid item without
+   *  losing its config. */
+  sub: NotchSubItem;
   pointerId: number;
   startX: number;
   startY: number;
@@ -112,6 +116,13 @@ interface SubDragState {
   /** The parent panel's sub-grid extent (cols × rows), captured at drag start. */
   parentSubCols: number;
   parentSubRows: number;
+  /** The parent panel's outer-grid rect (col, row, cols, rows) captured at
+   *  drag start — used to tell "drop is still inside this panel" from "drop
+   *  went out of the panel ⇒ promote to its own outer-grid item". */
+  parentOuterCol: number;
+  parentOuterRow: number;
+  parentOuterCols: number;
+  parentOuterRows: number;
   /** Sub-grid block size in px (so we can convert pointer-px to cells). */
   itemBlock: number;
   dx: number;
@@ -224,6 +235,13 @@ export function NotchGrid({
   const [subDrag, setSubDrag] = useState<SubDragState | null>(null);
   const subDragRef = useRef<SubDragState | null>(null);
   subDragRef.current = subDrag;
+  // Sub-items the user has dragged *out* of their parent panel. Each entry
+  // turns into a standalone top-level outer-grid item at the given cell, and
+  // is filtered out of its parent's sub-pack.
+  const [promotedSubs, setPromotedSubs] = useState<
+    Map<string, { parentKey: Key; subKey: Key; sub: NotchSubItem; col: number; row: number }>
+  >(new Map());
+  const promoteKey = (parentKey: Key, subKey: Key) => `${String(parentKey)} ${String(subKey)}`;
   const [hoveredSub, setHoveredSub] = useState<{ parentKey: Key; subKey: Key } | null>(null);
 
   /** Snap a drag offset to a sub-grid cell, clamped to the panel's pre-drag
@@ -262,8 +280,40 @@ export function NotchGrid({
       } catch {
         /* pointer may already be released */
       }
-      const { col: nextCol, row: nextRow } = snapDrag(s);
+      // Translate the drop point to an outer-grid cell. If it lands outside
+      // the parent panel's rect, the user dragged the sub-item *out* — promote
+      // it to a standalone outer-grid item there. Otherwise commit a normal
+      // sub-drag (snap inside the panel, update subOverrides).
+      const gridRect = ref.current?.getBoundingClientRect();
+      const dropOuterCol = gridRect
+        ? Math.max(0, Math.floor((e.clientX - gridRect.left) / block))
+        : null;
+      const dropOuterRow = gridRect
+        ? Math.max(0, Math.floor((e.clientY - gridRect.top) / block))
+        : null;
+      const droppedInsidePanel =
+        dropOuterCol != null &&
+        dropOuterRow != null &&
+        dropOuterCol >= s.parentOuterCol &&
+        dropOuterCol < s.parentOuterCol + s.parentOuterCols &&
+        dropOuterRow >= s.parentOuterRow &&
+        dropOuterRow < s.parentOuterRow + s.parentOuterRows;
       setSubDrag(null);
+      if (!droppedInsidePanel && dropOuterCol != null && dropOuterRow != null) {
+        setPromotedSubs((prev) => {
+          const next = new Map(prev);
+          next.set(promoteKey(s.parentKey, s.subKey), {
+            parentKey: s.parentKey,
+            subKey: s.subKey,
+            sub: s.sub,
+            col: dropOuterCol,
+            row: dropOuterRow,
+          });
+          return next;
+        });
+        return;
+      }
+      const { col: nextCol, row: nextRow } = snapDrag(s);
       setSubOverrides((prev) => {
         const next = new Map(prev);
         const inner = new Map(next.get(s.parentKey) ?? new Map());
@@ -273,7 +323,7 @@ export function NotchGrid({
       });
       onSubItemMove?.(s.parentKey, s.subKey, nextCol, nextRow);
     },
-    [onSubItemMove],
+    [block, onSubItemMove],
   );
 
   const { placed, gridCols, gridRows } = useMemo(() => {
@@ -288,9 +338,16 @@ export function NotchGrid({
     });
     (items ?? []).forEach((p, i) => configs.push({ props: p, key: p.key ?? `i${i}` }));
 
-    const resolved: ResolvedItem[] = configs.map(({ props, key }) => {
-      if (props.subItems && props.subItems.length > 0) {
-        const subs = props.subItems.map((s, i) => ({ ...asSubItem(s), _i: i }));
+    const resolved: ResolvedItem[] = [];
+    for (const { props, key } of configs) {
+      // Hide sub-items the user dragged out of this panel — they're rendered
+      // as their own outer-grid items further below instead.
+      const raw = props.subItems?.filter((s, i) => {
+        const k = s.key ?? `s${i}`;
+        return !promotedSubs.has(promoteKey(key, k));
+      });
+      if (raw && raw.length > 0) {
+        const subs = raw.map((s, i) => ({ ...asSubItem(s), _i: i }));
         const cw = (s: { cost: readonly [number, number] }) => Math.max(1, Math.floor(s.cost[0]));
         const maxSubW = Math.max(1, ...subs.map(cw));
         const subOver = subOverrides.get(key);
@@ -344,21 +401,47 @@ export function NotchGrid({
         const subC = Math.max(props.subCols ?? compactCols, maxPinCol);
         const subPlaced = packItems(subInputs, subC, { flowOrder: "farthest-fit" }).placed;
         const matrix = placementToMask(subPlaced).map((row) => row.map((b) => (b ? 1 : 0)));
-        return {
+        resolved.push({
           props,
           key,
           matrix,
           tier: 1,
           subPlaced: subPlaced.map((p) => ({ sub: p.item.sub, key: p.item.key, col: p.col, row: p.row })),
-        };
+        });
+        continue;
       }
+      // Plain item (or panel whose every sub-item was dragged out — render the
+      // empty husk as a 1×1 so the panel still has a key for animations etc.).
+      if (props.subItems && props.subItems.length > 0) continue; // every sub was promoted away — drop the empty husk
       const matrix = resolveShapeMatrix(props.shape ?? [[1]], {
         width,
         columns: colCount,
         breakpoints: bps,
       });
-      return { props, key, matrix, tier: props.tier ?? maxTier(matrix) };
-    });
+      resolved.push({ props, key, matrix, tier: props.tier ?? maxTier(matrix) });
+    }
+    // Promoted sub-items show up as standalone outer-grid items at the cell
+    // the user dropped them on. Their pinned position lives in `promotedSubs`
+    // (not the regular `overrides` map) so they're independent of the parent
+    // panel's drag state.
+    for (const entry of promotedSubs.values()) {
+      const cost = entry.sub.cost;
+      const matrix = rectMatrix(cost[0], cost[1]);
+      resolved.push({
+        props: {
+          shape: matrix,
+          fill: entry.sub.fill,
+          radius: entry.sub.radius,
+          pad: entry.sub.pad,
+          col: entry.col,
+          row: entry.row,
+          children: entry.sub.content,
+        },
+        key: promoteKey(entry.parentKey, entry.subKey),
+        matrix,
+        tier: 1,
+      });
+    }
 
     const toInput = (r: ResolvedItem): LayoutInput<ResolvedItem> => {
       const pinned = overrides.get(r.key);
@@ -388,7 +471,7 @@ export function NotchGrid({
     return { placed: packed.placed, gridCols: packed.cols, gridRows: packed.rows };
     // Primitive `liveSnap` deps — re-pack only when the dragged sub-item's
     // snapped cell changes, not on every sub-pixel pointer-move.
-  }, [children, items, width, colCount, bps, nest, overrides, subOverrides, liveSnap?.parentKey, liveSnap?.subKey, liveSnap?.col, liveSnap?.row]);
+  }, [children, items, width, colCount, bps, nest, overrides, subOverrides, promotedSubs, liveSnap?.parentKey, liveSnap?.subKey, liveSnap?.col, liveSnap?.row]);
 
   return (
     <div ref={ref} className={cn("w-full", className)} style={style}>
@@ -443,6 +526,7 @@ export function NotchGrid({
                         setSubDrag({
                           parentKey: key,
                           subKey,
+                          sub,
                           pointerId: e.pointerId,
                           startX: e.clientX,
                           startY: e.clientY,
@@ -451,6 +535,10 @@ export function NotchGrid({
                           cost: sub.cost,
                           parentSubCols,
                           parentSubRows,
+                          parentOuterCol: col,
+                          parentOuterRow: row,
+                          parentOuterCols: itemCols,
+                          parentOuterRows: matrix.length,
                           itemBlock,
                           dx: 0,
                           dy: 0,

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -340,12 +340,6 @@ export function NotchGrid({
     row: Math.max(0, s.originRow + Math.round(s.dy / s.itemBlock)),
   });
 
-  // Live-preview snap: the cell the dragged sub-item would land in *right now*.
-  // Fed into the layout pipeline so the other sub-items re-flow as the user
-  // drags (instead of waiting for the drop), while the dragged sub-item's own
-  // CSS transform keeps it under the cursor smoothly.
-  const liveSnap = subDrag ? { parentKey: subDrag.parentKey, subKey: subDrag.subKey, ...snapDrag(subDrag) } : null;
-
   const handleSubPointerMove = useCallback((e: ReactPointerEvent) => {
     const s = subDragRef.current;
     if (!s || e.pointerId !== s.pointerId) return;
@@ -492,8 +486,8 @@ export function NotchGrid({
         );
         const targetAspect = props.subAspect ?? 1.6;
         const compactCols = Math.max(maxSubW, Math.ceil(Math.sqrt(totalSubCells * targetAspect)));
-        // Grow the column cap if a pin (drag drop / live preview) sits past
-        // the compact extent, so dragging a sub-item past the panel's current
+        // Grow the column cap if a sub-drag commit pinned a tile past the
+        // compact extent, so dropping a sub-item past the panel's current
         // right edge extends the panel instead of having the packer overflow
         // the pin and re-flow it back inside.
         const maxPinCol = subInputs.reduce((m, i) => {
@@ -504,21 +498,25 @@ export function NotchGrid({
         const subC = Math.max(props.subCols ?? compactCols, maxPinCol);
         const subPlaced = packItems(subInputs, subC, { flowOrder: "farthest-fit" }).placed;
         const matrix = placementToMask(subPlaced).map((row) => row.map((b) => (b ? 1 : 0)));
-        // Natural extent — same pack but ignoring `subOverrides` (within-panel
-        // drag positions). Sub-drags shrink the panel's matrix; the natural
-        // extent is what the chrome *would* be at rest, used as the stable
-        // hit-box for the in-panel vs. promote decision so a "drag up → drag
-        // back" cycle doesn't trip the promote branch on the way back.
-        const naturalInputs: LayoutInput<{ sub: NotchSubItem; key: Key }>[] = ordered.map(
-          (sub) => ({
-            item: { sub, key: sub.key ?? `s${sub._i}` },
-            mask: rectMask(sub.cost[0], sub.cost[1]),
-            col: sub.col,
-            row: sub.row,
-          }),
-        );
-        const naturalSubC = Math.max(props.subCols ?? compactCols, 1);
-        const naturalPlaced = packItems(naturalInputs, naturalSubC, { flowOrder: "farthest-fit" }).placed;
+        // Natural extent — what the chrome would be at rest with no sub-drag
+        // overrides applied. Used as the in-panel hit-box for promote
+        // decisions so a "drag-up → drag-back" cycle stays inside the panel
+        // even when the first drop shrunk the live matrix. Re-pack only when
+        // subOverrides actually pins something; otherwise it'd be identical
+        // to subPlaced.
+        const naturalPlaced =
+          subOver && subOver.size > 0
+            ? packItems(
+                ordered.map((sub) => ({
+                  item: { sub, key: sub.key ?? `s${sub._i}` },
+                  mask: rectMask(sub.cost[0], sub.cost[1]),
+                  col: sub.col,
+                  row: sub.row,
+                })),
+                Math.max(props.subCols ?? compactCols, 1),
+                { flowOrder: "farthest-fit" },
+              ).placed
+            : subPlaced;
         const naturalCols = naturalPlaced.reduce(
           (m, p) => Math.max(m, p.col + p.cols),
           maskCols(matrix),

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -102,10 +102,6 @@ interface DragState {
 interface SubDragState {
   parentKey: Key;
   subKey: Key;
-  /** The sub-item being dragged (cost, content, etc.) — kept so a drop outside
-   *  the parent panel can promote it to a standalone outer-grid item without
-   *  losing its config. */
-  sub: NotchSubItem;
   pointerId: number;
   startX: number;
   startY: number;
@@ -116,13 +112,6 @@ interface SubDragState {
   /** The parent panel's sub-grid extent (cols × rows), captured at drag start. */
   parentSubCols: number;
   parentSubRows: number;
-  /** The parent panel's outer-grid rect (col, row, cols, rows) captured at
-   *  drag start — used to tell "drop is still inside this panel" from "drop
-   *  went out of the panel ⇒ promote to its own outer-grid item". */
-  parentOuterCol: number;
-  parentOuterRow: number;
-  parentOuterCols: number;
-  parentOuterRows: number;
   /** Sub-grid block size in px (so we can convert pointer-px to cells). */
   itemBlock: number;
   dx: number;
@@ -235,13 +224,6 @@ export function NotchGrid({
   const [subDrag, setSubDrag] = useState<SubDragState | null>(null);
   const subDragRef = useRef<SubDragState | null>(null);
   subDragRef.current = subDrag;
-  // Sub-items the user has dragged *out* of their parent panel. Each entry
-  // turns into a standalone top-level outer-grid item at the given cell, and
-  // is filtered out of its parent's sub-pack.
-  const [promotedSubs, setPromotedSubs] = useState<
-    Map<string, { parentKey: Key; subKey: Key; sub: NotchSubItem; col: number; row: number }>
-  >(new Map());
-  const promoteKey = (parentKey: Key, subKey: Key) => `${String(parentKey)} ${String(subKey)}`;
   const [hoveredSub, setHoveredSub] = useState<{ parentKey: Key; subKey: Key } | null>(null);
 
   /** Snap a drag offset to a sub-grid cell, clamped to the panel's pre-drag
@@ -280,40 +262,8 @@ export function NotchGrid({
       } catch {
         /* pointer may already be released */
       }
-      // Translate the drop point to an outer-grid cell. If it lands outside
-      // the parent panel's rect, the user dragged the sub-item *out* — promote
-      // it to a standalone outer-grid item there. Otherwise commit a normal
-      // sub-drag (snap inside the panel, update subOverrides).
-      const gridRect = ref.current?.getBoundingClientRect();
-      const dropOuterCol = gridRect
-        ? Math.max(0, Math.floor((e.clientX - gridRect.left) / block))
-        : null;
-      const dropOuterRow = gridRect
-        ? Math.max(0, Math.floor((e.clientY - gridRect.top) / block))
-        : null;
-      const droppedInsidePanel =
-        dropOuterCol != null &&
-        dropOuterRow != null &&
-        dropOuterCol >= s.parentOuterCol &&
-        dropOuterCol < s.parentOuterCol + s.parentOuterCols &&
-        dropOuterRow >= s.parentOuterRow &&
-        dropOuterRow < s.parentOuterRow + s.parentOuterRows;
-      setSubDrag(null);
-      if (!droppedInsidePanel && dropOuterCol != null && dropOuterRow != null) {
-        setPromotedSubs((prev) => {
-          const next = new Map(prev);
-          next.set(promoteKey(s.parentKey, s.subKey), {
-            parentKey: s.parentKey,
-            subKey: s.subKey,
-            sub: s.sub,
-            col: dropOuterCol,
-            row: dropOuterRow,
-          });
-          return next;
-        });
-        return;
-      }
       const { col: nextCol, row: nextRow } = snapDrag(s);
+      setSubDrag(null);
       setSubOverrides((prev) => {
         const next = new Map(prev);
         const inner = new Map(next.get(s.parentKey) ?? new Map());
@@ -323,7 +273,7 @@ export function NotchGrid({
       });
       onSubItemMove?.(s.parentKey, s.subKey, nextCol, nextRow);
     },
-    [block, onSubItemMove],
+    [onSubItemMove],
   );
 
   const { placed, gridCols, gridRows } = useMemo(() => {
@@ -338,16 +288,9 @@ export function NotchGrid({
     });
     (items ?? []).forEach((p, i) => configs.push({ props: p, key: p.key ?? `i${i}` }));
 
-    const resolved: ResolvedItem[] = [];
-    for (const { props, key } of configs) {
-      // Hide sub-items the user dragged out of this panel — they're rendered
-      // as their own outer-grid items further below instead.
-      const raw = props.subItems?.filter((s, i) => {
-        const k = s.key ?? `s${i}`;
-        return !promotedSubs.has(promoteKey(key, k));
-      });
-      if (raw && raw.length > 0) {
-        const subs = raw.map((s, i) => ({ ...asSubItem(s), _i: i }));
+    const resolved: ResolvedItem[] = configs.map(({ props, key }) => {
+      if (props.subItems && props.subItems.length > 0) {
+        const subs = props.subItems.map((s, i) => ({ ...asSubItem(s), _i: i }));
         const cw = (s: { cost: readonly [number, number] }) => Math.max(1, Math.floor(s.cost[0]));
         const maxSubW = Math.max(1, ...subs.map(cw));
         const subOver = subOverrides.get(key);
@@ -401,47 +344,21 @@ export function NotchGrid({
         const subC = Math.max(props.subCols ?? compactCols, maxPinCol);
         const subPlaced = packItems(subInputs, subC, { flowOrder: "farthest-fit" }).placed;
         const matrix = placementToMask(subPlaced).map((row) => row.map((b) => (b ? 1 : 0)));
-        resolved.push({
+        return {
           props,
           key,
           matrix,
           tier: 1,
           subPlaced: subPlaced.map((p) => ({ sub: p.item.sub, key: p.item.key, col: p.col, row: p.row })),
-        });
-        continue;
+        };
       }
-      // Plain item (or panel whose every sub-item was dragged out — render the
-      // empty husk as a 1×1 so the panel still has a key for animations etc.).
-      if (props.subItems && props.subItems.length > 0) continue; // every sub was promoted away — drop the empty husk
       const matrix = resolveShapeMatrix(props.shape ?? [[1]], {
         width,
         columns: colCount,
         breakpoints: bps,
       });
-      resolved.push({ props, key, matrix, tier: props.tier ?? maxTier(matrix) });
-    }
-    // Promoted sub-items show up as standalone outer-grid items at the cell
-    // the user dropped them on. Their pinned position lives in `promotedSubs`
-    // (not the regular `overrides` map) so they're independent of the parent
-    // panel's drag state.
-    for (const entry of promotedSubs.values()) {
-      const cost = entry.sub.cost;
-      const matrix = rectMatrix(cost[0], cost[1]);
-      resolved.push({
-        props: {
-          shape: matrix,
-          fill: entry.sub.fill,
-          radius: entry.sub.radius,
-          pad: entry.sub.pad,
-          col: entry.col,
-          row: entry.row,
-          children: entry.sub.content,
-        },
-        key: promoteKey(entry.parentKey, entry.subKey),
-        matrix,
-        tier: 1,
-      });
-    }
+      return { props, key, matrix, tier: props.tier ?? maxTier(matrix) };
+    });
 
     const toInput = (r: ResolvedItem): LayoutInput<ResolvedItem> => {
       const pinned = overrides.get(r.key);
@@ -471,7 +388,7 @@ export function NotchGrid({
     return { placed: packed.placed, gridCols: packed.cols, gridRows: packed.rows };
     // Primitive `liveSnap` deps — re-pack only when the dragged sub-item's
     // snapped cell changes, not on every sub-pixel pointer-move.
-  }, [children, items, width, colCount, bps, nest, overrides, subOverrides, promotedSubs, liveSnap?.parentKey, liveSnap?.subKey, liveSnap?.col, liveSnap?.row]);
+  }, [children, items, width, colCount, bps, nest, overrides, subOverrides, liveSnap?.parentKey, liveSnap?.subKey, liveSnap?.col, liveSnap?.row]);
 
   return (
     <div ref={ref} className={cn("w-full", className)} style={style}>
@@ -526,7 +443,6 @@ export function NotchGrid({
                         setSubDrag({
                           parentKey: key,
                           subKey,
-                          sub,
                           pointerId: e.pointerId,
                           startX: e.clientX,
                           startY: e.clientY,
@@ -535,10 +451,6 @@ export function NotchGrid({
                           cost: sub.cost,
                           parentSubCols,
                           parentSubRows,
-                          parentOuterCol: col,
-                          parentOuterRow: row,
-                          parentOuterCols: itemCols,
-                          parentOuterRows: matrix.length,
                           itemBlock,
                           dx: 0,
                           dy: 0,

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -24,7 +24,6 @@ import {
   type NotchBreakpoints,
 } from "./breakpoints";
 import {
-  optimalPlacement,
   packItems,
   placementToMask,
   rectMask,
@@ -287,7 +286,15 @@ export function NotchGrid({
         const cw = (s: { cost: readonly [number, number] }) => Math.max(1, Math.floor(s.cost[0]));
         const maxSubW = Math.max(1, ...subs.map(cw));
         const subOver = subOverrides.get(key);
-        const subInputs: LayoutInput<{ sub: NotchSubItem; key: Key }>[] = subs.map((sub) => {
+        // Pack the biggest sub-item first so it anchors the corner — combined
+        // with `farthest-fit` flow below this puts the small tile at the
+        // diagonally opposite cell instead of having the big tile collapse
+        // next to it. `_packIdx` preserves the original index for stable React
+        // keys (`subPlaced` may end up in pack order, not props order).
+        const ordered = [...subs].sort(
+          (a, b) => b.cost[0] * b.cost[1] - a.cost[0] * a.cost[1] || a._i - b._i,
+        );
+        const subInputs: LayoutInput<{ sub: NotchSubItem; key: Key }>[] = ordered.map((sub) => {
           const subKey = sub.key ?? `s${sub._i}`;
           // Live drag preview wins over the persistent pinned position so the
           // pack reshapes around the dragged sub-item *as* it moves.
@@ -300,33 +307,27 @@ export function NotchGrid({
             row: pinned?.row ?? sub.row,
           };
         });
-        // When *any* sub-item has an explicit position (a drag drop, a live
-        // drag preview, or a user-supplied `col`/`row`), pack with
-        // `farthest-fit` flow so the un-anchored sub-items spread to the cells
-        // furthest from the anchors — i.e. a small tile dropped at one corner
-        // pushes the big tile to the diagonally opposite corner instead of
-        // collapsing into the anchor's column. The cols cap is **the compact
-        // square root of the total area** (with the panel's target aspect) —
-        // a wider cap would let the farthest-fit run away to the far right of
-        // the outer grid instead of landing at the diagonal corner.
-        const anyExplicit = subInputs.some((i) => i.col != null && i.row != null);
+        // Pack into a compact square-ish box (capped at `√(area · aspect)` —
+        // wider would let `farthest-fit` run away to the far right of the
+        // outer grid instead of landing at the diagonal corner) with
+        // `farthest-fit` flow always on, so:
+        //  • the *first* (largest) tile anchors at `(0,0)`,
+        //  • each subsequent tile lands as far from the anchors as it fits,
+        //  • when a tile has an explicit drop position, the rest still arrange
+        //    around it diagonally,
+        //  • pressing a tile (drag-start with no movement) doesn't shift
+        //    anything — its origin = its current cell, so the diagonal
+        //    re-pack is identical to the previous frame.
         const totalSubCells = subs.reduce(
           (n, s) => n + Math.max(1, Math.floor(s.cost[0])) * Math.max(1, Math.floor(s.cost[1])),
           0,
         );
         const targetAspect = props.subAspect ?? 1.6;
         const compactCols = Math.max(maxSubW, Math.ceil(Math.sqrt(totalSubCells * targetAspect)));
-        const subMaxCols = anyExplicit ? compactCols : Math.max(maxSubW, colCount);
-        const subPlaced = (
-          props.subCols != null
-            ? packItems(subInputs, props.subCols, anyExplicit ? { flowOrder: "farthest-fit" } : undefined)
-            : anyExplicit
-              ? packItems(subInputs, subMaxCols, { flowOrder: "farthest-fit" })
-              : optimalPlacement(subInputs, {
-                  maxCols: Math.max(maxSubW, colCount),
-                  minCols: maxSubW,
-                  targetAspect,
-                })
+        const subPlaced = packItems(
+          subInputs,
+          props.subCols ?? compactCols,
+          { flowOrder: "farthest-fit" },
         ).placed;
         const matrix = placementToMask(subPlaced).map((row) => row.map((b) => (b ? 1 : 0)));
         return {

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -228,9 +228,13 @@ export function NotchGrid({
 
   /** Snap a drag offset to a sub-grid cell, clamped to one cell past the
    *  panel's current edge so the drop can grow / reshape the panel. */
+  // The drop position snaps to the nearest sub-grid cell; only the *negative*
+  // side is clamped (a sub-item can't live above / left of the panel's origin).
+  // The drop is *not* capped at the panel's current right / bottom edge — the
+  // sub-pack happily grows to accept a sub-item dropped past it.
   const snapDrag = (s: SubDragState): { col: number; row: number } => ({
-    col: Math.min(Math.max(0, s.parentSubCols), Math.max(0, s.originCol + Math.round(s.dx / s.itemBlock))),
-    row: Math.min(Math.max(0, s.parentSubRows), Math.max(0, s.originRow + Math.round(s.dy / s.itemBlock))),
+    col: Math.max(0, s.originCol + Math.round(s.dx / s.itemBlock)),
+    row: Math.max(0, s.originRow + Math.round(s.dy / s.itemBlock)),
   });
 
   // Live-preview snap: the cell the dragged sub-item would land in *right now*.
@@ -324,11 +328,17 @@ export function NotchGrid({
         );
         const targetAspect = props.subAspect ?? 1.6;
         const compactCols = Math.max(maxSubW, Math.ceil(Math.sqrt(totalSubCells * targetAspect)));
-        const subPlaced = packItems(
-          subInputs,
-          props.subCols ?? compactCols,
-          { flowOrder: "farthest-fit" },
-        ).placed;
+        // Grow the column cap if a pin (drag drop / live preview) sits past
+        // the compact extent, so dragging a sub-item past the panel's current
+        // right edge extends the panel instead of having the packer overflow
+        // the pin and re-flow it back inside.
+        const maxPinCol = subInputs.reduce((m, i) => {
+          if (i.col == null) return m;
+          const w = i.mask[0]?.length ?? 1;
+          return Math.max(m, i.col + w);
+        }, 0);
+        const subC = Math.max(props.subCols ?? compactCols, maxPinCol);
+        const subPlaced = packItems(subInputs, subC, { flowOrder: "farthest-fit" }).placed;
         const matrix = placementToMask(subPlaced).map((row) => row.map((b) => (b ? 1 : 0)));
         return {
           props,

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -906,18 +906,24 @@ export function NotchGrid({
                       width: blocks(sub.cost[0]) * mItemBlock - gap,
                       height: blocks(sub.cost[1]) * mItemBlock - gap,
                       padding: sub.pad ?? mProps.pad ?? pad ?? 16,
-                      // Drag-active visual: tighten the corner radius (0.6
-                      // vs 0.75 at rest) and force a solid background so the
-                      // tile reads as a picked-up card lifted off the chrome
-                      // when the whole linked component is being dragged.
-                      borderRadius:
-                        (sub.radius ?? mProps.radius ?? radius ?? 24) *
-                        (wrapperDragging ? 0.6 : 0.75),
+                      // Drag-active visual: force a solid background and a
+                      // natural 1px outline (matches the default chrome
+                      // stroke color) so the tile reads as a picked-up
+                      // card lifted off the chrome when the whole linked
+                      // component is being dragged.
+                      borderRadius: (sub.radius ?? mProps.radius ?? radius ?? 24) * 0.75,
                       background: wrapperDragging
                         ? sub.fill ?? mProps.fill ?? fill
                         : sub.fill && sub.fill !== "none"
                         ? sub.fill
                         : undefined,
+                      // `outline` (not `border`) so the ring doesn't change
+                      // the tile's intrinsic width / height — nothing
+                      // reflows when the state toggles.
+                      outline: wrapperDragging
+                        ? "1px solid var(--color-outline-variant)"
+                        : undefined,
+                      outlineOffset: wrapperDragging ? "-1px" : undefined,
                       // Hide the in-chrome tile during the drag — the ghost
                       // overlay (rendered as a sibling of the grid below)
                       // tracks the cursor with the rounded filled preview.
@@ -999,19 +1005,21 @@ export function NotchGrid({
                     width: maskCols(mMatrix) * mItemBlock - gap,
                     height: mMatrix.length * mItemBlock - gap,
                     padding: mProps.pad ?? pad ?? 16,
-                    // Drag-active visual: tighter corner radius (0.6 vs
-                    // 0.75 at rest) so a picked-up tile reads as a lifted
-                    // card. Applies whether this tile is the one being
-                    // outer-dragged or the whole linked component is.
-                    borderRadius:
-                      (mProps.radius ?? radius ?? 24) *
-                      (draggingThis || wrapperDragging ? 0.6 : 0.75),
+                    borderRadius: (mProps.radius ?? radius ?? 24) * 0.75,
                     // Same fill as the chrome behind it — invisible at rest
                     // (they overlap exactly), but the moment the member is
                     // outer-dragged its transform takes it past the chrome
                     // and this background keeps the rounded teal preview.
                     background:
                       mProps.fill && mProps.fill !== "none" ? mProps.fill : undefined,
+                    // Drag-active visual: a natural 1px outline (matches the
+                    // chrome's default stroke color) so a picked-up tile
+                    // reads as a lifted card.
+                    outline:
+                      draggingThis || wrapperDragging
+                        ? "1px solid var(--color-outline-variant)"
+                        : undefined,
+                    outlineOffset: draggingThis || wrapperDragging ? "-1px" : undefined,
                     transform: draggingThis && drag
                       ? `translate(${drag.dx}px, ${drag.dy}px)`
                       : undefined,
@@ -1095,10 +1103,12 @@ export function NotchGrid({
                 gap / 2,
               width: blocks(subDrag.cost[0]) * subDrag.itemBlock - gap,
               height: blocks(subDrag.cost[1]) * subDrag.itemBlock - gap,
-              // Tighter radius than at-rest (`* 0.75`) matches the drag-
-              // active visual the other tile paths use during a wrapper
-              // drag, so the cursor-follow ghost reads consistently.
-              borderRadius: subDrag.ghostRadius * 0.6,
+              // Same rest radius and a natural 1px outline as the other
+              // drag-active paths so the cursor-follow ghost reads as the
+              // same picked-up card visual.
+              borderRadius: subDrag.ghostRadius * 0.75,
+              outline: "1px solid var(--color-outline-variant)",
+              outlineOffset: "-1px",
               background:
                 subDrag.ghostFill && subDrag.ghostFill !== "none"
                   ? subDrag.ghostFill

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -300,16 +300,33 @@ export function NotchGrid({
             row: pinned?.row ?? sub.row,
           };
         });
-        // When `subCols` is pinned, pack at exactly that width; otherwise search
-        // column counts × orderings for the most compact arrangement.
+        // When *any* sub-item has an explicit position (a drag drop, a live
+        // drag preview, or a user-supplied `col`/`row`), pack with
+        // `farthest-fit` flow so the un-anchored sub-items spread to the cells
+        // furthest from the anchors — i.e. a small tile dropped at one corner
+        // pushes the big tile to the diagonally opposite corner instead of
+        // collapsing into the anchor's column. The cols cap is **the compact
+        // square root of the total area** (with the panel's target aspect) —
+        // a wider cap would let the farthest-fit run away to the far right of
+        // the outer grid instead of landing at the diagonal corner.
+        const anyExplicit = subInputs.some((i) => i.col != null && i.row != null);
+        const totalSubCells = subs.reduce(
+          (n, s) => n + Math.max(1, Math.floor(s.cost[0])) * Math.max(1, Math.floor(s.cost[1])),
+          0,
+        );
+        const targetAspect = props.subAspect ?? 1.6;
+        const compactCols = Math.max(maxSubW, Math.ceil(Math.sqrt(totalSubCells * targetAspect)));
+        const subMaxCols = anyExplicit ? compactCols : Math.max(maxSubW, colCount);
         const subPlaced = (
           props.subCols != null
-            ? packItems(subInputs, props.subCols)
-            : optimalPlacement(subInputs, {
-                maxCols: Math.max(maxSubW, colCount),
-                minCols: maxSubW,
-                targetAspect: props.subAspect,
-              })
+            ? packItems(subInputs, props.subCols, anyExplicit ? { flowOrder: "farthest-fit" } : undefined)
+            : anyExplicit
+              ? packItems(subInputs, subMaxCols, { flowOrder: "farthest-fit" })
+              : optimalPlacement(subInputs, {
+                  maxCols: Math.max(maxSubW, colCount),
+                  minCols: maxSubW,
+                  targetAspect,
+                })
         ).placed;
         const matrix = placementToMask(subPlaced).map((row) => row.map((b) => (b ? 1 : 0)));
         return {
@@ -395,22 +412,6 @@ export function NotchGrid({
                         if (e.button !== 0) return;
                         e.stopPropagation();
                         e.currentTarget.setPointerCapture(e.pointerId);
-                        // Pin every sibling at its current cell, so dragging
-                        // one sub-item doesn't shuffle the rest (the packer's
-                        // first-fit would otherwise re-flow them as the cell
-                        // under the cursor opens up). Idempotent — siblings
-                        // already in `subOverrides` keep their values.
-                        setSubOverrides((prev) => {
-                          const next = new Map(prev);
-                          const inner = new Map(next.get(key) ?? new Map());
-                          for (const sib of subPlaced!) {
-                            if (sib.key !== subKey && !inner.has(sib.key)) {
-                              inner.set(sib.key, { col: sib.col, row: sib.row });
-                            }
-                          }
-                          next.set(key, inner);
-                          return next;
-                        });
                         setSubDrag({
                           parentKey: key,
                           subKey,

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -906,8 +906,18 @@ export function NotchGrid({
                       width: blocks(sub.cost[0]) * mItemBlock - gap,
                       height: blocks(sub.cost[1]) * mItemBlock - gap,
                       padding: sub.pad ?? mProps.pad ?? pad ?? 16,
-                      borderRadius: (sub.radius ?? mProps.radius ?? radius ?? 24) * 0.75,
-                      background: sub.fill && sub.fill !== "none" ? sub.fill : undefined,
+                      // Drag-active visual: tighten the corner radius (0.5
+                      // vs 0.75 at rest) and force a solid background so the
+                      // tile reads as a picked-up card lifted off the chrome
+                      // when the whole linked component is being dragged.
+                      borderRadius:
+                        (sub.radius ?? mProps.radius ?? radius ?? 24) *
+                        (wrapperDragging ? 0.5 : 0.75),
+                      background: wrapperDragging
+                        ? sub.fill ?? mProps.fill ?? fill
+                        : sub.fill && sub.fill !== "none"
+                        ? sub.fill
+                        : undefined,
                       // Hide the in-chrome tile during the drag — the ghost
                       // overlay (rendered as a sibling of the grid below)
                       // tracks the cursor with the rounded filled preview.
@@ -989,7 +999,13 @@ export function NotchGrid({
                     width: maskCols(mMatrix) * mItemBlock - gap,
                     height: mMatrix.length * mItemBlock - gap,
                     padding: mProps.pad ?? pad ?? 16,
-                    borderRadius: (mProps.radius ?? radius ?? 24) * 0.75,
+                    // Drag-active visual: tighter corner radius (0.5 vs
+                    // 0.75 at rest) so a picked-up tile reads as a lifted
+                    // card. Applies whether this tile is the one being
+                    // outer-dragged or the whole linked component is.
+                    borderRadius:
+                      (mProps.radius ?? radius ?? 24) *
+                      (draggingThis || wrapperDragging ? 0.5 : 0.75),
                     // Same fill as the chrome behind it — invisible at rest
                     // (they overlap exactly), but the moment the member is
                     // outer-dragged its transform takes it past the chrome
@@ -1079,7 +1095,10 @@ export function NotchGrid({
                 gap / 2,
               width: blocks(subDrag.cost[0]) * subDrag.itemBlock - gap,
               height: blocks(subDrag.cost[1]) * subDrag.itemBlock - gap,
-              borderRadius: subDrag.ghostRadius * 0.75,
+              // Tighter radius than at-rest (`* 0.75`) matches the drag-
+              // active visual the other tile paths use during a wrapper
+              // drag, so the cursor-follow ghost reads consistently.
+              borderRadius: subDrag.ghostRadius * 0.5,
               background:
                 subDrag.ghostFill && subDrag.ghostFill !== "none"
                   ? subDrag.ghostFill

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -86,6 +86,70 @@ export interface NotchGridProps {
 /** Clamp a value to a whole block count `>= 1`. */
 const blocks = (n: number) => Math.max(1, Math.floor(n));
 
+type Cell = readonly [number, number];
+
+/** Outer-grid cells filled by a placed item — used for adjacency-based grouping
+ *  at render time so two same-`groupKey` tiles that end up next to each other
+ *  (edge or corner) get their chromes unioned into one shape. */
+function itemFilledCells(p: {
+  item: { matrix: number[][]; tier: number };
+  col: number;
+  row: number;
+}): Cell[] {
+  const out: Cell[] = [];
+  const m = p.item.matrix;
+  const tier = p.item.tier;
+  for (let r = 0; r < m.length; r++) {
+    const row = m[r] ?? [];
+    for (let c = 0; c < row.length; c++) {
+      const v = row[c];
+      if (v >= 1 && v <= tier) out.push([p.col + c, p.row + r]);
+    }
+  }
+  return out;
+}
+
+/** Group same-bucket placed items into 8-connected components — two items
+ *  belong to the same component if any of one's filled cells is within 1 row /
+ *  column of any of the other's (so corner-touching counts, just like the
+ *  grid-outline tracer's diagonal-junction handling). */
+function findConnectedComponents<T extends { col: number; row: number; cols: number; rows: number; item: { matrix: number[][]; tier: number } }>(
+  items: T[],
+): T[][] {
+  if (items.length <= 1) return items.length ? [items] : [];
+  const cells = items.map(itemFilledCells);
+  const visited = new Array<boolean>(items.length).fill(false);
+  const out: T[][] = [];
+  for (let s = 0; s < items.length; s++) {
+    if (visited[s]) continue;
+    visited[s] = true;
+    const queue = [s];
+    const comp: T[] = [];
+    while (queue.length) {
+      const i = queue.shift()!;
+      comp.push(items[i]);
+      for (let j = 0; j < items.length; j++) {
+        if (visited[j]) continue;
+        let adj = false;
+        outer: for (const [ax, ay] of cells[i]) {
+          for (const [bx, by] of cells[j]) {
+            if (Math.abs(ax - bx) <= 1 && Math.abs(ay - by) <= 1) {
+              adj = true;
+              break outer;
+            }
+          }
+        }
+        if (adj) {
+          visited[j] = true;
+          queue.push(j);
+        }
+      }
+    }
+    out.push(comp);
+  }
+  return out;
+}
+
 interface DragState {
   key: Key;
   pointerId: number;
@@ -102,6 +166,9 @@ interface DragState {
 interface SubDragState {
   parentKey: Key;
   subKey: Key;
+  /** Snapshot of the sub-item (cost, content, theme) so a drop outside the
+   *  parent panel can promote it to a standalone same-themed tile. */
+  sub: NotchSubItem;
   pointerId: number;
   startX: number;
   startY: number;
@@ -112,6 +179,12 @@ interface SubDragState {
   /** The parent panel's sub-grid extent (cols × rows), captured at drag start. */
   parentSubCols: number;
   parentSubRows: number;
+  /** The parent panel's outer-grid rect, captured at drag start — drops past
+   *  this rect promote the sub to a standalone same-group outer-grid tile. */
+  parentOuterCol: number;
+  parentOuterRow: number;
+  parentOuterCols: number;
+  parentOuterRows: number;
   /** Sub-grid block size in px (so we can convert pointer-px to cells). */
   itemBlock: number;
   dx: number;
@@ -155,6 +228,12 @@ interface ResolvedItem {
   tier: number;
   /** Packed sub-items when this item is a panel; otherwise undefined. */
   subPlaced?: PlacedSub[];
+  /** Adjacent same-`groupKey` placed items render unioned into one chrome.
+   *  Sub-items from a {@link NotchGridItemProps.subItems} panel automatically
+   *  share their parent's key as group; promoted (dragged-out) sub-items
+   *  keep the same group so they can re-link when dragged back beside the
+   *  rest. */
+  groupKey?: Key;
 }
 
 export function NotchGrid({
@@ -224,6 +303,15 @@ export function NotchGrid({
   const [subDrag, setSubDrag] = useState<SubDragState | null>(null);
   const subDragRef = useRef<SubDragState | null>(null);
   subDragRef.current = subDrag;
+  // Sub-items the user dragged *out* of their parent panel. Each entry renders
+  // as a standalone same-themed top-level outer-grid tile at the dropped cell,
+  // and is removed from the parent's sub-pack. Linking back happens at render
+  // time — promoted tiles share `groupKey = parentKey`, and the grid unions
+  // adjacent same-group tiles into one chrome.
+  const [promotedSubs, setPromotedSubs] = useState<
+    Map<string, { parentKey: Key; subKey: Key; sub: NotchSubItem; col: number; row: number }>
+  >(new Map());
+  const promoteKey = (parentKey: Key, subKey: Key) => `${String(parentKey)} ${String(subKey)}`;
   const [hoveredSub, setHoveredSub] = useState<{ parentKey: Key; subKey: Key } | null>(null);
 
   /** Snap a drag offset to a sub-grid cell, clamped to the panel's pre-drag
@@ -262,8 +350,40 @@ export function NotchGrid({
       } catch {
         /* pointer may already be released */
       }
-      const { col: nextCol, row: nextRow } = snapDrag(s);
+      // Translate the drop point to an outer-grid cell. If the cursor left the
+      // parent panel's rect, the user dragged the sub *out* — promote it to a
+      // standalone same-themed tile at that outer cell (adjacent tiles in the
+      // same group re-link at render time). Otherwise commit a normal sub-drag.
+      const gridRect = ref.current?.getBoundingClientRect();
+      const dropOuterCol = gridRect
+        ? Math.max(0, Math.floor((e.clientX - gridRect.left) / block))
+        : null;
+      const dropOuterRow = gridRect
+        ? Math.max(0, Math.floor((e.clientY - gridRect.top) / block))
+        : null;
+      const droppedInsidePanel =
+        dropOuterCol != null &&
+        dropOuterRow != null &&
+        dropOuterCol >= s.parentOuterCol &&
+        dropOuterCol < s.parentOuterCol + s.parentOuterCols &&
+        dropOuterRow >= s.parentOuterRow &&
+        dropOuterRow < s.parentOuterRow + s.parentOuterRows;
       setSubDrag(null);
+      if (!droppedInsidePanel && dropOuterCol != null && dropOuterRow != null) {
+        setPromotedSubs((prev) => {
+          const next = new Map(prev);
+          next.set(promoteKey(s.parentKey, s.subKey), {
+            parentKey: s.parentKey,
+            subKey: s.subKey,
+            sub: s.sub,
+            col: dropOuterCol,
+            row: dropOuterRow,
+          });
+          return next;
+        });
+        return;
+      }
+      const { col: nextCol, row: nextRow } = snapDrag(s);
       setSubOverrides((prev) => {
         const next = new Map(prev);
         const inner = new Map(next.get(s.parentKey) ?? new Map());
@@ -273,7 +393,7 @@ export function NotchGrid({
       });
       onSubItemMove?.(s.parentKey, s.subKey, nextCol, nextRow);
     },
-    [onSubItemMove],
+    [block, onSubItemMove],
   );
 
   const { placed, gridCols, gridRows } = useMemo(() => {
@@ -288,9 +408,16 @@ export function NotchGrid({
     });
     (items ?? []).forEach((p, i) => configs.push({ props: p, key: p.key ?? `i${i}` }));
 
-    const resolved: ResolvedItem[] = configs.map(({ props, key }) => {
-      if (props.subItems && props.subItems.length > 0) {
-        const subs = props.subItems.map((s, i) => ({ ...asSubItem(s), _i: i }));
+    const resolved: ResolvedItem[] = [];
+    for (const { props, key } of configs) {
+      // Sub-items the user has dragged out of *this* panel — they're rendered
+      // below as their own same-group outer-grid tiles, not inside the panel.
+      const raw = props.subItems?.filter((s, i) => {
+        const k = s.key ?? `s${i}`;
+        return !promotedSubs.has(promoteKey(key, k));
+      });
+      if (raw && raw.length > 0) {
+        const subs = raw.map((s, i) => ({ ...asSubItem(s), _i: i }));
         const cw = (s: { cost: readonly [number, number] }) => Math.max(1, Math.floor(s.cost[0]));
         const maxSubW = Math.max(1, ...subs.map(cw));
         const subOver = subOverrides.get(key);
@@ -344,21 +471,63 @@ export function NotchGrid({
         const subC = Math.max(props.subCols ?? compactCols, maxPinCol);
         const subPlaced = packItems(subInputs, subC, { flowOrder: "farthest-fit" }).placed;
         const matrix = placementToMask(subPlaced).map((row) => row.map((b) => (b ? 1 : 0)));
-        return {
+        resolved.push({
           props,
           key,
           matrix,
           tier: 1,
           subPlaced: subPlaced.map((p) => ({ sub: p.item.sub, key: p.item.key, col: p.col, row: p.row })),
-        };
+          groupKey: props.groupKey ?? key,
+        });
+        continue;
       }
+      // Plain item (or a panel whose every sub-item was dragged out — skip the
+      // empty husk, the promoted children below will represent the group).
+      if (props.subItems && props.subItems.length > 0) continue;
       const matrix = resolveShapeMatrix(props.shape ?? [[1]], {
         width,
         columns: colCount,
         breakpoints: bps,
       });
-      return { props, key, matrix, tier: props.tier ?? maxTier(matrix) };
-    });
+      resolved.push({
+        props,
+        key,
+        matrix,
+        tier: props.tier ?? maxTier(matrix),
+        groupKey: props.groupKey,
+      });
+    }
+    // Promoted sub-items become standalone outer-grid tiles at the dropped
+    // cell. They inherit the parent panel's theme so a Cron tile dragged out
+    // of a primary-container panel still reads as part of that family, and
+    // share `groupKey = parent-key` so adjacent ones re-link at render time.
+    for (const entry of promotedSubs.values()) {
+      const parentConfig = configs.find((c) => c.key === entry.parentKey);
+      const parentProps: NotchGridItemProps = parentConfig?.props ?? {};
+      const cost = entry.sub.cost;
+      const matrix = rectMatrix(cost[0], cost[1]);
+      resolved.push({
+        props: {
+          shape: matrix,
+          fill: entry.sub.fill ?? parentProps.fill,
+          stroke: entry.sub.stroke ?? parentProps.stroke,
+          strokeWidth: entry.sub.strokeWidth ?? parentProps.strokeWidth,
+          radius: entry.sub.radius ?? parentProps.radius,
+          inverseRadius: entry.sub.inverseRadius ?? parentProps.inverseRadius,
+          pad: entry.sub.pad ?? parentProps.pad,
+          noClip: entry.sub.noClip,
+          className: entry.sub.className,
+          style: entry.sub.style,
+          col: entry.col,
+          row: entry.row,
+          children: entry.sub.content,
+        },
+        key: promoteKey(entry.parentKey, entry.subKey),
+        matrix,
+        tier: 1,
+        groupKey: parentProps.groupKey ?? entry.parentKey,
+      });
+    }
 
     const toInput = (r: ResolvedItem): LayoutInput<ResolvedItem> => {
       const pinned = overrides.get(r.key);
@@ -388,7 +557,31 @@ export function NotchGrid({
     return { placed: packed.placed, gridCols: packed.cols, gridRows: packed.rows };
     // Primitive `liveSnap` deps — re-pack only when the dragged sub-item's
     // snapped cell changes, not on every sub-pixel pointer-move.
-  }, [children, items, width, colCount, bps, nest, overrides, subOverrides, liveSnap?.parentKey, liveSnap?.subKey, liveSnap?.col, liveSnap?.row]);
+  }, [children, items, width, colCount, bps, nest, overrides, subOverrides, promotedSubs, liveSnap?.parentKey, liveSnap?.subKey, liveSnap?.col, liveSnap?.row]);
+
+  // Bucket placed items by `groupKey` (singletons get a unique bucket so they
+  // never accidentally merge with anything). Within each bucket, find 8-
+  // connected components — a component is a set of placed items where every
+  // member is reachable via edge- or corner-adjacent cells — so two adjacent
+  // tiles in the same group render as one unioned chrome, while group members
+  // dragged far apart render as separate same-themed tiles.
+  const components = useMemo(() => {
+    const buckets = new Map<string, typeof placed>();
+    placed.forEach((p, i) => {
+      const gk =
+        p.item.groupKey != null
+          ? `g:${String(p.item.groupKey)}`
+          : `s:${i}:${String(p.item.key)}`;
+      const list = buckets.get(gk);
+      if (list) list.push(p);
+      else buckets.set(gk, [p]);
+    });
+    const out: typeof placed[] = [];
+    for (const members of buckets.values()) {
+      for (const comp of findConnectedComponents(members)) out.push(comp);
+    }
+    return out;
+  }, [placed]);
 
   return (
     <div ref={ref} className={cn("w-full", className)} style={style}>
@@ -396,53 +589,126 @@ export function NotchGrid({
         className="relative"
         style={{ width: gridCols * block, height: gridRows * block }}
       >
-        {placed.map(({ item, col, row, cols: itemCols }) => {
-          const { props, key, matrix, tier, subPlaced } = item;
-          const itemBlock = props.block ?? block;
-          const dragging = drag?.key === key;
-          const isPanel = !!subPlaced;
-          // Panel sub-grid extent — used to clamp sub-item drops.
-          const parentSubCols = isPanel
-            ? Math.max(1, ...subPlaced.map((p) => p.col + Math.max(1, p.sub.cost[0])))
-            : 0;
-          const parentSubRows = isPanel
-            ? Math.max(1, ...subPlaced.map((p) => p.row + Math.max(1, p.sub.cost[1])))
-            : 0;
-
-          // A panel's content is its sub-item regions positioned at their cells
-          // (the panel's BlockShape outline is the union of those footprints);
-          // a plain item just renders its own children.
-          const content = subPlaced
-            ? subPlaced.map(({ sub, key: subKey, col: sc, row: sr }) => {
-                const subBeingDragged = subDrag?.parentKey === key && subDrag.subKey === subKey;
-                const subHovered = hoveredSub?.parentKey === key && hoveredSub.subKey === subKey;
+        {components.map((comp) => {
+          // Bounding box of the component in outer-grid cells — the wrapper
+          // sits here and the union mask is built relative to it.
+          let minCol = Infinity,
+            minRow = Infinity,
+            maxCol = 0,
+            maxRow = 0;
+          for (const p of comp) {
+            minCol = Math.min(minCol, p.col);
+            minRow = Math.min(minRow, p.row);
+            maxCol = Math.max(maxCol, p.col + p.cols);
+            maxRow = Math.max(maxRow, p.row + p.rows);
+          }
+          const groupCols = Math.max(1, maxCol - minCol);
+          const groupRows = Math.max(1, maxRow - minRow);
+          // Union mask: union of each member's filled cells at their bounding-
+          // box-relative position. Same `BlockShape` outline tracer as before;
+          // it already handles edge AND corner-touching with the inverse-
+          // radius bridge.
+          const unionMask: number[][] = Array.from({ length: groupRows }, () =>
+            new Array<number>(groupCols).fill(0),
+          );
+          for (const p of comp) {
+            const m = p.item.matrix;
+            for (let r = 0; r < m.length; r++) {
+              const mr = m[r] ?? [];
+              for (let c = 0; c < mr.length; c++) {
+                const v = mr[c];
+                if (v >= 1 && v <= p.item.tier) {
+                  unionMask[p.row - minRow + r][p.col - minCol + c] = 1;
+                }
+              }
+            }
+          }
+          // Theme is taken from the lead member (the first placed entry in the
+          // component) — same-group tiles share their parent's theme by
+          // construction so this just propagates it to the unioned chrome.
+          const lead = comp[0];
+          const leadProps = lead.item.props;
+          const compKey = comp
+            .map((p) => String(p.item.key))
+            .sort()
+            .join("|");
+          const isPlainSingleton = comp.length === 1 && !lead.item.subPlaced;
+          // Drag handlers for a plain (no-sub-items) outer-grid singleton —
+          // wraps the whole tile so pointer-down anywhere on it starts the
+          // drag. Panels (with sub-items) leave the chrome plain and let each
+          // sub-item carry its own drag handler below.
+          const singletonDrag =
+            isPlainSingleton && draggable
+              ? {
+                  onPointerDown: (e: ReactPointerEvent) => {
+                    if (e.button !== 0) return;
+                    e.currentTarget.setPointerCapture(e.pointerId);
+                    setDrag({
+                      key: lead.item.key,
+                      pointerId: e.pointerId,
+                      startX: e.clientX,
+                      startY: e.clientY,
+                      originCol: lead.col,
+                      originRow: lead.row,
+                      originCols: lead.cols,
+                      dx: 0,
+                      dy: 0,
+                    });
+                  },
+                  onPointerMove: handlePointerMove,
+                  onPointerUp: endDrag,
+                  onPointerCancel: endDrag,
+                }
+              : undefined;
+          const singletonDragging = isPlainSingleton && drag?.key === lead.item.key;
+          // Each member of the component contributes its tile(s) — sub-items
+          // (with their own sub-drag handlers, which promote out of the panel
+          // when the drop leaves the parent rect) for a panel, or the whole
+          // content (with outer-drag handlers) for a standalone item.
+          const tiles: ReactNode[] = [];
+          for (const p of comp) {
+            const { props: mProps, key: mKey, matrix: mMatrix, subPlaced } = p.item;
+            const mItemBlock = mProps.block ?? block;
+            if (subPlaced) {
+              // Panel — render each kept sub-item as a positioned tile inside
+              // the unioned chrome.
+              const parentSubCols = Math.max(
+                1,
+                ...subPlaced.map((sp) => sp.col + Math.max(1, sp.sub.cost[0])),
+              );
+              const parentSubRows = Math.max(
+                1,
+                ...subPlaced.map((sp) => sp.row + Math.max(1, sp.sub.cost[1])),
+              );
+              for (const { sub, key: subKey, col: sc, row: sr } of subPlaced) {
+                const subBeingDragged =
+                  subDrag?.parentKey === mKey && subDrag.subKey === subKey;
+                const subHovered =
+                  hoveredSub?.parentKey === mKey && hoveredSub.subKey === subKey;
                 const subHandlers = draggable
                   ? {
-                      onPointerEnter: () => setHoveredSub({ parentKey: key, subKey }),
+                      onPointerEnter: () => setHoveredSub({ parentKey: mKey, subKey }),
                       onPointerLeave: () =>
                         setHoveredSub((prev) =>
-                          prev?.parentKey === key && prev.subKey === subKey ? null : prev,
+                          prev?.parentKey === mKey && prev.subKey === subKey
+                            ? null
+                            : prev,
                         ),
                       onPointerDown: (e: ReactPointerEvent) => {
                         if (e.button !== 0) return;
                         e.stopPropagation();
                         e.currentTarget.setPointerCapture(e.pointerId);
-                        // Pin every sibling at its current rendered cell so the
-                        // farthest-fit pack treats them as anchors during this
-                        // drag — without this, moving one sub-item makes the
-                        // others slide to the diagonally-opposite cell on every
-                        // re-pack. Only the dragged tile moves; siblings stay
-                        // put until the user drags them next.
                         setSubOverrides((prev) => {
                           const next = new Map(prev);
-                          const inner = new Map(next.get(key) ?? new Map());
-                          for (const p of subPlaced) inner.set(p.key, { col: p.col, row: p.row });
-                          next.set(key, inner);
+                          const inner = new Map(next.get(mKey) ?? new Map());
+                          for (const sp of subPlaced) inner.set(sp.key, { col: sp.col, row: sp.row });
+                          next.set(mKey, inner);
                           return next;
                         });
                         setSubDrag({
-                          parentKey: key,
+                          parentKey: mKey,
                           subKey,
+                          sub,
                           pointerId: e.pointerId,
                           startX: e.clientX,
                           startY: e.clientY,
@@ -451,7 +717,11 @@ export function NotchGrid({
                           cost: sub.cost,
                           parentSubCols,
                           parentSubRows,
-                          itemBlock,
+                          parentOuterCol: p.col,
+                          parentOuterRow: p.row,
+                          parentOuterCols: p.cols,
+                          parentOuterRows: p.rows,
+                          itemBlock: mItemBlock,
                           dx: 0,
                           dy: 0,
                         });
@@ -461,107 +731,139 @@ export function NotchGrid({
                       onPointerCancel: endSubDrag,
                     }
                   : undefined;
-                return (
+                // Position relative to the unioned chrome's top-left.
+                const tileLeft = (p.col - minCol + sc) * mItemBlock + gap / 2;
+                const tileTop = (p.row - minRow + sr) * mItemBlock + gap / 2;
+                tiles.push(
                   <div
-                    key={subKey}
+                    key={`${String(mKey)}/${String(subKey)}`}
                     {...subHandlers}
                     className={cn(
                       "absolute overflow-hidden transition-colors",
                       draggable && "cursor-grab select-none touch-none",
                       subBeingDragged && "cursor-grabbing",
-                      // Slight tonal lift on hover — sub-item reads as interactive.
                       subHovered && !subBeingDragged && "bg-on-surface/10",
                       sub.className,
                     )}
                     style={{
-                      // Inset by `gap / 2` on all sides so each sub-item is a
-                      // bounded rounded rect — adjacent ones sit `gap` apart and
-                      // the panel's chrome-background shows through, giving the
-                      // user something to grab to drag the whole panel.
-                      left: sc * itemBlock + gap / 2,
-                      top: sr * itemBlock + gap / 2,
-                      width: blocks(sub.cost[0]) * itemBlock - gap,
-                      height: blocks(sub.cost[1]) * itemBlock - gap,
-                      padding: sub.pad ?? props.pad ?? pad ?? 16,
-                      borderRadius: (sub.radius ?? props.radius ?? radius ?? 24) * 0.75,
+                      left: tileLeft,
+                      top: tileTop,
+                      width: blocks(sub.cost[0]) * mItemBlock - gap,
+                      height: blocks(sub.cost[1]) * mItemBlock - gap,
+                      padding: sub.pad ?? mProps.pad ?? pad ?? 16,
+                      borderRadius: (sub.radius ?? mProps.radius ?? radius ?? 24) * 0.75,
                       background: sub.fill && sub.fill !== "none" ? sub.fill : undefined,
-                      // Compensate for the dragged sub-item's packed cell
-                      // having moved under it during live re-pack: the visual
-                      // position follows the cursor's offset from the drag
-                      // start regardless of which cell the pack put it in.
                       transform: subBeingDragged
-                        ? `translate(${subDrag.dx - (sc - subDrag.originCol) * itemBlock}px, ${subDrag.dy - (sr - subDrag.originRow) * itemBlock}px)`
+                        ? `translate(${subDrag.dx - (sc - subDrag.originCol) * mItemBlock}px, ${subDrag.dy - (sr - subDrag.originRow) * mItemBlock}px)`
                         : undefined,
                       zIndex: subBeingDragged ? 30 : undefined,
                       ...sub.style,
                     }}
                   >
                     {sub.content}
-                  </div>
+                  </div>,
                 );
-              })
-            : props.children;
-
-          // Whole-item drag — for plain items, pointer-down anywhere on the tile
-          // drags it; for panels, pointer-down on the panel's chrome (the gap
-          // regions between sub-items, or any spot not covered by a sub-item)
-          // drags the panel, while pointer-down on a sub-item stops propagation
-          // and starts a sub-item drag instead.
-          const dragHandlers = draggable
-            ? {
-                onPointerDown: (e: ReactPointerEvent) => {
-                  if (e.button !== 0) return;
-                  e.currentTarget.setPointerCapture(e.pointerId);
-                  setDrag({
-                    key,
-                    pointerId: e.pointerId,
-                    startX: e.clientX,
-                    startY: e.clientY,
-                    originCol: col,
-                    originRow: row,
-                    originCols: itemCols,
-                    dx: 0,
-                    dy: 0,
-                  });
-                },
-                onPointerMove: handlePointerMove,
-                onPointerUp: endDrag,
-                onPointerCancel: endDrag,
               }
-            : undefined;
-
+            } else {
+              // Standalone tile inside a unioned chrome — render its children
+              // at its bounding-box-relative position, with outer-drag handlers
+              // when there's more than one member in the component (singletons
+              // get drag on the outer wrapper instead).
+              const draggingThis = drag?.key === mKey;
+              const memberDrag =
+                draggable && !isPlainSingleton
+                  ? {
+                      onPointerDown: (e: ReactPointerEvent) => {
+                        if (e.button !== 0) return;
+                        e.currentTarget.setPointerCapture(e.pointerId);
+                        setDrag({
+                          key: mKey,
+                          pointerId: e.pointerId,
+                          startX: e.clientX,
+                          startY: e.clientY,
+                          originCol: p.col,
+                          originRow: p.row,
+                          originCols: p.cols,
+                          dx: 0,
+                          dy: 0,
+                        });
+                      },
+                      onPointerMove: handlePointerMove,
+                      onPointerUp: endDrag,
+                      onPointerCancel: endDrag,
+                    }
+                  : undefined;
+              const tileLeft = (p.col - minCol) * mItemBlock + gap / 2;
+              const tileTop = (p.row - minRow) * mItemBlock + gap / 2;
+              tiles.push(
+                <div
+                  key={String(mKey)}
+                  {...memberDrag}
+                  className={cn(
+                    "absolute overflow-hidden",
+                    draggable && !isPlainSingleton && "cursor-grab select-none touch-none",
+                    draggingThis && "cursor-grabbing",
+                    mProps.className,
+                  )}
+                  style={{
+                    left: tileLeft,
+                    top: tileTop,
+                    width: maskCols(mMatrix) * mItemBlock - gap,
+                    height: mMatrix.length * mItemBlock - gap,
+                    padding: mProps.pad ?? pad ?? 16,
+                    borderRadius: (mProps.radius ?? radius ?? 24) * 0.75,
+                    transform: draggingThis && drag
+                      ? `translate(${drag.dx}px, ${drag.dy}px)`
+                      : undefined,
+                    zIndex: draggingThis ? 30 : undefined,
+                    ...mProps.style,
+                  }}
+                >
+                  {mProps.children}
+                </div>,
+              );
+            }
+          }
           return (
             <div
-              key={key}
-              {...dragHandlers}
+              key={compKey}
+              {...singletonDrag}
               className={cn(
                 "absolute",
-                draggable && "select-none touch-none",
-                draggable && (dragging ? "cursor-grabbing" : "cursor-grab"),
+                draggable && isPlainSingleton && "select-none touch-none",
+                draggable &&
+                  isPlainSingleton &&
+                  (singletonDragging ? "cursor-grabbing" : "cursor-grab"),
               )}
               style={{
-                left: col * block,
-                top: row * block,
-                transform: dragging ? `translate(${drag.dx}px, ${drag.dy}px)` : undefined,
-                zIndex: dragging ? 20 : overrides.has(key) ? 10 : undefined,
+                left: minCol * block,
+                top: minRow * block,
+                transform: singletonDragging && drag
+                  ? `translate(${drag.dx}px, ${drag.dy}px)`
+                  : undefined,
+                zIndex: singletonDragging
+                  ? 20
+                  : overrides.has(lead.item.key)
+                  ? 10
+                  : undefined,
               }}
             >
               <BlockShape
-                shape={matrix}
-                tier={tier}
-                block={itemBlock}
+                shape={unionMask}
+                tier={1}
+                block={block}
                 gap={gap}
-                radius={props.radius ?? radius}
-                inverseRadius={props.inverseRadius ?? inverseRadius}
-                fill={props.fill ?? fill}
-                stroke={props.stroke ?? stroke}
-                strokeWidth={props.strokeWidth ?? strokeWidth}
-                pad={subPlaced ? 0 : props.pad ?? pad}
-                noClip={subPlaced ? undefined : props.noClip}
-                className={props.className}
-                style={props.style}
+                radius={leadProps.radius ?? radius}
+                inverseRadius={leadProps.inverseRadius ?? inverseRadius}
+                fill={leadProps.fill ?? fill}
+                stroke={leadProps.stroke ?? stroke}
+                strokeWidth={leadProps.strokeWidth ?? strokeWidth}
+                pad={isPlainSingleton ? leadProps.pad ?? pad : 0}
+                noClip={isPlainSingleton ? leadProps.noClip : undefined}
+                className={isPlainSingleton ? leadProps.className : undefined}
+                style={isPlainSingleton ? leadProps.style : undefined}
               >
-                {content}
+                {isPlainSingleton ? leadProps.children : tiles}
               </BlockShape>
             </div>
           );
@@ -570,3 +872,4 @@ export function NotchGrid({
     </div>
   );
 }
+

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -322,19 +322,15 @@ export function NotchGrid({
   const promoteKey = (parentKey: Key, subKey: Key) => `${String(parentKey)} ${String(subKey)}`;
   const [hoveredSub, setHoveredSub] = useState<{ parentKey: Key; subKey: Key } | null>(null);
 
-  /** Snap a drag offset to a sub-grid cell, clamped to the panel's pre-drag
-   *  bounds — the sub-item can't leave the panel. Going past an edge holds at
-   *  the edge instead of jumping the sub-item to a far-away cell that would
-   *  split the panel into two disjoint regions. */
+  /** Snap a drag offset to a sub-grid cell, clamped to `>= 0` on each axis.
+   *  No upper clamp — letting the panel grow back is essential for cycles like
+   *  "drag up 1 row → drag back": after the first drop the panel has shrunk,
+   *  and clamping to the shrunken extent would prevent the drag-back from
+   *  reaching its original sub-cell. The chrome can grow because the in-chrome
+   *  layout is rebuilt from the placed sub-cells each render. */
   const snapDrag = (s: SubDragState): { col: number; row: number } => ({
-    col: Math.max(
-      0,
-      Math.min(s.parentSubCols - s.cost[0], s.originCol + Math.round(s.dx / s.itemBlock)),
-    ),
-    row: Math.max(
-      0,
-      Math.min(s.parentSubRows - s.cost[1], s.originRow + Math.round(s.dy / s.itemBlock)),
-    ),
+    col: Math.max(0, s.originCol + Math.round(s.dx / s.itemBlock)),
+    row: Math.max(0, s.originRow + Math.round(s.dy / s.itemBlock)),
   });
 
   // Live-preview snap: the cell the dragged sub-item would land in *right now*.
@@ -369,13 +365,18 @@ export function NotchGrid({
       const dropOuterRow = gridRect
         ? Math.max(0, Math.floor((e.clientY - gridRect.top) / block))
         : null;
+      // 1-cell halo on every side: a drop just past the panel's current edge
+      // still counts as sub-drag (so it can grow the panel back to a previous
+      // size), but a drop further away promotes. Otherwise a `drag-up → drag-
+      // back` cycle promotes on the second drop because the first shrunk the
+      // panel and the drag-back lands one row past the new edge.
       const droppedInsidePanel =
         dropOuterCol != null &&
         dropOuterRow != null &&
-        dropOuterCol >= s.parentOuterCol &&
-        dropOuterCol < s.parentOuterCol + s.parentOuterCols &&
-        dropOuterRow >= s.parentOuterRow &&
-        dropOuterRow < s.parentOuterRow + s.parentOuterRows;
+        dropOuterCol >= s.parentOuterCol - 1 &&
+        dropOuterCol < s.parentOuterCol + s.parentOuterCols + 1 &&
+        dropOuterRow >= s.parentOuterRow - 1 &&
+        dropOuterRow < s.parentOuterRow + s.parentOuterRows + 1;
       setSubDrag(null);
       if (!droppedInsidePanel && dropOuterCol != null && dropOuterRow != null) {
         setPromotedSubs((prev) => {

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -964,10 +964,17 @@ export function NotchGrid({
                   key={String(mKey)}
                   {...memberDrag}
                   className={cn(
-                    "absolute overflow-hidden transition-colors",
+                    "absolute overflow-hidden transition-[filter] duration-150",
                     draggable && !isPlainSingleton && "cursor-grab select-none touch-none",
                     draggingThis && "cursor-grabbing",
-                    memberHovered && !draggingThis && "bg-on-surface/10",
+                    // Standalone member tiles have an inline background
+                    // (inherited from the parent's `fill` so the cursor-
+                    // follow visual stays themed when dragged past the
+                    // chrome). A Tailwind `bg-on-surface/10` class would be
+                    // overridden by that inline background, so use a filter
+                    // here — same affordance as sub-items, just applied
+                    // through brightness instead of an overlay.
+                    memberHovered && !draggingThis && "brightness-95",
                     mProps.className,
                   )}
                   style={{

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -226,15 +226,19 @@ export function NotchGrid({
   subDragRef.current = subDrag;
   const [hoveredSub, setHoveredSub] = useState<{ parentKey: Key; subKey: Key } | null>(null);
 
-  /** Snap a drag offset to a sub-grid cell, clamped to one cell past the
-   *  panel's current edge so the drop can grow / reshape the panel. */
-  // The drop position snaps to the nearest sub-grid cell; only the *negative*
-  // side is clamped (a sub-item can't live above / left of the panel's origin).
-  // The drop is *not* capped at the panel's current right / bottom edge — the
-  // sub-pack happily grows to accept a sub-item dropped past it.
+  /** Snap a drag offset to a sub-grid cell, clamped to the panel's pre-drag
+   *  bounds — the sub-item can't leave the panel. Going past an edge holds at
+   *  the edge instead of jumping the sub-item to a far-away cell that would
+   *  split the panel into two disjoint regions. */
   const snapDrag = (s: SubDragState): { col: number; row: number } => ({
-    col: Math.max(0, s.originCol + Math.round(s.dx / s.itemBlock)),
-    row: Math.max(0, s.originRow + Math.round(s.dy / s.itemBlock)),
+    col: Math.max(
+      0,
+      Math.min(s.parentSubCols - s.cost[0], s.originCol + Math.round(s.dx / s.itemBlock)),
+    ),
+    row: Math.max(
+      0,
+      Math.min(s.parentSubRows - s.cost[1], s.originRow + Math.round(s.dy / s.itemBlock)),
+    ),
   });
 
   // Live-preview snap: the cell the dragged sub-item would land in *right now*.

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -642,16 +642,6 @@ export function NotchGrid({
             .map((p) => String(p.item.key))
             .sort()
             .join("|");
-          // Drop the chrome's clip while a sub-item in this component is being
-          // dragged so the cursor-following ghost can render through it
-          // without being chopped at the parent's outline.
-          const isDraggingInComp =
-            !!subDrag &&
-            comp.some(
-              (p) =>
-                p.item.key === subDrag.parentKey ||
-                p.item.subPlaced?.some((sp) => sp.key === subDrag.subKey && p.item.key === subDrag.parentKey),
-            );
           const isPlainSingleton = comp.length === 1 && !lead.item.subPlaced;
           // Drag handlers for a plain (no-sub-items) outer-grid singleton —
           // wraps the whole tile so pointer-down anywhere on it starts the
@@ -891,7 +881,7 @@ export function NotchGrid({
                 stroke={leadProps.stroke ?? stroke}
                 strokeWidth={leadProps.strokeWidth ?? strokeWidth}
                 pad={isPlainSingleton ? leadProps.pad ?? pad : 0}
-                noClip={isDraggingInComp || (isPlainSingleton ? leadProps.noClip : undefined)}
+                noClip={isPlainSingleton ? leadProps.noClip : undefined}
                 className={isPlainSingleton ? leadProps.className : undefined}
                 style={isPlainSingleton ? leadProps.style : undefined}
               >

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -423,6 +423,19 @@ export function NotchGrid({
                         if (e.button !== 0) return;
                         e.stopPropagation();
                         e.currentTarget.setPointerCapture(e.pointerId);
+                        // Pin every sibling at its current rendered cell so the
+                        // farthest-fit pack treats them as anchors during this
+                        // drag — without this, moving one sub-item makes the
+                        // others slide to the diagonally-opposite cell on every
+                        // re-pack. Only the dragged tile moves; siblings stay
+                        // put until the user drags them next.
+                        setSubOverrides((prev) => {
+                          const next = new Map(prev);
+                          const inner = new Map(next.get(key) ?? new Map());
+                          for (const p of subPlaced) inner.set(p.key, { col: p.col, row: p.row });
+                          next.set(key, inner);
+                          return next;
+                        });
                         setSubDrag({
                           parentKey: key,
                           subKey,

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -15,7 +15,7 @@ import {
 import { cn } from "@/utils/cn";
 import { isDev } from "@/utils/env";
 import type { ComponentMeta } from "@/types/component-meta";
-import { maskCols, maskFromShape, maxTier } from "@/utils/grid-outline";
+import { gridOutlinePath, maskCols, maskFromShape, maxTier } from "@/utils/grid-outline";
 import { BlockShape, BLOCK_SIZE } from "./BlockShape";
 import {
   NOTCH_BREAKPOINTS,
@@ -159,6 +159,12 @@ interface DragState {
   originRow: number;
   /** The dragged item's footprint width in blocks (to clamp the drop column). */
   originCols: number;
+  /** When set, the drag moves a *whole linked component* — every member's
+   *  override shifts by the same outer-cell delta on drop, so two tiles that
+   *  share a unioned chrome (auto-linked at render time) move together when
+   *  the user drags the chrome bridge between them. Singleton-component drags
+   *  leave this undefined and just move the one tile. */
+  members?: Array<{ key: Key; col: number; row: number; cols: number }>;
   dx: number;
   dy: number;
 }
@@ -303,10 +309,34 @@ export function NotchGrid({
       } catch {
         /* pointer may already be released */
       }
-      const maxCol = Math.max(0, colCount - d.originCols);
-      const nextCol = Math.min(maxCol, Math.max(0, d.originCol + Math.round(d.dx / block)));
-      const nextRow = Math.max(0, d.originRow + Math.round(d.dy / block));
+      const deltaCol = Math.round(d.dx / block);
+      const deltaRow = Math.round(d.dy / block);
       setDrag(null);
+      if (d.members) {
+        // Multi-member drag (linked chrome) — shift every member by the same
+        // outer-cell delta so they keep their relative arrangement.
+        setOverrides((prev) => {
+          const next = new Map(prev);
+          for (const m of d.members) {
+            next.set(m.key, {
+              col: Math.max(0, m.col + deltaCol),
+              row: Math.max(0, m.row + deltaRow),
+            });
+          }
+          return next;
+        });
+        for (const m of d.members) {
+          onItemMove?.(
+            m.key,
+            Math.max(0, m.col + deltaCol),
+            Math.max(0, m.row + deltaRow),
+          );
+        }
+        return;
+      }
+      const maxCol = Math.max(0, colCount - d.originCols);
+      const nextCol = Math.min(maxCol, Math.max(0, d.originCol + deltaCol));
+      const nextRow = Math.max(0, d.originRow + deltaRow);
       setOverrides((prev) => new Map(prev).set(d.key, { col: nextCol, row: nextRow }));
       onItemMove?.(d.key, nextCol, nextRow);
     },
@@ -695,6 +725,20 @@ export function NotchGrid({
           // construction so this just propagates it to the unioned chrome.
           const lead = comp[0];
           const leadProps = lead.item.props;
+          // Chrome outline (CSS path) — clips the wrapper's hit area to the
+          // actual shape so a click on a *notch* (a cell inside the bounding
+          // box but outside the chrome) doesn't drag the panel; it passes
+          // through to the tile underneath. Dropped during a drag so the
+          // cursor-follow tile can extend past the chrome unclipped.
+          const wrapperChromePath = gridOutlinePath(
+            unionMask.map((row) => row.map((v) => v > 0)),
+            {
+              cell: block,
+              gap,
+              radius: leadProps.radius ?? radius ?? 24,
+              inverseRadius: leadProps.inverseRadius ?? inverseRadius ?? 32,
+            },
+          );
           const compKey = comp
             .map((p) => String(p.item.key))
             .sort()
@@ -707,19 +751,28 @@ export function NotchGrid({
           const isDraggingInComp =
             (!!subDrag && comp.some((p) => p.item.key === subDrag.parentKey)) ||
             (!!drag && comp.some((p) => p.item.key === drag.key));
-          const isPlainSingleton = comp.length === 1 && !lead.item.subPlaced;
-          // Drag handlers for a plain (no-sub-items) outer-grid singleton —
-          // wraps the whole tile so pointer-down anywhere on it starts the
-          // drag. Panels (with sub-items) leave the chrome plain and let each
-          // sub-item carry its own drag handler below.
+          const isSingletonComp = comp.length === 1;
+          const isPlainSingleton = isSingletonComp && !lead.item.subPlaced;
+          // Drag handlers on the component wrapper. For a singleton it moves
+          // the one tile (panel chrome or plain tile); for a multi-member
+          // linked component it carries `members` and moves every linked
+          // tile together. Sub-items / individual member tiles inside have
+          // their own handlers with `stopPropagation`, so a press on a tile
+          // starts the per-tile drag instead.
           const singletonTileKey = String(lead.item.key);
           const singletonHovered = isPlainSingleton && hoveredTile === singletonTileKey;
-          const singletonDrag =
-            isPlainSingleton && draggable
+          const wrapperDrag =
+            draggable
               ? {
-                  onPointerEnter: () => setHoveredTile(singletonTileKey),
-                  onPointerLeave: () =>
-                    setHoveredTile((prev) => (prev === singletonTileKey ? null : prev)),
+                  onPointerEnter: isPlainSingleton
+                    ? () => setHoveredTile(singletonTileKey)
+                    : undefined,
+                  onPointerLeave: isPlainSingleton
+                    ? () =>
+                        setHoveredTile((prev) =>
+                          prev === singletonTileKey ? null : prev,
+                        )
+                    : undefined,
                   onPointerDown: (e: ReactPointerEvent) => {
                     if (e.button !== 0) return;
                     e.currentTarget.setPointerCapture(e.pointerId);
@@ -732,6 +785,14 @@ export function NotchGrid({
                       originCol: lead.col,
                       originRow: lead.row,
                       originCols: lead.cols,
+                      members: isSingletonComp
+                        ? undefined
+                        : comp.map((p) => ({
+                            key: p.item.key,
+                            col: p.col,
+                            row: p.row,
+                            cols: p.cols,
+                          })),
                       dx: 0,
                       dy: 0,
                     });
@@ -741,7 +802,11 @@ export function NotchGrid({
                   onPointerCancel: endDrag,
                 }
               : undefined;
-          const singletonDragging = isPlainSingleton && drag?.key === lead.item.key;
+          const wrapperDragging =
+            !!drag &&
+            (drag.members
+              ? drag.members.some((m) => comp.some((p) => p.item.key === m.key))
+              : isSingletonComp && drag.key === lead.item.key);
           // Each member of the component contributes its tile(s) — sub-items
           // (with their own sub-drag handlers, which promote out of the panel
           // when the drop leaves the parent rect) for a panel, or the whole
@@ -869,6 +934,10 @@ export function NotchGrid({
                         setHoveredTile((prev) => (prev === memberTileKey ? null : prev)),
                       onPointerDown: (e: ReactPointerEvent) => {
                         if (e.button !== 0) return;
+                        // Stop bubbling so a tile-level press doesn't also
+                        // fire the wrapper's whole-component drag — clicking
+                        // a tile moves only that tile.
+                        e.stopPropagation();
                         e.currentTarget.setPointerCapture(e.pointerId);
                         setHoveredTile(null);
                         setDrag({
@@ -929,31 +998,36 @@ export function NotchGrid({
           return (
             <div
               key={compKey}
-              {...singletonDrag}
+              {...wrapperDrag}
               className={cn(
                 "absolute transition-[filter] duration-150",
-                draggable && isPlainSingleton && "select-none touch-none",
-                draggable &&
-                  isPlainSingleton &&
-                  (singletonDragging ? "cursor-grabbing" : "cursor-grab"),
+                draggable && "select-none touch-none",
+                draggable && (wrapperDragging ? "cursor-grabbing" : "cursor-grab"),
                 // Slight tonal dim on the whole tile when hovered — the same
                 // affordance the in-chrome members get via `bg-on-surface/10`,
                 // applied here via brightness since a singleton's tile is a
                 // BlockShape with its own SVG fill (a background overlay would
                 // sit *outside* the chrome outline instead of tinting the fill).
-                singletonHovered && !singletonDragging && "brightness-95",
+                // Only for plain singletons; panels and linked components leave
+                // their chrome alone and let each tile carry its own hover.
+                singletonHovered && !wrapperDragging && "brightness-95",
               )}
               style={{
                 left: minCol * block,
                 top: minRow * block,
-                transform: singletonDragging && drag
+                transform: wrapperDragging && drag
                   ? `translate(${drag.dx}px, ${drag.dy}px)`
                   : undefined,
-                zIndex: singletonDragging
+                zIndex: wrapperDragging
                   ? 20
                   : overrides.has(lead.item.key)
                   ? 10
                   : undefined,
+                // Hit-clip the wrapper to the chrome outline so a click on a
+                // notch (e.g. Builds nestled into the Status panel's plus-
+                // shaped notch) reaches the underlying tile instead of being
+                // intercepted by this component's wrapper rectangle.
+                clipPath: isDraggingInComp ? undefined : `path('${wrapperChromePath}')`,
               }}
             >
               <BlockShape

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -242,8 +242,13 @@ export function NotchGrid({
       } catch {
         /* pointer may already be released */
       }
-      const maxCol = Math.max(0, s.parentSubCols - s.cost[0]);
-      const maxRow = Math.max(0, s.parentSubRows - s.cost[1]);
+      // Clamp the drop to the panel's current edge — i.e. a sub-item may land
+      // *at* `parentSubX` (one cell past the existing extent) so it can grow /
+      // reshape the panel. Pinning inside the current footprint (the old
+      // `parentSubCols - cost[0]` bound) trapped reshapes like
+      // `xxx/.xx` → `x/xx/xx`, because `row = parentSubRows` was excluded.
+      const maxCol = Math.max(0, s.parentSubCols);
+      const maxRow = Math.max(0, s.parentSubRows);
       const nextCol = Math.min(maxCol, Math.max(0, s.originCol + Math.round(s.dx / s.itemBlock)));
       const nextRow = Math.min(maxRow, Math.max(0, s.originRow + Math.round(s.dy / s.itemBlock)));
       setSubDrag(null);

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -438,12 +438,18 @@ export function NotchGrid({
     for (const { props, key } of configs) {
       // Sub-items the user has dragged out of *this* panel — they're rendered
       // below as their own same-group outer-grid tiles, not inside the panel.
-      const raw = props.subItems?.filter((s, i) => {
-        const k = s.key ?? `s${i}`;
-        return !promotedSubs.has(promoteKey(key, k));
-      });
-      if (raw && raw.length > 0) {
-        const subs = raw.map((s, i) => ({ ...asSubItem(s), _i: i }));
+      // Preserve the *original* prop-order index as `_i` so the derived
+      // sub-keys (`s0`, `s1`, ...) stay stable across filters; otherwise a
+      // remaining sibling inherits a promoted tile's stale subOverrides pin
+      // and ends up at the wrong sub-cell.
+      const raw = (props.subItems ?? [])
+        .map((s, i) => ({ s, i }))
+        .filter(({ s, i }) => {
+          const k = s.key ?? `s${i}`;
+          return !promotedSubs.has(promoteKey(key, k));
+        });
+      if (raw.length > 0) {
+        const subs = raw.map(({ s, i }) => ({ ...asSubItem(s), _i: i }));
         const cw = (s: { cost: readonly [number, number] }) => Math.max(1, Math.floor(s.cost[0]));
         const maxSubW = Math.max(1, ...subs.map(cw));
         const subOver = subOverrides.get(key);

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -906,13 +906,13 @@ export function NotchGrid({
                       width: blocks(sub.cost[0]) * mItemBlock - gap,
                       height: blocks(sub.cost[1]) * mItemBlock - gap,
                       padding: sub.pad ?? mProps.pad ?? pad ?? 16,
-                      // Drag-active visual: tighten the corner radius (0.5
+                      // Drag-active visual: tighten the corner radius (0.6
                       // vs 0.75 at rest) and force a solid background so the
                       // tile reads as a picked-up card lifted off the chrome
                       // when the whole linked component is being dragged.
                       borderRadius:
                         (sub.radius ?? mProps.radius ?? radius ?? 24) *
-                        (wrapperDragging ? 0.5 : 0.75),
+                        (wrapperDragging ? 0.6 : 0.75),
                       background: wrapperDragging
                         ? sub.fill ?? mProps.fill ?? fill
                         : sub.fill && sub.fill !== "none"
@@ -999,13 +999,13 @@ export function NotchGrid({
                     width: maskCols(mMatrix) * mItemBlock - gap,
                     height: mMatrix.length * mItemBlock - gap,
                     padding: mProps.pad ?? pad ?? 16,
-                    // Drag-active visual: tighter corner radius (0.5 vs
+                    // Drag-active visual: tighter corner radius (0.6 vs
                     // 0.75 at rest) so a picked-up tile reads as a lifted
                     // card. Applies whether this tile is the one being
                     // outer-dragged or the whole linked component is.
                     borderRadius:
                       (mProps.radius ?? radius ?? 24) *
-                      (draggingThis || wrapperDragging ? 0.5 : 0.75),
+                      (draggingThis || wrapperDragging ? 0.6 : 0.75),
                     // Same fill as the chrome behind it — invisible at rest
                     // (they overlap exactly), but the moment the member is
                     // outer-dragged its transform takes it past the chrome
@@ -1098,7 +1098,7 @@ export function NotchGrid({
               // Tighter radius than at-rest (`* 0.75`) matches the drag-
               // active visual the other tile paths use during a wrapper
               // drag, so the cursor-follow ghost reads consistently.
-              borderRadius: subDrag.ghostRadius * 0.5,
+              borderRadius: subDrag.ghostRadius * 0.6,
               background:
                 subDrag.ghostFill && subDrag.ghostFill !== "none"
                   ? subDrag.ghostFill

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -312,12 +312,13 @@ export function NotchGrid({
       const deltaCol = Math.round(d.dx / block);
       const deltaRow = Math.round(d.dy / block);
       setDrag(null);
-      if (d.members) {
+      const dragMembers = d.members;
+      if (dragMembers) {
         // Multi-member drag (linked chrome) — shift every member by the same
         // outer-cell delta so they keep their relative arrangement.
         setOverrides((prev) => {
           const next = new Map(prev);
-          for (const m of d.members) {
+          for (const m of dragMembers) {
             next.set(m.key, {
               col: Math.max(0, m.col + deltaCol),
               row: Math.max(0, m.row + deltaRow),
@@ -325,7 +326,7 @@ export function NotchGrid({
           }
           return next;
         });
-        for (const m of d.members) {
+        for (const m of dragMembers) {
           onItemMove?.(
             m.key,
             Math.max(0, m.col + deltaCol),
@@ -475,7 +476,9 @@ export function NotchGrid({
       const raw = (props.subItems ?? [])
         .map((s, i) => ({ s, i }))
         .filter(({ s, i }) => {
-          const k = s.key ?? `s${i}`;
+          // `s` may be the `[cols, rows]` tuple shorthand — normalize before
+          // reaching for `.key`, otherwise TS sees a number tuple.
+          const k = asSubItem(s).key ?? `s${i}`;
           return !promotedSubs.has(promoteKey(key, k));
         });
       if (raw.length > 0) {

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -397,6 +397,16 @@ export function NotchGrid({
           });
           return next;
         });
+        // Pin the parent panel at its current outer cell — promoting a sub
+        // shrinks the panel's mask, and without a pin the outer pack would
+        // reflow it (Calls/Day jumping to a new cell when Cron is dragged
+        // out). The user can still drag the panel itself later to re-pin.
+        setOverrides((prev) => {
+          if (prev.has(s.parentKey)) return prev;
+          const next = new Map(prev);
+          next.set(s.parentKey, { col: s.parentOuterCol, row: s.parentOuterRow });
+          return next;
+        });
         return;
       }
       const { col: nextCol, row: nextRow } = snapDrag(s);
@@ -679,12 +689,14 @@ export function NotchGrid({
             .map((p) => String(p.item.key))
             .sort()
             .join("|");
-          // Drop the chrome's clip while a sub-item in this component is being
-          // dragged so the cursor-follow visual isn't chopped at the parent's
-          // outline. The in-chrome tile is opacity:0 during the drag so no
-          // visible artifact appears at the cell that was clipping it before.
+          // Drop the chrome's clip while *any* member of this component is
+          // being dragged — sub-drag of a panel sub-item *or* outer-drag of a
+          // unioned standalone (e.g. a promoted Cron sitting beside Calls/Day
+          // in the same chrome). Without this the cursor-follow tile gets
+          // chopped at the parent outline.
           const isDraggingInComp =
-            !!subDrag && comp.some((p) => p.item.key === subDrag.parentKey);
+            (!!subDrag && comp.some((p) => p.item.key === subDrag.parentKey)) ||
+            (!!drag && comp.some((p) => p.item.key === drag.key));
           const isPlainSingleton = comp.length === 1 && !lead.item.subPlaced;
           // Drag handlers for a plain (no-sub-items) outer-grid singleton —
           // wraps the whole tile so pointer-down anywhere on it starts the
@@ -877,6 +889,12 @@ export function NotchGrid({
                     height: mMatrix.length * mItemBlock - gap,
                     padding: mProps.pad ?? pad ?? 16,
                     borderRadius: (mProps.radius ?? radius ?? 24) * 0.75,
+                    // Same fill as the chrome behind it — invisible at rest
+                    // (they overlap exactly), but the moment the member is
+                    // outer-dragged its transform takes it past the chrome
+                    // and this background keeps the rounded teal preview.
+                    background:
+                      mProps.fill && mProps.fill !== "none" ? mProps.fill : undefined,
                     transform: draggingThis && drag
                       ? `translate(${drag.dx}px, ${drag.dy}px)`
                       : undefined,

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -187,6 +187,14 @@ interface SubDragState {
   parentOuterRows: number;
   /** Sub-grid block size in px (so we can convert pointer-px to cells). */
   itemBlock: number;
+  /** Resolved styles for the cursor-following ghost (theme inherits from the
+   *  parent panel where the sub doesn't override). The ghost replaces the
+   *  in-chrome tile during the drag so the user sees a rounded filled
+   *  preview that follows their cursor instead of just the sub's contents
+   *  silhouetted through the panel. */
+  ghostFill?: string;
+  ghostRadius: number;
+  ghostPad: number;
   dx: number;
   dy: number;
 }
@@ -431,10 +439,11 @@ export function NotchGrid({
         );
         const subInputs: LayoutInput<{ sub: NotchSubItem; key: Key }>[] = ordered.map((sub) => {
           const subKey = sub.key ?? `s${sub._i}`;
-          // Live drag preview wins over the persistent pinned position so the
-          // pack reshapes around the dragged sub-item *as* it moves.
-          const isLive = liveSnap && liveSnap.parentKey === key && liveSnap.subKey === subKey;
-          const pinned = isLive ? { col: liveSnap.col, row: liveSnap.row } : subOver?.get(subKey);
+          // Panel layout stays frozen during a sub-drag — the dragged tile is
+          // replaced by a cursor-following ghost overlay (rendered at the
+          // outer-grid root below) so nothing in the chrome reshapes until the
+          // drop commits.
+          const pinned = subOver?.get(subKey);
           return {
             item: { sub, key: subKey },
             mask: rectMask(sub.cost[0], sub.cost[1]),
@@ -555,9 +564,10 @@ export function NotchGrid({
       );
     }
     return { placed: packed.placed, gridCols: packed.cols, gridRows: packed.rows };
-    // Primitive `liveSnap` deps — re-pack only when the dragged sub-item's
-    // snapped cell changes, not on every sub-pixel pointer-move.
-  }, [children, items, width, colCount, bps, nest, overrides, subOverrides, promotedSubs, liveSnap?.parentKey, liveSnap?.subKey, liveSnap?.col, liveSnap?.row]);
+    // Layout is frozen during the drag itself — only the commits in
+    // `subOverrides` / `promotedSubs` re-pack. The cursor-following ghost is
+    // a render-only overlay that doesn't touch the pack.
+  }, [children, items, width, colCount, bps, nest, overrides, subOverrides, promotedSubs]);
 
   // Bucket placed items by `groupKey` (singletons get a unique bucket so they
   // never accidentally merge with anything). Within each bucket, find 8-
@@ -632,6 +642,16 @@ export function NotchGrid({
             .map((p) => String(p.item.key))
             .sort()
             .join("|");
+          // Drop the chrome's clip while a sub-item in this component is being
+          // dragged so the cursor-following ghost can render through it
+          // without being chopped at the parent's outline.
+          const isDraggingInComp =
+            !!subDrag &&
+            comp.some(
+              (p) =>
+                p.item.key === subDrag.parentKey ||
+                p.item.subPlaced?.some((sp) => sp.key === subDrag.subKey && p.item.key === subDrag.parentKey),
+            );
           const isPlainSingleton = comp.length === 1 && !lead.item.subPlaced;
           // Drag handlers for a plain (no-sub-items) outer-grid singleton —
           // wraps the whole tile so pointer-down anywhere on it starts the
@@ -698,6 +718,12 @@ export function NotchGrid({
                         if (e.button !== 0) return;
                         e.stopPropagation();
                         e.currentTarget.setPointerCapture(e.pointerId);
+                        // Pointer capture sticks to this element for the rest
+                        // of the drag, so siblings never receive a leave event
+                        // — clear hover here so a sibling that the cursor *was*
+                        // on (e.g. Calls/Day while reaching for Cron) doesn't
+                        // stay highlighted for the whole drag.
+                        setHoveredSub(null);
                         setSubOverrides((prev) => {
                           const next = new Map(prev);
                           const inner = new Map(next.get(mKey) ?? new Map());
@@ -722,6 +748,9 @@ export function NotchGrid({
                           parentOuterCols: p.cols,
                           parentOuterRows: p.rows,
                           itemBlock: mItemBlock,
+                          ghostFill: sub.fill ?? mProps.fill ?? fill,
+                          ghostRadius: sub.radius ?? mProps.radius ?? radius ?? 24,
+                          ghostPad: sub.pad ?? mProps.pad ?? pad ?? 16,
                           dx: 0,
                           dy: 0,
                         });
@@ -753,9 +782,12 @@ export function NotchGrid({
                       padding: sub.pad ?? mProps.pad ?? pad ?? 16,
                       borderRadius: (sub.radius ?? mProps.radius ?? radius ?? 24) * 0.75,
                       background: sub.fill && sub.fill !== "none" ? sub.fill : undefined,
-                      transform: subBeingDragged
-                        ? `translate(${subDrag.dx - (sc - subDrag.originCol) * mItemBlock}px, ${subDrag.dy - (sr - subDrag.originRow) * mItemBlock}px)`
-                        : undefined,
+                      // Hide the in-chrome tile during the drag — the ghost
+                      // overlay (rendered as a sibling of the grid below)
+                      // tracks the cursor with the rounded filled preview.
+                      // We keep the element mounted so the captured pointer
+                      // still has its target.
+                      opacity: subBeingDragged ? 0 : undefined,
                       zIndex: subBeingDragged ? 30 : undefined,
                       ...sub.style,
                     }}
@@ -859,7 +891,7 @@ export function NotchGrid({
                 stroke={leadProps.stroke ?? stroke}
                 strokeWidth={leadProps.strokeWidth ?? strokeWidth}
                 pad={isPlainSingleton ? leadProps.pad ?? pad : 0}
-                noClip={isPlainSingleton ? leadProps.noClip : undefined}
+                noClip={isDraggingInComp || (isPlainSingleton ? leadProps.noClip : undefined)}
                 className={isPlainSingleton ? leadProps.className : undefined}
                 style={isPlainSingleton ? leadProps.style : undefined}
               >
@@ -868,6 +900,34 @@ export function NotchGrid({
             </div>
           );
         })}
+        {subDrag && (
+          <div
+            aria-hidden
+            className="pointer-events-none absolute"
+            style={{
+              left:
+                subDrag.parentOuterCol * block +
+                subDrag.originCol * subDrag.itemBlock +
+                gap / 2,
+              top:
+                subDrag.parentOuterRow * block +
+                subDrag.originRow * subDrag.itemBlock +
+                gap / 2,
+              width: blocks(subDrag.cost[0]) * subDrag.itemBlock - gap,
+              height: blocks(subDrag.cost[1]) * subDrag.itemBlock - gap,
+              borderRadius: subDrag.ghostRadius * 0.75,
+              background:
+                subDrag.ghostFill && subDrag.ghostFill !== "none"
+                  ? subDrag.ghostFill
+                  : undefined,
+              padding: subDrag.ghostPad,
+              transform: `translate(${subDrag.dx}px, ${subDrag.dy}px)`,
+              zIndex: 50,
+            }}
+          >
+            {subDrag.sub.content}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -906,24 +906,18 @@ export function NotchGrid({
                       width: blocks(sub.cost[0]) * mItemBlock - gap,
                       height: blocks(sub.cost[1]) * mItemBlock - gap,
                       padding: sub.pad ?? mProps.pad ?? pad ?? 16,
-                      // Drag-active visual: force a solid background and a
-                      // natural 1px outline (matches the default chrome
-                      // stroke color) so the tile reads as a picked-up
-                      // card lifted off the chrome when the whole linked
-                      // component is being dragged.
-                      borderRadius: (sub.radius ?? mProps.radius ?? radius ?? 24) * 0.75,
+                      // Drag-active visual: tighten the corner radius (0.6
+                      // vs 0.75 at rest) and force a solid background so the
+                      // tile reads as a picked-up card lifted off the chrome
+                      // when the whole linked component is being dragged.
+                      borderRadius:
+                        (sub.radius ?? mProps.radius ?? radius ?? 24) *
+                        (wrapperDragging ? 0.6 : 0.75),
                       background: wrapperDragging
                         ? sub.fill ?? mProps.fill ?? fill
                         : sub.fill && sub.fill !== "none"
                         ? sub.fill
                         : undefined,
-                      // `outline` (not `border`) so the ring doesn't change
-                      // the tile's intrinsic width / height — nothing
-                      // reflows when the state toggles.
-                      outline: wrapperDragging
-                        ? "1px solid var(--color-outline-variant)"
-                        : undefined,
-                      outlineOffset: wrapperDragging ? "-1px" : undefined,
                       // Hide the in-chrome tile during the drag — the ghost
                       // overlay (rendered as a sibling of the grid below)
                       // tracks the cursor with the rounded filled preview.
@@ -1005,21 +999,19 @@ export function NotchGrid({
                     width: maskCols(mMatrix) * mItemBlock - gap,
                     height: mMatrix.length * mItemBlock - gap,
                     padding: mProps.pad ?? pad ?? 16,
-                    borderRadius: (mProps.radius ?? radius ?? 24) * 0.75,
+                    // Drag-active visual: tighter corner radius (0.6 vs
+                    // 0.75 at rest) so a picked-up tile reads as a lifted
+                    // card. Applies whether this tile is the one being
+                    // outer-dragged or the whole linked component is.
+                    borderRadius:
+                      (mProps.radius ?? radius ?? 24) *
+                      (draggingThis || wrapperDragging ? 0.6 : 0.75),
                     // Same fill as the chrome behind it — invisible at rest
                     // (they overlap exactly), but the moment the member is
                     // outer-dragged its transform takes it past the chrome
                     // and this background keeps the rounded teal preview.
                     background:
                       mProps.fill && mProps.fill !== "none" ? mProps.fill : undefined,
-                    // Drag-active visual: a natural 1px outline (matches the
-                    // chrome's default stroke color) so a picked-up tile
-                    // reads as a lifted card.
-                    outline:
-                      draggingThis || wrapperDragging
-                        ? "1px solid var(--color-outline-variant)"
-                        : undefined,
-                    outlineOffset: draggingThis || wrapperDragging ? "-1px" : undefined,
                     transform: draggingThis && drag
                       ? `translate(${drag.dx}px, ${drag.dy}px)`
                       : undefined,
@@ -1103,12 +1095,10 @@ export function NotchGrid({
                 gap / 2,
               width: blocks(subDrag.cost[0]) * subDrag.itemBlock - gap,
               height: blocks(subDrag.cost[1]) * subDrag.itemBlock - gap,
-              // Same rest radius and a natural 1px outline as the other
-              // drag-active paths so the cursor-follow ghost reads as the
-              // same picked-up card visual.
-              borderRadius: subDrag.ghostRadius * 0.75,
-              outline: "1px solid var(--color-outline-variant)",
-              outlineOffset: "-1px",
+              // Tighter radius than at-rest (`* 0.75`) matches the drag-
+              // active visual the other tile paths use during a wrapper
+              // drag, so the cursor-follow ghost reads consistently.
+              borderRadius: subDrag.ghostRadius * 0.6,
               background:
                 subDrag.ghostFill && subDrag.ghostFill !== "none"
                   ? subDrag.ghostFill

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -227,6 +227,19 @@ export function NotchGrid({
   subDragRef.current = subDrag;
   const [hoveredSub, setHoveredSub] = useState<{ parentKey: Key; subKey: Key } | null>(null);
 
+  /** Snap a drag offset to a sub-grid cell, clamped to one cell past the
+   *  panel's current edge so the drop can grow / reshape the panel. */
+  const snapDrag = (s: SubDragState): { col: number; row: number } => ({
+    col: Math.min(Math.max(0, s.parentSubCols), Math.max(0, s.originCol + Math.round(s.dx / s.itemBlock))),
+    row: Math.min(Math.max(0, s.parentSubRows), Math.max(0, s.originRow + Math.round(s.dy / s.itemBlock))),
+  });
+
+  // Live-preview snap: the cell the dragged sub-item would land in *right now*.
+  // Fed into the layout pipeline so the other sub-items re-flow as the user
+  // drags (instead of waiting for the drop), while the dragged sub-item's own
+  // CSS transform keeps it under the cursor smoothly.
+  const liveSnap = subDrag ? { parentKey: subDrag.parentKey, subKey: subDrag.subKey, ...snapDrag(subDrag) } : null;
+
   const handleSubPointerMove = useCallback((e: ReactPointerEvent) => {
     const s = subDragRef.current;
     if (!s || e.pointerId !== s.pointerId) return;
@@ -242,15 +255,7 @@ export function NotchGrid({
       } catch {
         /* pointer may already be released */
       }
-      // Clamp the drop to the panel's current edge — i.e. a sub-item may land
-      // *at* `parentSubX` (one cell past the existing extent) so it can grow /
-      // reshape the panel. Pinning inside the current footprint (the old
-      // `parentSubCols - cost[0]` bound) trapped reshapes like
-      // `xxx/.xx` → `x/xx/xx`, because `row = parentSubRows` was excluded.
-      const maxCol = Math.max(0, s.parentSubCols);
-      const maxRow = Math.max(0, s.parentSubRows);
-      const nextCol = Math.min(maxCol, Math.max(0, s.originCol + Math.round(s.dx / s.itemBlock)));
-      const nextRow = Math.min(maxRow, Math.max(0, s.originRow + Math.round(s.dy / s.itemBlock)));
+      const { col: nextCol, row: nextRow } = snapDrag(s);
       setSubDrag(null);
       setSubOverrides((prev) => {
         const next = new Map(prev);
@@ -284,7 +289,10 @@ export function NotchGrid({
         const subOver = subOverrides.get(key);
         const subInputs: LayoutInput<{ sub: NotchSubItem; key: Key }>[] = subs.map((sub) => {
           const subKey = sub.key ?? `s${sub._i}`;
-          const pinned = subOver?.get(subKey);
+          // Live drag preview wins over the persistent pinned position so the
+          // pack reshapes around the dragged sub-item *as* it moves.
+          const isLive = liveSnap && liveSnap.parentKey === key && liveSnap.subKey === subKey;
+          const pinned = isLive ? { col: liveSnap.col, row: liveSnap.row } : subOver?.get(subKey);
           return {
             item: { sub, key: subKey },
             mask: rectMask(sub.cost[0], sub.cost[1]),
@@ -346,7 +354,9 @@ export function NotchGrid({
       );
     }
     return { placed: packed.placed, gridCols: packed.cols, gridRows: packed.rows };
-  }, [children, items, width, colCount, bps, nest, overrides, subOverrides]);
+    // Primitive `liveSnap` deps — re-pack only when the dragged sub-item's
+    // snapped cell changes, not on every sub-pixel pointer-move.
+  }, [children, items, width, colCount, bps, nest, overrides, subOverrides, liveSnap?.parentKey, liveSnap?.subKey, liveSnap?.col, liveSnap?.row]);
 
   return (
     <div ref={ref} className={cn("w-full", className)} style={style}>
@@ -430,7 +440,13 @@ export function NotchGrid({
                       padding: sub.pad ?? props.pad ?? pad ?? 16,
                       borderRadius: (sub.radius ?? props.radius ?? radius ?? 24) * 0.75,
                       background: sub.fill && sub.fill !== "none" ? sub.fill : undefined,
-                      transform: subBeingDragged ? `translate(${subDrag.dx}px, ${subDrag.dy}px)` : undefined,
+                      // Compensate for the dragged sub-item's packed cell
+                      // having moved under it during live re-pack: the visual
+                      // position follows the cursor's offset from the drag
+                      // start regardless of which cell the pack put it in.
+                      transform: subBeingDragged
+                        ? `translate(${subDrag.dx - (sc - subDrag.originCol) * itemBlock}px, ${subDrag.dy - (sr - subDrag.originRow) * itemBlock}px)`
+                        : undefined,
                       zIndex: subBeingDragged ? 30 : undefined,
                       ...sub.style,
                     }}

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -242,6 +242,13 @@ interface ResolvedItem {
    *  keep the same group so they can re-link when dragged back beside the
    *  rest. */
   groupKey?: Key;
+  /** Natural panel extent — what the matrix would be if no sub-item drags
+   *  had moved anything. Used as the inside-panel hit-box for sub-drag promote
+   *  decisions: a drop within the natural rect is a sub-drag (the chrome
+   *  reshapes / regrows), a drop past it promotes the sub to a standalone
+   *  same-themed tile. Defaults to the current matrix size for plain items. */
+  naturalCols: number;
+  naturalRows: number;
 }
 
 export function NotchGrid({
@@ -365,18 +372,18 @@ export function NotchGrid({
       const dropOuterRow = gridRect
         ? Math.max(0, Math.floor((e.clientY - gridRect.top) / block))
         : null;
-      // 1-cell halo on every side: a drop just past the panel's current edge
-      // still counts as sub-drag (so it can grow the panel back to a previous
-      // size), but a drop further away promotes. Otherwise a `drag-up → drag-
-      // back` cycle promotes on the second drop because the first shrunk the
-      // panel and the drag-back lands one row past the new edge.
+      // The panel's natural extent (captured at drag start) is the in-panel
+      // hit-box: drops inside it sub-drag (the chrome can reshape back to its
+      // natural shape), drops outside promote. Using natural rather than the
+      // current shrunken extent stops a "drag-up → drag-back" cycle from
+      // tripping the promote branch on the way back.
       const droppedInsidePanel =
         dropOuterCol != null &&
         dropOuterRow != null &&
-        dropOuterCol >= s.parentOuterCol - 1 &&
-        dropOuterCol < s.parentOuterCol + s.parentOuterCols + 1 &&
-        dropOuterRow >= s.parentOuterRow - 1 &&
-        dropOuterRow < s.parentOuterRow + s.parentOuterRows + 1;
+        dropOuterCol >= s.parentOuterCol &&
+        dropOuterCol < s.parentOuterCol + s.parentOuterCols &&
+        dropOuterRow >= s.parentOuterRow &&
+        dropOuterRow < s.parentOuterRow + s.parentOuterRows;
       setSubDrag(null);
       if (!droppedInsidePanel && dropOuterCol != null && dropOuterRow != null) {
         setPromotedSubs((prev) => {
@@ -481,6 +488,29 @@ export function NotchGrid({
         const subC = Math.max(props.subCols ?? compactCols, maxPinCol);
         const subPlaced = packItems(subInputs, subC, { flowOrder: "farthest-fit" }).placed;
         const matrix = placementToMask(subPlaced).map((row) => row.map((b) => (b ? 1 : 0)));
+        // Natural extent — same pack but ignoring `subOverrides` (within-panel
+        // drag positions). Sub-drags shrink the panel's matrix; the natural
+        // extent is what the chrome *would* be at rest, used as the stable
+        // hit-box for the in-panel vs. promote decision so a "drag up → drag
+        // back" cycle doesn't trip the promote branch on the way back.
+        const naturalInputs: LayoutInput<{ sub: NotchSubItem; key: Key }>[] = ordered.map(
+          (sub) => ({
+            item: { sub, key: sub.key ?? `s${sub._i}` },
+            mask: rectMask(sub.cost[0], sub.cost[1]),
+            col: sub.col,
+            row: sub.row,
+          }),
+        );
+        const naturalSubC = Math.max(props.subCols ?? compactCols, 1);
+        const naturalPlaced = packItems(naturalInputs, naturalSubC, { flowOrder: "farthest-fit" }).placed;
+        const naturalCols = naturalPlaced.reduce(
+          (m, p) => Math.max(m, p.col + p.cols),
+          maskCols(matrix),
+        );
+        const naturalRows = naturalPlaced.reduce(
+          (m, p) => Math.max(m, p.row + p.rows),
+          matrix.length,
+        );
         resolved.push({
           props,
           key,
@@ -488,6 +518,8 @@ export function NotchGrid({
           tier: 1,
           subPlaced: subPlaced.map((p) => ({ sub: p.item.sub, key: p.item.key, col: p.col, row: p.row })),
           groupKey: props.groupKey ?? key,
+          naturalCols,
+          naturalRows,
         });
         continue;
       }
@@ -505,6 +537,8 @@ export function NotchGrid({
         matrix,
         tier: props.tier ?? maxTier(matrix),
         groupKey: props.groupKey,
+        naturalCols: Math.max(1, maskCols(matrix)),
+        naturalRows: Math.max(1, matrix.length),
       });
     }
     // Promoted sub-items become standalone outer-grid tiles at the dropped
@@ -536,6 +570,8 @@ export function NotchGrid({
         matrix,
         tier: 1,
         groupKey: parentProps.groupKey ?? entry.parentKey,
+        naturalCols: Math.max(1, maskCols(matrix)),
+        naturalRows: Math.max(1, matrix.length),
       });
     }
 
@@ -742,8 +778,8 @@ export function NotchGrid({
                           parentSubRows,
                           parentOuterCol: p.col,
                           parentOuterRow: p.row,
-                          parentOuterCols: p.cols,
-                          parentOuterRows: p.rows,
+                          parentOuterCols: p.item.naturalCols,
+                          parentOuterRows: p.item.naturalRows,
                           itemBlock: mItemBlock,
                           ghostFill: sub.fill ?? mProps.fill ?? fill,
                           ghostRadius: sub.radius ?? mProps.radius ?? radius ?? 24,

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -327,7 +327,13 @@ export function NotchGrid({
     Map<string, { parentKey: Key; subKey: Key; sub: NotchSubItem; col: number; row: number }>
   >(new Map());
   const promoteKey = (parentKey: Key, subKey: Key) => `${String(parentKey)} ${String(subKey)}`;
-  const [hoveredSub, setHoveredSub] = useState<{ parentKey: Key; subKey: Key } | null>(null);
+  // The hovered tile, identified by a composed key. For panel sub-items it's
+  // `${parentKey}::${subKey}`; for standalone outer tiles inside a unioned
+  // chrome it's the item's own key. The dim overlay (`bg-on-surface/10`) is
+  // applied on the matching tile so adjacent grouped items get the same
+  // hover affordance, not just sub-items.
+  const [hoveredTile, setHoveredTile] = useState<string | null>(null);
+  const subTileKey = (parentKey: Key, subKey: Key) => `${String(parentKey)}::${String(subKey)}`;
 
   /** Snap a drag offset to a sub-grid cell, clamped to `>= 0` on each axis.
    *  No upper clamp — letting the panel grow back is essential for cycles like
@@ -706,12 +712,18 @@ export function NotchGrid({
           // wraps the whole tile so pointer-down anywhere on it starts the
           // drag. Panels (with sub-items) leave the chrome plain and let each
           // sub-item carry its own drag handler below.
+          const singletonTileKey = String(lead.item.key);
+          const singletonHovered = isPlainSingleton && hoveredTile === singletonTileKey;
           const singletonDrag =
             isPlainSingleton && draggable
               ? {
+                  onPointerEnter: () => setHoveredTile(singletonTileKey),
+                  onPointerLeave: () =>
+                    setHoveredTile((prev) => (prev === singletonTileKey ? null : prev)),
                   onPointerDown: (e: ReactPointerEvent) => {
                     if (e.button !== 0) return;
                     e.currentTarget.setPointerCapture(e.pointerId);
+                    setHoveredTile(null);
                     setDrag({
                       key: lead.item.key,
                       pointerId: e.pointerId,
@@ -752,17 +764,13 @@ export function NotchGrid({
               for (const { sub, key: subKey, col: sc, row: sr } of subPlaced) {
                 const subBeingDragged =
                   subDrag?.parentKey === mKey && subDrag.subKey === subKey;
-                const subHovered =
-                  hoveredSub?.parentKey === mKey && hoveredSub.subKey === subKey;
+                const tileKey = subTileKey(mKey, subKey);
+                const subHovered = hoveredTile === tileKey;
                 const subHandlers = draggable
                   ? {
-                      onPointerEnter: () => setHoveredSub({ parentKey: mKey, subKey }),
+                      onPointerEnter: () => setHoveredTile(tileKey),
                       onPointerLeave: () =>
-                        setHoveredSub((prev) =>
-                          prev?.parentKey === mKey && prev.subKey === subKey
-                            ? null
-                            : prev,
-                        ),
+                        setHoveredTile((prev) => (prev === tileKey ? null : prev)),
                       onPointerDown: (e: ReactPointerEvent) => {
                         if (e.button !== 0) return;
                         e.stopPropagation();
@@ -772,7 +780,7 @@ export function NotchGrid({
                         // — clear hover here so a sibling that the cursor *was*
                         // on (e.g. Calls/Day while reaching for Cron) doesn't
                         // stay highlighted for the whole drag.
-                        setHoveredSub(null);
+                        setHoveredTile(null);
                         setSubOverrides((prev) => {
                           const next = new Map(prev);
                           const inner = new Map(next.get(mKey) ?? new Map());
@@ -851,12 +859,18 @@ export function NotchGrid({
               // when there's more than one member in the component (singletons
               // get drag on the outer wrapper instead).
               const draggingThis = drag?.key === mKey;
+              const memberTileKey = String(mKey);
+              const memberHovered = hoveredTile === memberTileKey;
               const memberDrag =
                 draggable && !isPlainSingleton
                   ? {
+                      onPointerEnter: () => setHoveredTile(memberTileKey),
+                      onPointerLeave: () =>
+                        setHoveredTile((prev) => (prev === memberTileKey ? null : prev)),
                       onPointerDown: (e: ReactPointerEvent) => {
                         if (e.button !== 0) return;
                         e.currentTarget.setPointerCapture(e.pointerId);
+                        setHoveredTile(null);
                         setDrag({
                           key: mKey,
                           pointerId: e.pointerId,
@@ -881,9 +895,10 @@ export function NotchGrid({
                   key={String(mKey)}
                   {...memberDrag}
                   className={cn(
-                    "absolute overflow-hidden",
+                    "absolute overflow-hidden transition-colors",
                     draggable && !isPlainSingleton && "cursor-grab select-none touch-none",
                     draggingThis && "cursor-grabbing",
+                    memberHovered && !draggingThis && "bg-on-surface/10",
                     mProps.className,
                   )}
                   style={{
@@ -916,11 +931,17 @@ export function NotchGrid({
               key={compKey}
               {...singletonDrag}
               className={cn(
-                "absolute",
+                "absolute transition-[filter] duration-150",
                 draggable && isPlainSingleton && "select-none touch-none",
                 draggable &&
                   isPlainSingleton &&
                   (singletonDragging ? "cursor-grabbing" : "cursor-grab"),
+                // Slight tonal dim on the whole tile when hovered — the same
+                // affordance the in-chrome members get via `bg-on-surface/10`,
+                // applied here via brightness since a singleton's tile is a
+                // BlockShape with its own SVG fill (a background overlay would
+                // sit *outside* the chrome outline instead of tinting the fill).
+                singletonHovered && !singletonDragging && "brightness-95",
               )}
               style={{
                 left: minCol * block,

--- a/src/components/ui/surfaces/notch-grid/NotchGridItem.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGridItem.tsx
@@ -1,0 +1,149 @@
+import type { CSSProperties, Key, ReactNode } from "react";
+import type { ComponentMeta } from "@/types/component-meta";
+import { maxTier } from "@/utils/grid-outline";
+import { BlockShape } from "./BlockShape";
+import { resolveShapeMatrix, type NotchShape } from "./breakpoints";
+
+export const meta: ComponentMeta = {
+  name: "NotchGridItem",
+  description:
+    "One cell of a NotchGrid — a (responsive) block-shape footprint, or a panel of sub-items each with a block cost, plus content; the grid positions it",
+};
+
+export type { NotchShape };
+
+/** A widget inside a {@link NotchGridItem} panel. Costs `[cols, rows]` blocks;
+ *  the parent's notched footprint is the union of its sub-items' positions. A
+ *  bare `[cols, rows]` tuple is shorthand for `{ cost: [cols, rows] }`. */
+export interface NotchSubItem {
+  key?: Key;
+  /** Block cost `[cols, rows]`. */
+  cost: readonly [number, number];
+  /** Explicit position within the panel (block units). Auto-flowed when omitted. */
+  col?: number;
+  row?: number;
+  fill?: string;
+  stroke?: string;
+  strokeWidth?: number;
+  radius?: number;
+  inverseRadius?: number;
+  pad?: number;
+  noClip?: boolean;
+  className?: string;
+  style?: CSSProperties;
+  content?: ReactNode;
+}
+
+export type NotchSubItemInput = NotchSubItem | readonly [number, number];
+
+export interface NotchGridItemProps {
+  /** React key when supplied via the `items` prop array. */
+  key?: Key;
+  /**
+   * The block footprint — one of:
+   *  - a matrix `[[0,1],[1,1]]` (`0` notch/empty, `1` filled, `2+` tier-encoded);
+   *  - a breakpoint map of matrices, `{ base: …, md: … }` or px keys `{ 0: …, 900: … }`;
+   *  - candidate `[cols, rows]` block costs `{ sizes: [[1,1],[2,2]] }` — the grid
+   *    picks the largest that fits, so the component grows when there's room;
+   *  - preferred matrices in priority order `{ prefer: [bigShape, smallerShape, …] }`
+   *    — the grid uses the first that fits the column count, else the narrowest.
+   *
+   * Ignored when {@link subItems} is given (the footprint is derived from those).
+   */
+  shape?: NotchShape;
+  /**
+   * Build this item as a panel of sub-widgets, each with a `[cols, rows]` block
+   * cost — `[[1,1],[2,2]]` is a 1×1 sub-item beside a 2×2 one. The grid packs
+   * them (into {@link subCols} columns) and the panel's notched footprint is the
+   * union of their positions.
+   */
+  subItems?: ReadonlyArray<NotchSubItemInput>;
+  /** Pin the column count the sub-items pack into. Omit to let the grid search
+   *  column counts × orderings for the most compact arrangement. */
+  subCols?: number;
+  /** Preferred width ÷ height for the auto-arranged sub-item layout — the
+   *  tie-breaker between equally-compact options. Default 1.6 (gently landscape).
+   *  Ignored when `subCols` is set. */
+  subAspect?: number;
+  /** Explicit grid position in block units. Auto-flowed when omitted. */
+  col?: number;
+  row?: number;
+  /** Tier selector for a tier-encoded matrix. Default: every tier (`maxTier`). */
+  tier?: number;
+  /** Block edge in px (normally inherited from the parent `NotchGrid`). */
+  block?: number;
+  radius?: number;
+  inverseRadius?: number;
+  fill?: string;
+  stroke?: string;
+  strokeWidth?: number;
+  pad?: number;
+  noClip?: boolean;
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+
+/** Normalise a {@link NotchSubItemInput} to a {@link NotchSubItem}. */
+export function asSubItem(input: NotchSubItemInput): NotchSubItem {
+  return Array.isArray(input) ? { cost: input as readonly [number, number] } : (input as NotchSubItem);
+}
+
+/**
+ * Inside a {@link NotchGrid} this component is *not* rendered directly — the
+ * grid reads these props, packs sub-items / resolves the responsive shape, and
+ * renders the positioned `BlockShape`s itself.
+ *
+ * Rendered standalone, it falls back to its largest defined shape variant (or,
+ * with `subItems`, just renders its `children`) so it still shows something
+ * useful in isolation / tests.
+ */
+export function NotchGridItem({
+  shape,
+  subItems,
+  tier,
+  block,
+  radius,
+  inverseRadius,
+  fill,
+  stroke,
+  strokeWidth,
+  pad,
+  noClip,
+  className,
+  style,
+  children,
+}: NotchGridItemProps) {
+  if (subItems && subItems.length > 0) {
+    // Standalone: the sub-item packing happens inside a NotchGrid; here we just
+    // surface the content.
+    return (
+      <div className={className} style={style}>
+        {children}
+      </div>
+    );
+  }
+  const matrix = resolveShapeMatrix(shape ?? [[1]], {
+    width: Number.POSITIVE_INFINITY,
+    columns: Number.MAX_SAFE_INTEGER,
+  });
+  const resolvedTier = tier ?? maxTier(matrix);
+  return (
+    <BlockShape
+      shape={matrix}
+      tier={resolvedTier}
+      block={block}
+      radius={radius}
+      inverseRadius={inverseRadius}
+      fill={fill}
+      stroke={stroke}
+      strokeWidth={strokeWidth}
+      pad={pad}
+      noClip={noClip}
+      className={className}
+      style={style}
+    >
+      {children}
+    </BlockShape>
+  );
+}

--- a/src/components/ui/surfaces/notch-grid/NotchGridItem.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGridItem.tsx
@@ -39,6 +39,13 @@ export type NotchSubItemInput = NotchSubItem | readonly [number, number];
 export interface NotchGridItemProps {
   /** React key when supplied via the `items` prop array. */
   key?: Key;
+  /** Group items so the grid renders adjacent same-`groupKey` tiles as one
+   *  unioned panel (their chromes merge into a single rounded outline with
+   *  the inverse-radius bridge where two cells meet at a corner). Items in
+   *  the same group dragged *away* from their group render as separate
+   *  same-themed tiles. Implicit for sub-items packed via {@link subItems} —
+   *  every sub gets `groupKey = panel-key` automatically. */
+  groupKey?: Key;
   /**
    * The block footprint — one of:
    *  - a matrix `[[0,1],[1,1]]` (`0` notch/empty, `1` filled, `2+` tier-encoded);

--- a/src/components/ui/surfaces/notch-grid/breakpoints.test.ts
+++ b/src/components/ui/surfaces/notch-grid/breakpoints.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  NOTCH_BREAKPOINTS,
+  rectMatrix,
+  resolveResponsive,
+  resolveShapeMatrix,
+} from "./breakpoints";
+
+describe("resolveResponsive", () => {
+  it("returns a non-map value unchanged (incl. arrays / matrices)", () => {
+    expect(resolveResponsive(5, 800)).toBe(5);
+    const matrix = [[1, 1], [1, 0]];
+    expect(resolveResponsive(matrix, 800)).toBe(matrix);
+  });
+
+  it("picks the largest named breakpoint <= width (mobile-first cascade)", () => {
+    const v = { base: "b", md: "m", lg: "l" };
+    expect(resolveResponsive(v, 0)).toBe("b");
+    expect(resolveResponsive(v, 700)).toBe("b"); // < md (768)
+    expect(resolveResponsive(v, 768)).toBe("m"); // == md
+    expect(resolveResponsive(v, 900)).toBe("m"); // md <= 900 < lg
+    expect(resolveResponsive(v, 1200)).toBe("l");
+  });
+
+  it("accepts raw px thresholds as keys", () => {
+    const v = { 0: "s", 500: "m", 900: "l" };
+    expect(resolveResponsive(v, 100)).toBe("s");
+    expect(resolveResponsive(v, 500)).toBe("m");
+    expect(resolveResponsive(v, 1000)).toBe("l");
+  });
+
+  it("mixes named and px keys, sorting by resolved threshold", () => {
+    const v = { base: "s", 500: "m", lg: "l" }; // 0, 500, 1024
+    expect(resolveResponsive(v, 400)).toBe("s");
+    expect(resolveResponsive(v, 600)).toBe("m");
+    expect(resolveResponsive(v, 1100)).toBe("l");
+  });
+
+  it("falls back to the smallest threshold when width is below all of them", () => {
+    expect(resolveResponsive({ md: "m", lg: "l" }, 0)).toBe("m");
+  });
+
+  it("honours overridden breakpoints", () => {
+    const v = { base: "s", md: "m" };
+    // Move md down to 600 — now 650 resolves to m instead of s.
+    expect(resolveResponsive(v, 650, { ...NOTCH_BREAKPOINTS, md: 600 })).toBe("m");
+    expect(resolveResponsive(v, 650)).toBe("s");
+  });
+
+  it("treats an unknown breakpoint name as base (0)", () => {
+    expect(resolveResponsive({ weird: "w", lg: "l" }, 10)).toBe("w");
+  });
+});
+
+describe("rectMatrix", () => {
+  it("builds a solid cols×rows matrix of 1s", () => {
+    expect(rectMatrix(2, 3)).toEqual([
+      [1, 1],
+      [1, 1],
+      [1, 1],
+    ]);
+  });
+  it("clamps to at least 1×1", () => {
+    expect(rectMatrix(0, 0)).toEqual([[1]]);
+  });
+});
+
+describe("resolveShapeMatrix", () => {
+  it("passes a bare matrix through", () => {
+    const m = [[1, 0], [1, 1]];
+    expect(resolveShapeMatrix(m, { width: 800, columns: 4 })).toBe(m);
+  });
+
+  it("cascades a breakpoint map by width", () => {
+    const shape = { base: [[1]], md: [[1, 1], [1, 1]] };
+    expect(resolveShapeMatrix(shape, { width: 400, columns: 4 })).toEqual([[1]]);
+    expect(resolveShapeMatrix(shape, { width: 900, columns: 4 })).toEqual([
+      [1, 1],
+      [1, 1],
+    ]);
+  });
+
+  it("picks the largest size-candidate whose width fits the column count", () => {
+    const shape = { sizes: [[1, 1], [2, 2], [3, 2]] as const };
+    expect(resolveShapeMatrix(shape, { width: 0, columns: 1 })).toEqual([[1]]);
+    expect(resolveShapeMatrix(shape, { width: 0, columns: 2 })).toEqual([
+      [1, 1],
+      [1, 1],
+    ]);
+    // columns=4 ⇒ the 3×2 candidate fits and is the largest.
+    expect(resolveShapeMatrix(shape, { width: 0, columns: 4 })).toEqual([
+      [1, 1, 1],
+      [1, 1, 1],
+    ]);
+  });
+
+  it("falls back to the smallest size-candidate when none fit", () => {
+    const shape = { sizes: [[3, 1], [4, 1]] as const };
+    expect(resolveShapeMatrix(shape, { width: 0, columns: 1 })).toEqual([[1, 1, 1]]);
+  });
+
+  it("picks the first `prefer` matrix that fits the column count", () => {
+    const big = [[1, 1, 1], [1, 1, 0]];
+    const mid = [[1, 1], [1, 1]];
+    const small = [[1]];
+    const shape = { prefer: [big, mid, small] };
+    expect(resolveShapeMatrix(shape, { width: 0, columns: 4 })).toBe(big);
+    expect(resolveShapeMatrix(shape, { width: 0, columns: 2 })).toBe(mid);
+    expect(resolveShapeMatrix(shape, { width: 0, columns: 1 })).toBe(small);
+  });
+
+  it("falls back to the narrowest `prefer` matrix when none fit", () => {
+    const wide = [[1, 1, 1]];
+    const narrower = [[1, 1]];
+    expect(resolveShapeMatrix({ prefer: [wide, narrower] }, { width: 0, columns: 1 })).toBe(narrower);
+  });
+
+  it("returns a 1×1 for an empty `prefer` list", () => {
+    expect(resolveShapeMatrix({ prefer: [] }, { width: 0, columns: 4 })).toEqual([[1]]);
+  });
+});

--- a/src/components/ui/surfaces/notch-grid/breakpoints.ts
+++ b/src/components/ui/surfaces/notch-grid/breakpoints.ts
@@ -1,0 +1,127 @@
+// Tailwind-style responsive resolution for the notch grid.
+//
+// A "responsive" value can be a single value, or a map keyed by breakpoint name
+// (`base`, `sm`, `md`, …) or a raw min-width in px (`0`, `560`, `900`, …). At a
+// given container width, the entry with the largest threshold `<= width` wins —
+// exactly the mobile-first cascade Tailwind uses.
+
+import { maskCols } from "@/utils/grid-outline";
+
+/** Default breakpoint thresholds (min container width, px). Mirrors Tailwind.
+ *  Override per-grid via `<NotchGrid breakpoints={…}>`. */
+export const NOTCH_BREAKPOINTS = {
+  base: 0,
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  "2xl": 1536,
+} as const;
+
+export type NotchBreakpointName = keyof typeof NOTCH_BREAKPOINTS;
+
+/** Breakpoint name → min container width (px). */
+export type NotchBreakpoints = Record<string, number>;
+
+/** A value that may vary by breakpoint. Map keys are breakpoint names or raw
+ *  px thresholds (as numbers or numeric strings). `base` / `0` = no minimum. */
+export type Responsive<T> = T | { [key: string]: T };
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v != null && typeof v === "object" && !Array.isArray(v);
+}
+
+function isResponsiveMap<T>(v: Responsive<T>): v is { [key: string]: T } {
+  return isPlainObject(v);
+}
+
+function thresholdPx(key: string, breakpoints: NotchBreakpoints): number {
+  if (key in breakpoints) return breakpoints[key];
+  const n = Number(key);
+  return Number.isFinite(n) ? n : 0; // unknown name ⇒ treat as base (0)
+}
+
+/**
+ * Resolve a {@link Responsive} value for `width`. Returns `value` itself when it
+ * is not a breakpoint map. For a map, picks the entry whose threshold is the
+ * largest one `<= width`, falling back to the entry with the smallest threshold.
+ */
+export function resolveResponsive<T>(
+  value: Responsive<T>,
+  width: number,
+  breakpoints: NotchBreakpoints = NOTCH_BREAKPOINTS,
+): T {
+  if (!isResponsiveMap(value)) return value;
+  const entries = Object.entries(value)
+    .map(([key, val]) => [thresholdPx(key, breakpoints), val] as const)
+    .sort((a, b) => a[0] - b[0]);
+  if (entries.length === 0) return value as unknown as T; // degenerate empty map
+  let chosen = entries[0][1];
+  for (const [px, val] of entries) {
+    if (width >= px) chosen = val;
+    else break;
+  }
+  return chosen;
+}
+
+// --- Shape resolution -------------------------------------------------------
+
+/** A shape's block footprint matrix. `0` = empty/notch, `1` = filled, `2+` =
+ *  tier-encoded (joins via `tier`). */
+export type ShapeMatrix = number[][];
+
+/** Candidate `[cols, rows]` block costs — the grid picks the largest whose
+ *  `cols` still fits the available column count, so the component grows when
+ *  there's room. e.g. `{ sizes: [[1, 1], [2, 2]] }`. Order doesn't matter. */
+export type ShapeSizes = { readonly sizes: ReadonlyArray<readonly number[]> };
+
+/** Candidate footprint matrices in **priority order** (most-preferred first) —
+ *  the grid uses the first one whose width fits the column count, falling back
+ *  to the narrowest. e.g. `{ prefer: [[[1,1,1],[1,1,0]], [[1,1],[1,1]], [[1]]] }`. */
+export type ShapePreferences = { readonly prefer: ReadonlyArray<ShapeMatrix> };
+
+/** Every form a {@link NotchGridItem} `shape` can take. */
+export type NotchShape = Responsive<ShapeMatrix> | ShapeSizes | ShapePreferences;
+
+export function isShapeSizes(v: NotchShape): v is ShapeSizes {
+  return isPlainObject(v) && Array.isArray((v as ShapeSizes).sizes);
+}
+
+export function isShapePreferences(v: NotchShape): v is ShapePreferences {
+  return isPlainObject(v) && Array.isArray((v as ShapePreferences).prefer);
+}
+
+/** Solid `cols × rows` matrix (all `1`s). */
+export function rectMatrix(cols: number, rows: number): ShapeMatrix {
+  const c = Math.max(1, Math.floor(cols));
+  const r = Math.max(1, Math.floor(rows));
+  return Array.from({ length: r }, () => Array<number>(c).fill(1));
+}
+
+/**
+ * Collapse any {@link NotchShape} to a plain matrix for the current container
+ * `width` and column `columns` count:
+ *  - `{ prefer: [m0, m1, …] }` — the first matrix that fits `columns`, else the narrowest;
+ *  - `{ sizes: [[c,r], …] }` — the biggest `[cols,rows]` that fits `columns`, else the smallest;
+ *  - `{ base: …, md: … }` — the Tailwind-style cascade against `width`;
+ *  - a bare matrix — passes through.
+ */
+export function resolveShapeMatrix(
+  shape: NotchShape,
+  ctx: { width: number; columns: number; breakpoints?: NotchBreakpoints },
+): ShapeMatrix {
+  if (isShapePreferences(shape)) {
+    const cands = shape.prefer.filter((m) => m.length > 0 && maskCols(m) > 0);
+    if (cands.length === 0) return [[1]];
+    const fits = cands.find((m) => maskCols(m) <= ctx.columns);
+    return fits ?? cands.reduce((best, m) => (maskCols(m) < maskCols(best) ? m : best));
+  }
+  if (isShapeSizes(shape)) {
+    const dims = shape.sizes.map((s) => [s[0] ?? 1, s[1] ?? s[0] ?? 1] as const);
+    const sorted = [...dims].sort((a, b) => a[0] - b[0]);
+    let chosen = sorted[0] ?? ([1, 1] as const);
+    for (const size of sorted) if (size[0] <= ctx.columns) chosen = size;
+    return rectMatrix(chosen[0], chosen[1]);
+  }
+  return resolveResponsive(shape, ctx.width, ctx.breakpoints);
+}

--- a/src/components/ui/surfaces/notch-grid/layout.test.ts
+++ b/src/components/ui/surfaces/notch-grid/layout.test.ts
@@ -162,3 +162,66 @@ describe("optimalPlacement", () => {
     expect(optimalPlacement([], { maxCols: 4 })).toMatchObject({ placed: [], cols: 4, rows: 0 });
   });
 });
+
+describe("packItems flowOrder='farthest-fit'", () => {
+  const ascii = (m: boolean[][]) => m.map((r) => r.map((c) => (c ? "x" : ".")).join("")).join("/");
+  const ff = { flowOrder: "farthest-fit" } as const;
+  // The compact cols cap NotchGrid uses for the sub-pack: max(widest, ceil(√(area·1.6))).
+  // For a 1×1 + a 2×2 → area 5, widest 2 → cols 3.
+  const COLS = 3;
+
+  it("places a flow item at the diagonally opposite cell of an explicit one", () => {
+    // Explicit 1×1 at the bottom-left → 2×2 lands at the top-right (1,0).
+    const r = packItems(
+      [
+        { item: { key: "a" }, mask: rectMask(1, 1), col: 0, row: 2 },
+        { item: { key: "b" }, mask: rectMask(2, 2) },
+      ],
+      COLS,
+      ff,
+    );
+    expect(ascii(placementToMask(r.placed))).toBe(".xx/.xx/x..");
+  });
+
+  it("mirrors for the opposite corner — bottom-right → top-left", () => {
+    const r = packItems(
+      [
+        { item: { key: "a" }, mask: rectMask(1, 1), col: 2, row: 2 },
+        { item: { key: "b" }, mask: rectMask(2, 2) },
+      ],
+      COLS,
+      ff,
+    );
+    expect(ascii(placementToMask(r.placed))).toBe("xx./xx./..x");
+  });
+
+  it("top-left → 2×2 at the diagonal centre (1,1)", () => {
+    const r = packItems(
+      [
+        { item: { key: "a" }, mask: rectMask(1, 1), col: 0, row: 0 },
+        { item: { key: "b" }, mask: rectMask(2, 2) },
+      ],
+      COLS,
+      ff,
+    );
+    expect(ascii(placementToMask(r.placed))).toBe("x../.xx/.xx");
+  });
+
+  it("treats each placed flow item as an anchor for the next, so a flow-only pack still spreads", () => {
+    // No initial anchors → `a` lands by first-fit at (0,0) and then becomes
+    // an anchor, so `b` falls to the diagonally opposite cell rather than
+    // packing right next to `a`.
+    const r = packItems(
+      [
+        { item: { key: "a" }, mask: rectMask(1, 1) },
+        { item: { key: "b" }, mask: rectMask(2, 2) },
+      ],
+      3,
+      ff,
+    );
+    expect(r.placed.map((p) => `${(p.item as { key: string }).key}@(${p.col},${p.row})`)).toEqual([
+      "a@(0,0)",
+      "b@(1,1)",
+    ]);
+  });
+});

--- a/src/components/ui/surfaces/notch-grid/layout.test.ts
+++ b/src/components/ui/surfaces/notch-grid/layout.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+import {
+  optimalPlacement,
+  packItems,
+  placementToMask,
+  rectMask,
+  type LayoutInput,
+} from "./layout";
+
+/** Build a rectangular boolean mask of `rows × cols` true cells. */
+const rect = (cols: number, rows: number): boolean[][] =>
+  Array.from({ length: rows }, () => Array<boolean>(cols).fill(true));
+
+/** Convenience: a tagged flow item with an `r×c` rectangular footprint. */
+const box = (tag: string, cols: number, rows: number): LayoutInput<string> => ({
+  item: tag,
+  mask: rect(cols, rows),
+});
+
+const at = <T,>(r: { placed: { item: T; col: number; row: number }[] }, item: T) =>
+  r.placed.find((p) => p.item === item)!;
+
+describe("packItems", () => {
+  it("flows 1×1 boxes left-to-right then wraps", () => {
+    const res = packItems([box("a", 1, 1), box("b", 1, 1), box("c", 1, 1)], 2);
+    expect(at(res, "a")).toMatchObject({ col: 0, row: 0 });
+    expect(at(res, "b")).toMatchObject({ col: 1, row: 0 });
+    expect(at(res, "c")).toMatchObject({ col: 0, row: 1 });
+    expect(res).toMatchObject({ cols: 2, rows: 2 });
+  });
+
+  it("packs a wide box onto its own row when it doesn't fit beside others", () => {
+    const res = packItems([box("a", 1, 1), box("wide", 3, 1), box("b", 1, 1)], 3);
+    expect(at(res, "a")).toMatchObject({ col: 0, row: 0 });
+    expect(at(res, "wide")).toMatchObject({ col: 0, row: 1 });
+    // "b" backfills the gap on row 0 (cols 1–2 are free).
+    expect(at(res, "b")).toMatchObject({ col: 1, row: 0 });
+    expect(res.rows).toBe(2);
+  });
+
+  it("nestles a complementary L-shape into another item's notch", () => {
+    // A: a 2×2 block missing its bottom-right cell → leaves a 1×1 notch.
+    const aMask = [
+      [true, true],
+      [true, false],
+    ];
+    // B: a single cell — should drop into A's notch at (1, 1).
+    const res = packItems(
+      [{ item: "A", mask: aMask }, box("B", 1, 1)],
+      2,
+    );
+    expect(at(res, "A")).toMatchObject({ col: 0, row: 0 });
+    expect(at(res, "B")).toMatchObject({ col: 1, row: 1 });
+    expect(res).toMatchObject({ cols: 2, rows: 2 });
+  });
+
+  it("places explicit items first, then flows the rest around them", () => {
+    const res = packItems(
+      [
+        box("flow1", 1, 1),
+        { item: "pinned", mask: rect(1, 1), col: 0, row: 0 },
+        box("flow2", 1, 1),
+      ],
+      2,
+    );
+    expect(at(res, "pinned")).toMatchObject({ col: 0, row: 0 });
+    // flow items skip the occupied (0,0): land at (1,0) then (0,1).
+    expect(at(res, "flow1")).toMatchObject({ col: 1, row: 0 });
+    expect(at(res, "flow2")).toMatchObject({ col: 0, row: 1 });
+  });
+
+  it("clamps column count to at least 1", () => {
+    const res = packItems([box("a", 1, 1), box("b", 1, 1)], 0);
+    expect(res.cols).toBeGreaterThanOrEqual(1);
+    expect(at(res, "a")).toMatchObject({ col: 0, row: 0 });
+    expect(at(res, "b")).toMatchObject({ col: 0, row: 1 });
+  });
+
+  it("reports items wider than the column count and stacks them at col 0", () => {
+    const res = packItems([box("a", 1, 1), box("toobig", 3, 1)], 2);
+    expect(res.overflowed).toEqual(["toobig"]);
+    expect(at(res, "toobig").col).toBe(0);
+    expect(res.cols).toBe(3); // grid widened to contain it
+  });
+
+  it("returns a grid size that contains every placed item", () => {
+    const res = packItems([box("a", 2, 1), box("b", 1, 2), box("c", 1, 1)], 3);
+    for (const p of res.placed) {
+      expect(p.col + p.cols).toBeLessThanOrEqual(res.cols);
+      expect(p.row + p.rows).toBeLessThanOrEqual(res.rows);
+    }
+  });
+});
+
+describe("rectMask", () => {
+  it("builds an all-true cols×rows mask, clamped to at least 1×1", () => {
+    expect(rectMask(2, 3)).toEqual([
+      [true, true],
+      [true, true],
+      [true, true],
+    ]);
+    expect(rectMask(0, 0)).toEqual([[true]]);
+  });
+});
+
+describe("placementToMask", () => {
+  it("unions placed rectangles into one mask — gaps become notches", () => {
+    // Pack [2×2, 1×1] into 2 cols → 2×2 at (0,0), 1×1 at (2,0):
+    const { placed } = packItems(
+      [
+        { item: "big", mask: rectMask(2, 2) },
+        { item: "small", mask: rectMask(1, 1) },
+      ],
+      2,
+    );
+    expect(placementToMask(placed)).toEqual([
+      [true, true],
+      [true, true],
+      [true, false], // the 1×1 leaves the (2,1) cell empty — a notch
+    ]);
+  });
+
+  it("never returns an empty mask", () => {
+    expect(placementToMask([])).toEqual([[false]]);
+  });
+});
+
+describe("optimalPlacement", () => {
+  const sub = (id: string, w: number, h: number): LayoutInput<string> => ({
+    item: id,
+    mask: rectMask(w, h),
+  });
+
+  it("packs a 1×1 + 2×2 into the compact landscape L (xxx / ·xx)", () => {
+    const res = optimalPlacement([sub("a", 1, 1), sub("b", 2, 2)], { maxCols: 6 });
+    expect({ cols: res.cols, rows: res.rows }).toEqual({ cols: 3, rows: 2 }); // 3×2 bbox
+    const mask = placementToMask(res.placed);
+    expect(mask).toEqual([
+      [true, true, true], // xxx
+      [false, true, true], // ·xx — the 1×1 (input first) anchors the top-left
+    ]);
+  });
+
+  it("a square `targetAspect` prefers the tall stack instead", () => {
+    const res = optimalPlacement([sub("a", 1, 1), sub("b", 2, 2)], {
+      maxCols: 6,
+      targetAspect: 1,
+    });
+    expect({ cols: res.cols, rows: res.rows }).toEqual({ cols: 2, rows: 3 }); // 2×3 bbox
+  });
+
+  it("honours an explicit position and skips the search", () => {
+    const res = optimalPlacement(
+      [{ item: "pinned", mask: rectMask(1, 1), col: 3, row: 1 }, sub("flow", 1, 1)],
+      { maxCols: 4 },
+    );
+    const p = res.placed.find((x) => x.item === "pinned")!;
+    expect({ col: p.col, row: p.row }).toEqual({ col: 3, row: 1 });
+  });
+
+  it("falls back gracefully for an empty input", () => {
+    expect(optimalPlacement([], { maxCols: 4 })).toMatchObject({ placed: [], cols: 4, rows: 0 });
+  });
+});

--- a/src/components/ui/surfaces/notch-grid/layout.ts
+++ b/src/components/ui/surfaces/notch-grid/layout.ts
@@ -1,0 +1,267 @@
+// Block-aligned packing for the notch grid.
+//
+// Items declare a footprint as a boolean mask (the `1` cells of their shape).
+// `packItems` drops them into a column-bounded grid: explicitly-positioned
+// items first, then the rest flow top-to-bottom / left-to-right into the first
+// free spot where none of their filled cells collide with an occupied cell.
+// Because collision uses the *actual* filled cells (not the bounding box), a
+// complementary shape can nestle into another item's notch.
+
+import { maskCols } from "@/utils/grid-outline";
+
+export type Mask = ReadonlyArray<ReadonlyArray<boolean>>;
+
+export interface LayoutInput<T> {
+  item: T;
+  /** Resolved boolean footprint (the shape's `1` cells) for the active size. */
+  mask: Mask;
+  /** Explicit position in block units; auto-flowed when omitted. */
+  col?: number;
+  row?: number;
+}
+
+export interface PlacedItem<T> {
+  item: T;
+  /** Position in block units. */
+  col: number;
+  row: number;
+  /** Bounding-box size in blocks. */
+  cols: number;
+  rows: number;
+}
+
+export interface LayoutResult<T> {
+  placed: PlacedItem<T>[];
+  /** Total grid size in blocks (>= the requested column count). */
+  cols: number;
+  rows: number;
+  /** Items whose footprint is wider than the column count (placed at col 0,
+   *  overflowing). Lets callers warn in dev. */
+  overflowed: T[];
+}
+
+const MAX_ROWS = 100_000; // hard stop — guards against a pathological loop
+
+function dims(mask: Mask): { w: number; h: number } {
+  return { w: maskCols(mask), h: mask.length };
+}
+
+/** All-true `cols × rows` mask — the footprint of a rectangular (sub-)item. */
+export function rectMask(cols: number, rows: number): boolean[][] {
+  const c = Math.max(1, Math.floor(cols));
+  const r = Math.max(1, Math.floor(rows));
+  return Array.from({ length: r }, () => Array<boolean>(c).fill(true));
+}
+
+/** Union of placed rectangular items into one boolean mask — the derived
+ *  footprint of a panel built from sub-items. Empty cells become notches. */
+export function placementToMask<T>(placed: ReadonlyArray<PlacedItem<T>>): boolean[][] {
+  let maxRow = 1;
+  let maxCol = 1;
+  for (const p of placed) {
+    maxRow = Math.max(maxRow, p.row + p.rows);
+    maxCol = Math.max(maxCol, p.col + p.cols);
+  }
+  const mask = Array.from({ length: maxRow }, () => Array<boolean>(maxCol).fill(false));
+  for (const p of placed) {
+    for (let r = 0; r < p.rows; r++) {
+      for (let c = 0; c < p.cols; c++) mask[p.row + r][p.col + c] = true;
+    }
+  }
+  return mask;
+}
+
+/** First-fit packing into `cols` columns. Positions are in block units. */
+export function packItems<T>(
+  inputs: ReadonlyArray<LayoutInput<T>>,
+  cols: number,
+): LayoutResult<T> {
+  const C = Math.max(1, Math.floor(cols));
+  const occ: boolean[][] = [];
+  const ensureRow = (r: number) => {
+    while (occ.length <= r) occ.push(new Array<boolean>(C).fill(false));
+  };
+  const collides = (mask: Mask, atCol: number, atRow: number): boolean => {
+    for (let r = 0; r < mask.length; r++) {
+      const row = mask[r];
+      for (let c = 0; c < row.length; c++) {
+        if (!row[c]) continue;
+        const gc = atCol + c;
+        if (gc < 0 || gc >= C) return true;
+        const gr = atRow + r;
+        ensureRow(gr);
+        if (occ[gr][gc]) return true;
+      }
+    }
+    return false;
+  };
+  const occupy = (mask: Mask, atCol: number, atRow: number) => {
+    for (let r = 0; r < mask.length; r++) {
+      const row = mask[r];
+      for (let c = 0; c < row.length; c++) {
+        if (!row[c]) continue;
+        ensureRow(atRow + r);
+        occ[atRow + r][atCol + c] = true;
+      }
+    }
+  };
+
+  const placed: PlacedItem<T>[] = [];
+  const overflowed: T[] = [];
+  const isExplicit = (i: LayoutInput<T>) => i.col != null && i.row != null;
+
+  // Explicit items first — at their requested cell when it's free; if it
+  // collides with something already placed, they fall back to flowing (so
+  // dropped / pinned items can't end up overlapping each other).
+  const flowQueue: LayoutInput<T>[] = [];
+  for (const i of inputs) {
+    if (!isExplicit(i)) {
+      flowQueue.push(i);
+      continue;
+    }
+    const { w, h } = dims(i.mask);
+    if (i.col! >= 0 && i.col! + w <= C && !collides(i.mask, i.col!, i.row!)) {
+      occupy(i.mask, i.col!, i.row!);
+      placed.push({ item: i.item, col: i.col!, row: i.row!, cols: w, rows: h });
+    } else {
+      flowQueue.unshift(i); // re-flow it (with priority over plain flow items)
+    }
+  }
+
+  /** First row index after every currently-occupied row. */
+  const nextFreeRow = (): number => {
+    let row = 0;
+    for (let r = 0; r < occ.length; r++) {
+      if (occ[r].some(Boolean)) row = r + 1;
+    }
+    return row;
+  };
+
+  for (const i of flowQueue) {
+    const { w, h } = dims(i.mask);
+    if (w > C) {
+      // Footprint can't fit the column count — drop it below everything else
+      // and reserve its full row band so nothing else collides with it.
+      const row = nextFreeRow();
+      for (let r = 0; r < h; r++) {
+        ensureRow(row + r);
+        for (let c = 0; c < C; c++) occ[row + r][c] = true;
+      }
+      placed.push({ item: i.item, col: 0, row, cols: w, rows: h });
+      overflowed.push(i.item);
+      continue;
+    }
+    let found = false;
+    for (let row = 0; row < MAX_ROWS && !found; row++) {
+      for (let col = 0; col + w <= C; col++) {
+        if (!collides(i.mask, col, row)) {
+          occupy(i.mask, col, row);
+          placed.push({ item: i.item, col, row, cols: w, rows: h });
+          found = true;
+          break;
+        }
+      }
+    }
+  }
+
+  let maxRow = 0;
+  let maxCol = C;
+  for (const p of placed) {
+    maxRow = Math.max(maxRow, p.row + p.rows);
+    maxCol = Math.max(maxCol, p.col + p.cols);
+  }
+  return { placed, cols: maxCol, rows: maxRow, overflowed };
+}
+
+// --- Best-arrangement search ------------------------------------------------
+
+function maskArea(mask: Mask): number {
+  let n = 0;
+  for (const row of mask) for (const cell of row) if (cell) n++;
+  return n;
+}
+
+/** All orderings of `arr` (only call for small N). */
+function permutations<T>(arr: readonly T[]): T[][] {
+  if (arr.length <= 1) return [[...arr]];
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i++) {
+    const rest = [...arr.slice(0, i), ...arr.slice(i + 1)];
+    for (const p of permutations(rest)) out.push([arr[i], ...p]);
+  }
+  return out;
+}
+
+/** Lexicographic `<` on numeric tuples (lower wins). */
+function lexLess(a: readonly number[], b: readonly number[]): boolean {
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] < b[i]) return true;
+    if (a[i] > b[i]) return false;
+  }
+  return false;
+}
+
+export interface OptimalOptions {
+  /** Largest column count to consider. */
+  maxCols: number;
+  /** Smallest column count to consider. Default: the widest item's width. */
+  minCols?: number;
+  /** Preferred width ÷ height of the packed bounding box, used as the
+   *  tie-breaker between equally-compact layouts. Default 1.6 (gently landscape). */
+  targetAspect?: number;
+  /** Try every item ordering (exhaustive) when there are at most this many
+   *  items; above it only a few heuristic orderings are tried. Default 4
+   *  (4! = 24 packings × column counts per call — kept modest since this runs
+   *  in render). */
+  exhaustiveUpTo?: number;
+}
+
+/**
+ * Search column counts × item orderings for the arrangement with the smallest
+ * bounding-box **area**, tie-broken toward `targetAspect`, then toward fewer
+ * empty (notch) cells. For ≤ `exhaustiveUpTo` items this is an exhaustive
+ * search (genuinely optimal for the chosen objective); above it, a few good
+ * orderings are tried. Items with explicit `{ col, row }` skip the search
+ * (their layout is fixed) — packed once at `maxCols` in input order.
+ *
+ * `item` references pass through untouched, so callers map results back as with
+ * {@link packItems}.
+ */
+export function optimalPlacement<T>(
+  inputs: ReadonlyArray<LayoutInput<T>>,
+  { maxCols, minCols, targetAspect = 1.6, exhaustiveUpTo = 4 }: OptimalOptions,
+): LayoutResult<T> {
+  const C = Math.max(1, Math.floor(maxCols));
+  if (inputs.length === 0) return { placed: [], cols: C, rows: 0, overflowed: [] };
+
+  const widest = Math.max(1, ...inputs.map((i) => maskCols(i.mask)));
+  const lo = Math.max(1, Math.floor(minCols ?? widest));
+  const totalArea = inputs.reduce((a, i) => a + maskArea(i.mask), 0);
+  const hi = Math.max(lo, Math.min(C, Math.max(widest, totalArea)));
+
+  // An explicit position is absolute — don't second-guess it with a column /
+  // ordering search; just pack once at the requested width.
+  if (inputs.some((i) => i.col != null && i.row != null)) return packItems(inputs, C);
+
+  const byAreaDesc = [...inputs].sort((a, b) => maskArea(b.mask) - maskArea(a.mask));
+  const byAreaAsc = [...inputs].sort((a, b) => maskArea(a.mask) - maskArea(b.mask));
+  const orderings: ReadonlyArray<ReadonlyArray<LayoutInput<T>>> =
+    inputs.length <= exhaustiveUpTo
+      ? permutations([...inputs])
+      : [inputs, byAreaDesc, byAreaAsc];
+
+  let best: LayoutResult<T> | undefined;
+  let bestScore: readonly number[] = [Infinity, Infinity, Infinity];
+  for (let cols = lo; cols <= hi; cols++) {
+    for (const order of orderings) {
+      const res = packItems(order, cols);
+      const area = res.cols * res.rows;
+      const score = [area, Math.abs(res.cols / res.rows - targetAspect), area - totalArea];
+      if (lexLess(score, bestScore)) {
+        best = res;
+        bestScore = score;
+      }
+    }
+  }
+  return best ?? packItems(inputs, C);
+}

--- a/src/components/ui/surfaces/notch-grid/layout.ts
+++ b/src/components/ui/surfaces/notch-grid/layout.ts
@@ -71,10 +71,22 @@ export function placementToMask<T>(placed: ReadonlyArray<PlacedItem<T>>): boolea
   return mask;
 }
 
-/** First-fit packing into `cols` columns. Positions are in block units. */
+export interface PackOptions {
+  /** Flow placement strategy for non-explicit items. Default `"first-fit"` —
+   *  top-to-bottom / left-to-right scan. `"farthest-fit"` instead picks the
+   *  position that is **farthest** from any already-occupied (explicit) cell;
+   *  with no explicit items present this falls back to first-fit. Used by the
+   *  sub-item pack so the un-dragged sub-items arrange diagonally around the
+   *  dragged one instead of collapsing into its column. */
+  flowOrder?: "first-fit" | "farthest-fit";
+}
+
+/** First-fit packing into `cols` columns (or {@link PackOptions.flowOrder} for
+ *  alternative flow placement). Positions are in block units. */
 export function packItems<T>(
   inputs: ReadonlyArray<LayoutInput<T>>,
   cols: number,
+  options?: PackOptions,
 ): LayoutResult<T> {
   const C = Math.max(1, Math.floor(cols));
   const occ: boolean[][] = [];
@@ -137,6 +149,45 @@ export function packItems<T>(
     return row;
   };
 
+  /** Cells that are off-limits as "neighbours" for the farthest-fit scan —
+   *  i.e. the cells occupied by *anchor* items (explicit drops). Grown as flow
+   *  items land too so successive flow items also spread away from each other. */
+  const anchorCells: Array<readonly [number, number]> = [];
+  const recordAnchor = (mask: Mask, atCol: number, atRow: number) => {
+    for (let r = 0; r < mask.length; r++)
+      for (let c = 0; c < mask[r].length; c++)
+        if (mask[r][c]) anchorCells.push([atCol + c, atRow + r]);
+  };
+  if (options?.flowOrder === "farthest-fit") {
+    for (const p of placed) {
+      for (let r = 0; r < p.rows; r++)
+        for (let c = 0; c < p.cols; c++) anchorCells.push([p.col + c, p.row + r]);
+    }
+  }
+
+  /** Minimum Euclidean distance from any of `mask`'s cells (at the given
+   *  position) to any anchor cell. Euclidean (vs Chebyshev) breaks the tie
+   *  between an orthogonal neighbour and a diagonal one in favour of the
+   *  diagonal — which is what we want for a 1×1 in one corner and a 2×2 in
+   *  the diagonally opposite corner. */
+  const minDistTo = (mask: Mask, atCol: number, atRow: number): number => {
+    let best = Number.POSITIVE_INFINITY;
+    for (let r = 0; r < mask.length; r++) {
+      for (let c = 0; c < mask[r].length; c++) {
+        if (!mask[r][c]) continue;
+        const gx = atCol + c;
+        const gy = atRow + r;
+        for (const [ex, ey] of anchorCells) {
+          const dx = gx - ex;
+          const dy = gy - ey;
+          const d = Math.sqrt(dx * dx + dy * dy);
+          if (d < best) best = d;
+        }
+      }
+    }
+    return best;
+  };
+
   for (const i of flowQueue) {
     const { w, h } = dims(i.mask);
     if (w > C) {
@@ -152,13 +203,46 @@ export function packItems<T>(
       continue;
     }
     let found = false;
-    for (let row = 0; row < MAX_ROWS && !found; row++) {
-      for (let col = 0; col + w <= C; col++) {
-        if (!collides(i.mask, col, row)) {
-          occupy(i.mask, col, row);
-          placed.push({ item: i.item, col, row, cols: w, rows: h });
-          found = true;
-          break;
+    // Farthest-fit: pick the position that maximises distance to any anchor
+    // cell. The scan is bounded to a roughly C × C box (anchor rows + the
+    // column count, whichever is taller) — otherwise the packer would happily
+    // place the item arbitrarily far below the anchor instead of at the
+    // diagonally opposite corner of a compact panel. Falls back to first-fit
+    // when no anchor cells exist.
+    if (options?.flowOrder === "farthest-fit" && anchorCells.length > 0) {
+      const maxAnchorRow = anchorCells.reduce((m, [, r]) => Math.max(m, r), 0);
+      const scanRows = Math.max(maxAnchorRow + 1, C);
+      let bestCol = -1;
+      let bestRow = -1;
+      let bestDist = -1;
+      for (let row = 0; row + h <= scanRows; row++) {
+        for (let col = 0; col + w <= C; col++) {
+          if (collides(i.mask, col, row)) continue;
+          const d = minDistTo(i.mask, col, row);
+          if (d > bestDist) {
+            bestDist = d;
+            bestCol = col;
+            bestRow = row;
+          }
+        }
+      }
+      if (bestCol >= 0) {
+        occupy(i.mask, bestCol, bestRow);
+        placed.push({ item: i.item, col: bestCol, row: bestRow, cols: w, rows: h });
+        recordAnchor(i.mask, bestCol, bestRow);
+        found = true;
+      }
+    }
+    if (!found) {
+      for (let row = 0; row < MAX_ROWS && !found; row++) {
+        for (let col = 0; col + w <= C; col++) {
+          if (!collides(i.mask, col, row)) {
+            occupy(i.mask, col, row);
+            placed.push({ item: i.item, col, row, cols: w, rows: h });
+            if (options?.flowOrder === "farthest-fit") recordAnchor(i.mask, col, row);
+            found = true;
+            break;
+          }
         }
       }
     }

--- a/src/components/ui/surfaces/notch/Notch.stories.tsx
+++ b/src/components/ui/surfaces/notch/Notch.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Notch } from "./Notch";
 
 const meta: Meta<typeof Notch> = {
-  title: "UI/Surfaces/Notch",
+  title: "UI/Notch/Notch",
   component: Notch,
   args: {
     width: 200,

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,3 +241,41 @@ export {
   AppShell,
   type AppShellProps,
 } from "./components/layout/app-shell/app-shell/AppShell";
+export {
+  BlockShape,
+  BLOCK_SIZE,
+  type BlockShapeProps,
+} from "./components/ui/surfaces/notch-grid/BlockShape";
+export {
+  NotchGrid,
+  type NotchGridProps,
+} from "./components/ui/surfaces/notch-grid/NotchGrid";
+export {
+  NotchGridItem,
+  asSubItem,
+  type NotchGridItemProps,
+  type NotchShape,
+  type NotchSubItem,
+  type NotchSubItemInput,
+} from "./components/ui/surfaces/notch-grid/NotchGridItem";
+export {
+  NOTCH_BREAKPOINTS,
+  resolveResponsive,
+  resolveShapeMatrix,
+  rectMatrix,
+  isShapeSizes,
+  isShapePreferences,
+  type Responsive,
+  type NotchBreakpoints,
+  type NotchBreakpointName,
+  type ShapeMatrix,
+  type ShapeSizes,
+  type ShapePreferences,
+} from "./components/ui/surfaces/notch-grid/breakpoints";
+export {
+  gridOutlinePath,
+  maskFromShape,
+  maskCols,
+  maxTier,
+  type GridOutlineOptions,
+} from "./utils/grid-outline";

--- a/src/utils/grid-outline.test.ts
+++ b/src/utils/grid-outline.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+  gridOutlinePath,
+  maskCols,
+  maskFromShape,
+  maxTier,
+} from "./grid-outline";
+
+/** Count subpaths (each closed loop emits exactly one `M ... Z`). */
+const loopCount = (d: string) => (d.match(/Z/g) ?? []).length;
+/** Count distinct corner anchors: every corner emits an `A` arc (radius > 0). */
+const arcCount = (d: string) => (d.match(/ A /g) ?? []).length;
+
+describe("maskCols", () => {
+  it("returns the widest row length", () => {
+    expect(maskCols([[1, 1], [1, 1, 1], [1]])).toBe(3);
+    expect(maskCols([])).toBe(0);
+  });
+});
+
+describe("maskFromShape", () => {
+  it("fills cells with value between 1 and tier inclusive", () => {
+    const shape = [
+      [0, 1, 2],
+      [1, 2, 3],
+    ];
+    expect(maskFromShape(shape, 1)).toEqual([
+      [false, true, false],
+      [true, false, false],
+    ]);
+    expect(maskFromShape(shape, 2)).toEqual([
+      [false, true, true],
+      [true, true, false],
+    ]);
+    expect(maskFromShape(shape, 3)).toEqual([
+      [false, true, true],
+      [true, true, true],
+    ]);
+  });
+});
+
+describe("maxTier", () => {
+  it("is 1 for a plain 0/1 matrix", () => {
+    expect(maxTier([[0, 1], [1, 1]])).toBe(1);
+  });
+  it("returns the highest tier referenced", () => {
+    expect(maxTier([[1, 2], [3, 0]])).toBe(3);
+  });
+});
+
+describe("gridOutlinePath", () => {
+  it("returns empty string for an empty mask", () => {
+    expect(gridOutlinePath([], { cell: 10 })).toBe("");
+    expect(gridOutlinePath([[false]], { cell: 10 })).toBe("");
+  });
+
+  it("traces a single block as one closed loop with 4 rounded corners", () => {
+    const d = gridOutlinePath([[true]], { cell: 100 });
+    expect(d.startsWith("M ")).toBe(true);
+    expect(d.trim().endsWith("Z")).toBe(true);
+    expect(loopCount(d)).toBe(1);
+    expect(arcCount(d)).toBe(4);
+  });
+
+  it("merges collinear cells — a 1x3 row still has only 4 corners", () => {
+    expect(arcCount(gridOutlinePath([[true, true, true]], { cell: 50 }))).toBe(4);
+  });
+
+  it("an L-shape has 6 corners (5 convex + 1 concave)", () => {
+    const d = gridOutlinePath(
+      [
+        [true, false],
+        [true, true],
+      ],
+      { cell: 40 },
+    );
+    expect(loopCount(d)).toBe(1);
+    expect(arcCount(d)).toBe(6);
+  });
+
+  it("the user's example shape has 8 corners (one notch on each cut corner)", () => {
+    const d = gridOutlinePath(
+      maskFromShape(
+        [
+          [0, 1, 1, 1],
+          [1, 1, 1, 1],
+          [1, 1, 1, 0],
+        ],
+        1,
+      ),
+      { cell: 30 },
+    );
+    expect(loopCount(d)).toBe(1);
+    // 6 convex corners of the staircase rectangle outline + 2 concave notch
+    // corners (one per cut block) = 8.
+    expect(arcCount(d)).toBe(8);
+  });
+
+  it("a donut traces two loops (outer ring + interior hole)", () => {
+    const d = gridOutlinePath(
+      [
+        [true, true, true],
+        [true, false, true],
+        [true, true, true],
+      ],
+      { cell: 20 },
+    );
+    expect(loopCount(d)).toBe(2);
+    // outer square (4) + inner square (4) = 8
+    expect(arcCount(d)).toBe(8);
+  });
+
+  it("clamps corner radii so adjacent corners on a short edge don't overlap", () => {
+    // A single 10px block with radius 12: each of the 4 corners would want
+    // 12px but the edge is only 10px, so radius clamps to 5.
+    const d = gridOutlinePath([[true]], { cell: 10, radius: 12 });
+    expect(d).toContain("A 5 5 ");
+  });
+
+  it("erodes the shape by gap/2 — outer edges pull inward", () => {
+    // 200×100 rect, gap 20 ⇒ eroded by 10 ⇒ corners at (10,10)…(190,90).
+    const d = gridOutlinePath([[true, true]], { cell: 100, gap: 20, radius: 10 });
+    expect(arcCount(d)).toBe(4); // still a rectangle
+    expect(d).toMatch(/\b190\b/);
+    expect(d).toMatch(/\b90\b/);
+    expect(d).not.toMatch(/\b200\b/); // the un-eroded edge is gone
+  });
+
+  it("clamps gap below `cell` so the shape can't collapse", () => {
+    // gap 1000 with cell 100 ⇒ erosion clamps to (100−2)/2 = 49, leaving a sliver.
+    const d = gridOutlinePath([[true]], { cell: 100, gap: 1000 });
+    expect(d).not.toBe("");
+    expect(arcCount(d)).toBe(4);
+  });
+
+  it("respects a notch on a shape edge as a concave (sweep 0) corner", () => {
+    const d = gridOutlinePath(
+      [
+        [true, true, true],
+        [true, false, true],
+        [true, true, true],
+      ],
+      { cell: 30 },
+    );
+    // interior hole corners are concave from the filled region's perspective
+    expect(d).toMatch(/A \d+(\.\d+)? \d+(\.\d+)? 0 0 0 /); // at least one sweep-0 arc
+    expect(d).toMatch(/A \d+(\.\d+)? \d+(\.\d+)? 0 0 1 /); // and at least one sweep-1 arc
+  });
+});

--- a/src/utils/grid-outline.ts
+++ b/src/utils/grid-outline.ts
@@ -70,64 +70,81 @@ export function gridOutlinePath(
   // Keep at least a sliver of shape even when gap is set absurdly high.
   const erosion = Math.max(0, Math.min(gap, cell - 2)) / 2;
 
-  // Trace each *edge-connected* component independently. Two cells that share
-  // only a corner (e.g. (1,1) and (2,2)) belong to different components, so
-  // their boundaries are written into separate edge maps and never get merged
-  // at the shared point — a single `Map<string, Pt>` keyed by edge-start would
-  // otherwise have the second cell's edge overwrite the first's, hooking the
-  // two loops into one and producing the "thin strip joining the squares" bug.
-  const cid: number[][] = mask.map((row) => row.map(() => -1));
-  let nComponents = 0;
+  // Directed boundary edges, oriented so the filled cell sits on the *right*
+  // of travel — every cell contributes its 4 boundary edges clockwise in
+  // y-down screen coords. Keyed by edge-start, with a *list* of out-points
+  // so a single junction (two diagonally-touching cells meeting at a corner)
+  // doesn't have one cell's edge silently overwrite the other's. The walker
+  // then naturally turns *into* the other cell's edge at the junction, so the
+  // two regions read as one shape with two concave inverse-radius arcs facing
+  // each other at the shared corner — the same path style `<Notch>` uses for
+  // its body↔tab transition.
+  const edges = new Map<string, Pt[]>();
+  const pushEdge = (from: Pt, to: Pt) => {
+    const k = ptKey(from[0], from[1]);
+    const list = edges.get(k);
+    if (list) list.push(to);
+    else edges.set(k, [to]);
+  };
   for (let r = 0; r < rows; r++) {
     for (let c = 0; c < mask[r].length; c++) {
-      if (!mask[r][c] || cid[r][c] !== -1) continue;
-      const id = nComponents++;
-      const stack: Pt[] = [[c, r]];
-      while (stack.length > 0) {
-        const [cc, rr] = stack.pop()!;
-        if (!filled(rr, cc) || cid[rr][cc] !== -1) continue;
-        cid[rr][cc] = id;
-        stack.push([cc + 1, rr], [cc - 1, rr], [cc, rr + 1], [cc, rr - 1]);
-      }
+      if (!mask[r][c]) continue;
+      const tl: Pt = [c, r];
+      const tr: Pt = [c + 1, r];
+      const br: Pt = [c + 1, r + 1];
+      const bl: Pt = [c, r + 1];
+      if (!filled(r - 1, c)) pushEdge(tl, tr); // top
+      if (!filled(r, c + 1)) pushEdge(tr, br); // right
+      if (!filled(r + 1, c)) pushEdge(br, bl); // bottom
+      if (!filled(r, c - 1)) pushEdge(bl, tl); // left
     }
   }
 
+  // Walk each loop. At a junction (multiple out-edges share a start point) we
+  // pick the *most-CCW* turn from the incoming direction — i.e. we turn *into*
+  // the other cell's boundary. That keeps the merged loop closed with two
+  // concave corners at the shared point (the "double-back" the renderer wants),
+  // instead of arbitrarily picking one cell's edge and orphaning the other.
+  const visitedEdges = new Set<string>();
   const subpaths: string[] = [];
-  for (let component = 0; component < nComponents; component++) {
-    // Directed boundary edges *for this component only*, oriented so the
-    // filled cell sits on the right of travel (clockwise in y-down screen
-    // coords). Keyed by start point so walking a loop is `next = edges.get(end)`.
-    const edges = new Map<string, Pt>();
-    const inComponent = (r: number, c: number) =>
-      filled(r, c) && cid[r][c] === component;
-    for (let r = 0; r < rows; r++) {
-      for (let c = 0; c < mask[r].length; c++) {
-        if (cid[r][c] !== component) continue;
-        const tl: Pt = [c, r];
-        const tr: Pt = [c + 1, r];
-        const br: Pt = [c + 1, r + 1];
-        const bl: Pt = [c, r + 1];
-        if (!inComponent(r - 1, c)) edges.set(ptKey(tl[0], tl[1]), tr); // top
-        if (!inComponent(r, c + 1)) edges.set(ptKey(tr[0], tr[1]), br); // right
-        if (!inComponent(r + 1, c)) edges.set(ptKey(br[0], br[1]), bl); // bottom
-        if (!inComponent(r, c - 1)) edges.set(ptKey(bl[0], bl[1]), tl); // left
-      }
-    }
-
-    // Walk each loop in this component, then drop collinear midpoints so only
-    // true corners remain. A component with holes (e.g. a frame around a notch)
-    // contributes one outer loop + one inner loop per hole.
-    const visited = new Set<string>();
-    for (const startKey of edges.keys()) {
-      if (visited.has(startKey)) continue;
+  const edgeKey = (from: string, to: Pt) => `${from}>${to[0]},${to[1]}`;
+  for (const [startKey, outs] of edges) {
+    for (const startTo of outs) {
+      if (visitedEdges.has(edgeKey(startKey, startTo))) continue;
       const loop: Pt[] = [];
-      let cur: string | undefined = startKey;
-      while (cur && !visited.has(cur)) {
-        visited.add(cur);
-        const [x, y] = cur.split(",").map(Number);
-        loop.push([x, y]);
-        const next = edges.get(cur);
-        cur = next ? ptKey(next[0], next[1]) : undefined;
+      let cur = startKey;
+      let to: Pt | null = startTo;
+      let inDir: [number, number] = [
+        startTo[0] - Number(startKey.split(",")[0]),
+        startTo[1] - Number(startKey.split(",")[1]),
+      ];
+      while (to) {
+        const k = edgeKey(cur, to);
+        if (visitedEdges.has(k)) break;
+        visitedEdges.add(k);
+        const [cx, cy] = cur.split(",").map(Number);
+        loop.push([cx, cy]);
+        const next = ptKey(to[0], to[1]);
+        const ndx = to[0] - cx;
+        const ndy = to[1] - cy;
+        inDir = [ndx, ndy];
+        cur = next;
+        // Pick the most-CCW unvisited out-edge from `cur`. y-down: cross > 0
+        // is CW, cross < 0 is CCW; we want the smallest (most-negative) cross.
+        const candidates = edges.get(cur) ?? [];
+        let best: Pt | null = null;
+        let bestCross = Number.POSITIVE_INFINITY;
+        for (const cand of candidates) {
+          if (visitedEdges.has(edgeKey(cur, cand))) continue;
+          const odx = cand[0] - to[0];
+          const ody = cand[1] - to[1];
+          const cross = inDir[0] * ody - inDir[1] * odx;
+          if (cross < bestCross) {
+            bestCross = cross;
+            best = cand;
+          }
+        }
+        to = best;
       }
       const corners = collinearStripped(loop).map(
         ([x, y]) => [x * cell, y * cell] as Pt,

--- a/src/utils/grid-outline.ts
+++ b/src/utils/grid-outline.ts
@@ -70,45 +70,72 @@ export function gridOutlinePath(
   // Keep at least a sliver of shape even when gap is set absurdly high.
   const erosion = Math.max(0, Math.min(gap, cell - 2)) / 2;
 
-  // Directed boundary edges, oriented so the filled cell sits on the *right*
-  // of the direction of travel — which makes every cell contribute its edges
-  // clockwise (y points down). Keyed by start point so a loop is just
-  // `next = edges.get(end)`.
-  const edges = new Map<string, Pt>();
+  // Trace each *edge-connected* component independently. Two cells that share
+  // only a corner (e.g. (1,1) and (2,2)) belong to different components, so
+  // their boundaries are written into separate edge maps and never get merged
+  // at the shared point — a single `Map<string, Pt>` keyed by edge-start would
+  // otherwise have the second cell's edge overwrite the first's, hooking the
+  // two loops into one and producing the "thin strip joining the squares" bug.
+  const cid: number[][] = mask.map((row) => row.map(() => -1));
+  let nComponents = 0;
   for (let r = 0; r < rows; r++) {
     for (let c = 0; c < mask[r].length; c++) {
-      if (!mask[r][c]) continue;
-      const tl: Pt = [c, r];
-      const tr: Pt = [c + 1, r];
-      const br: Pt = [c + 1, r + 1];
-      const bl: Pt = [c, r + 1];
-      if (!filled(r - 1, c)) edges.set(ptKey(tl[0], tl[1]), tr); // top
-      if (!filled(r, c + 1)) edges.set(ptKey(tr[0], tr[1]), br); // right
-      if (!filled(r + 1, c)) edges.set(ptKey(br[0], br[1]), bl); // bottom
-      if (!filled(r, c - 1)) edges.set(ptKey(bl[0], bl[1]), tl); // left
+      if (!mask[r][c] || cid[r][c] !== -1) continue;
+      const id = nComponents++;
+      const stack: Pt[] = [[c, r]];
+      while (stack.length > 0) {
+        const [cc, rr] = stack.pop()!;
+        if (!filled(rr, cc) || cid[rr][cc] !== -1) continue;
+        cid[rr][cc] = id;
+        stack.push([cc + 1, rr], [cc - 1, rr], [cc, rr + 1], [cc, rr - 1]);
+      }
     }
   }
 
-  // Walk each loop, then drop collinear midpoints so only true corners remain.
-  const visited = new Set<string>();
   const subpaths: string[] = [];
-  for (const startKey of edges.keys()) {
-    if (visited.has(startKey)) continue;
-    const loop: Pt[] = [];
-    let cur: string | undefined = startKey;
-    while (cur && !visited.has(cur)) {
-      visited.add(cur);
-      const [x, y] = cur.split(",").map(Number);
-      loop.push([x, y]);
-      const next = edges.get(cur);
-      cur = next ? ptKey(next[0], next[1]) : undefined;
+  for (let component = 0; component < nComponents; component++) {
+    // Directed boundary edges *for this component only*, oriented so the
+    // filled cell sits on the right of travel (clockwise in y-down screen
+    // coords). Keyed by start point so walking a loop is `next = edges.get(end)`.
+    const edges = new Map<string, Pt>();
+    const inComponent = (r: number, c: number) =>
+      filled(r, c) && cid[r][c] === component;
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < mask[r].length; c++) {
+        if (cid[r][c] !== component) continue;
+        const tl: Pt = [c, r];
+        const tr: Pt = [c + 1, r];
+        const br: Pt = [c + 1, r + 1];
+        const bl: Pt = [c, r + 1];
+        if (!inComponent(r - 1, c)) edges.set(ptKey(tl[0], tl[1]), tr); // top
+        if (!inComponent(r, c + 1)) edges.set(ptKey(tr[0], tr[1]), br); // right
+        if (!inComponent(r + 1, c)) edges.set(ptKey(br[0], br[1]), bl); // bottom
+        if (!inComponent(r, c - 1)) edges.set(ptKey(bl[0], bl[1]), tl); // left
+      }
     }
-    const corners = collinearStripped(loop).map(
-      ([x, y]) => [x * cell, y * cell] as Pt,
-    );
-    if (corners.length >= 3) {
-      const offset = erosion > 0 ? erodeRectilinear(corners, erosion) : corners;
-      subpaths.push(roundedRectilinearPath(offset, radius, inverseRadius));
+
+    // Walk each loop in this component, then drop collinear midpoints so only
+    // true corners remain. A component with holes (e.g. a frame around a notch)
+    // contributes one outer loop + one inner loop per hole.
+    const visited = new Set<string>();
+    for (const startKey of edges.keys()) {
+      if (visited.has(startKey)) continue;
+      const loop: Pt[] = [];
+      let cur: string | undefined = startKey;
+      while (cur && !visited.has(cur)) {
+        visited.add(cur);
+        const [x, y] = cur.split(",").map(Number);
+        loop.push([x, y]);
+        const next = edges.get(cur);
+        cur = next ? ptKey(next[0], next[1]) : undefined;
+      }
+      const corners = collinearStripped(loop).map(
+        ([x, y]) => [x * cell, y * cell] as Pt,
+      );
+      if (corners.length >= 3) {
+        const offset = erosion > 0 ? erodeRectilinear(corners, erosion) : corners;
+        subpaths.push(roundedRectilinearPath(offset, radius, inverseRadius));
+      }
     }
   }
   return subpaths.join(" ");

--- a/src/utils/grid-outline.ts
+++ b/src/utils/grid-outline.ts
@@ -1,0 +1,214 @@
+// Turns a boolean block-grid into a rounded SVG outline path.
+//
+// A "notched surface" is a grid of square blocks. A `true` cell is part of the
+// shape; a `false` cell is a hole / notch cut-out. This walks the rectilinear
+// boundary of the `true` region(s) and emits an SVG path `d` string with
+// rounded corners — convex corners use `radius`, concave (notch) corners use
+// `inverseRadius` — mirroring the look of the rectangle-with-one-notch `Notch`
+// component but for an arbitrary shape.
+//
+// A `gap` *erodes* the shape by `gap / 2` on every boundary: the outer edges
+// pull inward (so neighbouring items leave a gap between them) and notch holes
+// grow outward by the same amount (so an item nestled into a notch keeps that
+// gap). One uniform offset everywhere ⇒ a consistent visual gap regardless of
+// where the boundary is.
+//
+// Limitations: regions must be edge-connected. Two blocks touching only at a
+// corner (e.g. `[[1,0],[0,1]]`) is ambiguous and not supported — interior
+// holes and edge notches are. Render the result with `fillRule="evenodd"` so
+// interior holes carve out correctly.
+
+export interface GridOutlineOptions {
+  /** Pixels per grid cell. */
+  cell: number;
+  /** Convex corner radius (px). Default 24. */
+  radius?: number;
+  /** Concave / notch corner radius (px). Default 32 — rounder than the outer
+   *  corners so notch curves read openly. */
+  inverseRadius?: number;
+  /** Erode the whole boundary by `gap / 2` px, opening a `gap`-px space between
+   *  this shape and anything flush against it (incl. items in its notches).
+   *  Clamped below `cell` so the shape can't collapse. Default 0. */
+  gap?: number;
+}
+
+type Pt = readonly [number, number];
+
+const ptKey = (x: number, y: number) => `${x},${y}`;
+
+/** Largest column count across all rows of a matrix. */
+export function maskCols(matrix: readonly { readonly length: number }[]): number {
+  let cols = 0;
+  for (const row of matrix) cols = Math.max(cols, row.length);
+  return cols;
+}
+
+/** Build a `boolean[][]` from a tiered shape matrix: a cell is filled at `tier`
+ *  iff `1 <= value <= tier`. Higher values appear only as more space unlocks. */
+export function maskFromShape(
+  shape: readonly (readonly number[])[],
+  tier: number,
+): boolean[][] {
+  return shape.map((row) => row.map((v) => v >= 1 && v <= tier));
+}
+
+/** Max tier referenced by a shape matrix (so callers know how many breakpoints
+ *  it defines). Returns 1 for a plain 0/1 matrix. */
+export function maxTier(shape: readonly (readonly number[])[]): number {
+  let m = 1;
+  for (const row of shape) for (const v of row) if (v > m) m = v;
+  return m;
+}
+
+export function gridOutlinePath(
+  mask: readonly (readonly boolean[])[],
+  { cell, radius = 24, inverseRadius = 32, gap = 0 }: GridOutlineOptions,
+): string {
+  const rows = mask.length;
+  const filled = (r: number, c: number): boolean =>
+    r >= 0 && r < rows && c >= 0 && c < mask[r].length && !!mask[r][c];
+  // Keep at least a sliver of shape even when gap is set absurdly high.
+  const erosion = Math.max(0, Math.min(gap, cell - 2)) / 2;
+
+  // Directed boundary edges, oriented so the filled cell sits on the *right*
+  // of the direction of travel — which makes every cell contribute its edges
+  // clockwise (y points down). Keyed by start point so a loop is just
+  // `next = edges.get(end)`.
+  const edges = new Map<string, Pt>();
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < mask[r].length; c++) {
+      if (!mask[r][c]) continue;
+      const tl: Pt = [c, r];
+      const tr: Pt = [c + 1, r];
+      const br: Pt = [c + 1, r + 1];
+      const bl: Pt = [c, r + 1];
+      if (!filled(r - 1, c)) edges.set(ptKey(tl[0], tl[1]), tr); // top
+      if (!filled(r, c + 1)) edges.set(ptKey(tr[0], tr[1]), br); // right
+      if (!filled(r + 1, c)) edges.set(ptKey(br[0], br[1]), bl); // bottom
+      if (!filled(r, c - 1)) edges.set(ptKey(bl[0], bl[1]), tl); // left
+    }
+  }
+
+  // Walk each loop, then drop collinear midpoints so only true corners remain.
+  const visited = new Set<string>();
+  const subpaths: string[] = [];
+  for (const startKey of edges.keys()) {
+    if (visited.has(startKey)) continue;
+    const loop: Pt[] = [];
+    let cur: string | undefined = startKey;
+    while (cur && !visited.has(cur)) {
+      visited.add(cur);
+      const [x, y] = cur.split(",").map(Number);
+      loop.push([x, y]);
+      const next = edges.get(cur);
+      cur = next ? ptKey(next[0], next[1]) : undefined;
+    }
+    const corners = collinearStripped(loop).map(
+      ([x, y]) => [x * cell, y * cell] as Pt,
+    );
+    if (corners.length >= 3) {
+      const offset = erosion > 0 ? erodeRectilinear(corners, erosion) : corners;
+      subpaths.push(roundedRectilinearPath(offset, radius, inverseRadius));
+    }
+  }
+  return subpaths.join(" ");
+}
+
+function collinearStripped(loop: readonly Pt[]): Pt[] {
+  const n = loop.length;
+  const out: Pt[] = [];
+  for (let i = 0; i < n; i++) {
+    const prev = loop[(i - 1 + n) % n];
+    const p = loop[i];
+    const next = loop[(i + 1) % n];
+    const d1x = p[0] - prev[0];
+    const d1y = p[1] - prev[1];
+    const d2x = next[0] - p[0];
+    const d2y = next[1] - p[1];
+    if (d1x * d2y - d1y * d2x !== 0) out.push(p); // cross != 0 ⇒ a corner
+  }
+  return out;
+}
+
+/**
+ * Offset a closed rectilinear polygon (corners alternating H/V edges, built
+ * clockwise with the filled region on the right of each directed edge) inward
+ * by `e` px: every edge's supporting line shifts toward the filled side, then
+ * corners are recomputed as the intersection of the two adjacent shifted lines.
+ * Convex corners move inward; concave (notch) corners move outward — exactly
+ * the "shrink the shape, grow the notches" behaviour we want for gaps.
+ */
+function erodeRectilinear(corners: readonly Pt[], e: number): Pt[] {
+  const n = corners.length;
+  // Per edge i (corners[i] → corners[i+1]): which axis it's fixed in, and the
+  // shifted value of that fixed coordinate. Inward normal of a clockwise edge
+  // in y-down screen space is (−dy, dx) with dx,dy ∈ {−1,0,1}.
+  const shifted = corners.map((p, i) => {
+    const q = corners[(i + 1) % n];
+    const dx = Math.sign(q[0] - p[0]);
+    const dy = Math.sign(q[1] - p[1]);
+    const horizontal = dy === 0; // dx === 0 ⇒ vertical
+    return horizontal
+      ? { axis: "y" as const, value: p[1] + dx * e } // inward.y = dx
+      : { axis: "x" as const, value: p[0] + -dy * e }; // inward.x = -dy
+  });
+  const out: Pt[] = [];
+  for (let i = 0; i < n; i++) {
+    const incoming = shifted[(i - 1 + n) % n];
+    const outgoing = shifted[i];
+    // The two edges meeting at corner i are perpendicular: one fixes x, the
+    // other y. Take each coordinate from whichever edge fixes it.
+    const x = incoming.axis === "x" ? incoming.value : outgoing.value;
+    const y = incoming.axis === "y" ? incoming.value : outgoing.value;
+    out.push([x, y]);
+  }
+  return out;
+}
+
+function roundedRectilinearPath(
+  px: readonly Pt[],
+  radius: number,
+  inverseRadius: number,
+): string {
+  const n = px.length;
+  const parts: string[] = [];
+  for (let i = 0; i < n; i++) {
+    const a = px[(i - 1 + n) % n];
+    const v = px[i];
+    const b = px[(i + 1) % n];
+    const inLen = dist(a, v);
+    const outLen = dist(v, b);
+    const inDir = unit(a, v);
+    const outDir = unit(v, b);
+    // y-down: cross > 0 is a clockwise turn ⇒ convex corner of the filled
+    // region; cross < 0 is a notch (concave) corner.
+    const cross = inDir[0] * outDir[1] - inDir[1] * outDir[0];
+    const convex = cross > 0;
+    const rho = Math.min(convex ? radius : inverseRadius, inLen / 2, outLen / 2);
+    const p1 = [v[0] - inDir[0] * rho, v[1] - inDir[1] * rho] as const;
+    const p2 = [v[0] + outDir[0] * rho, v[1] + outDir[1] * rho] as const;
+    parts.push(`${i === 0 ? "M" : "L"} ${fmt(p1)}`);
+    if (rho > 0) parts.push(`A ${num(rho)} ${num(rho)} 0 0 ${convex ? 1 : 0} ${fmt(p2)}`);
+  }
+  parts.push("Z");
+  return parts.join(" ");
+}
+
+function dist(a: Pt, b: Pt): number {
+  return Math.hypot(b[0] - a[0], b[1] - a[1]);
+}
+
+function unit(a: Pt, b: Pt): Pt {
+  const dx = b[0] - a[0];
+  const dy = b[1] - a[1];
+  const len = Math.hypot(dx, dy) || 1;
+  return [dx / len, dy / len];
+}
+
+function num(n: number): string {
+  return Number.isInteger(n) ? String(n) : n.toFixed(2);
+}
+
+function fmt(p: Pt): string {
+  return `${num(p[0])},${num(p[1])}`;
+}


### PR DESCRIPTION
Adds the **notched-layout** family for data-driven overview pages:

- **`BlockShape`** — a surface whose outline follows a grid of 96px blocks: pass a `0`/`1` matrix (`0` = a notch / cutout; `2+` cells unlock at bigger size tiers) and it traces the rectilinear boundary, rounds convex *and* concave corners (`radius` / `inverseRadius`), erodes by `gap/2` for consistent spacing, and clips content to the shape.
- **`NotchGrid`** — measures its container width, picks each item's shape (Tailwind-style responsive `breakpoints` map, a `{sizes}` candidate list, or a `{prefer}` priority list), or packs its `subItems` (each with a `[cols,rows]` block cost — the panel's notched footprint is the union, arranged via `optimalPlacement`), then polyomino-bin-packs everything — with `nest` it slots small items into other items' notches. Supports `draggable` drag-to-place with `onItemMove`.
- **`NotchGridItem`** / `asSubItem` — declarative items / sub-items.
- `src/utils/grid-outline.ts` — the boolean-grid → rounded-rectilinear-SVG-path geometry; `breakpoints.ts` (responsive resolution) and `layout.ts` (packing) helpers, each unit-tested.
- Moves the existing `Notch` story to `UI/Notch/Notch` (so it sits next to `UI/Notch/BlockShape` / `UI/Notch/NotchGrid`).
- ~8 + 6 + 16 + 14 + 14 tests across the bundle.
- Reviewed with `/simplify`.

Independent of the chart PRs — branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)