### PR TITLE
feat(chart): SparklineLine

### DIFF
--- a/src/components/ui/chart/sparkline-line/SparklineLine.stories.tsx
+++ b/src/components/ui/chart/sparkline-line/SparklineLine.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SparklineLine } from "./SparklineLine";
+
+const seed = (n: number) => {
+  const x = Math.sin(n + 1) * 10_000;
+  return x - Math.floor(x);
+};
+const series = (count: number, base: number, variance: number) =>
+  Array.from({ length: count }, (_, i) => Math.max(0, base + (seed(i) - 0.5) * variance * 2));
+
+const LABELLED = series(14, 60, 36).map((value, i) => ({ value: Math.round(value), label: `Wk ${i + 1} · ${Math.round(value)}` }));
+
+const meta: Meta<typeof SparklineLine> = {
+  title: "UI/Chart/SparklineLine",
+  component: SparklineLine,
+  args: { data: LABELLED, endDot: true },
+};
+
+export default meta;
+type Story = StoryObj<typeof SparklineLine>;
+
+/** Drop it into any sized box — values auto-scale to the height. Hover for a
+ *  chip; the end-dot marks the latest value. */
+export const Playground: Story = {
+  render: (args) => (
+    <div className="bg-background p-6">
+      <div className="h-28 w-64 rounded-2xl border border-outline-variant p-3">
+        <SparklineLine {...args} />
+      </div>
+    </div>
+  ),
+};
+
+/** `areaClassName="fill-primary/15"` paints a tinted area under the line. */
+export const WithArea: Story = {
+  render: () => (
+    <div className="bg-background p-6">
+      <div className="h-28 w-64 rounded-2xl border border-outline-variant p-3">
+        <SparklineLine data={LABELLED} areaClassName="fill-primary/15" />
+      </div>
+    </div>
+  ),
+};
+
+/** The line + dot colour follow the wrapper's `text-…`, so a sparkline reads
+ *  well on whatever surface it sits on. */
+export const Tones: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-start gap-6 bg-background p-6">
+      <div className="h-24 w-64 rounded-2xl bg-surface-container-low p-3">
+        <SparklineLine data={LABELLED} />
+      </div>
+      <div className="h-24 w-64 rounded-2xl bg-primary-container p-3">
+        <SparklineLine data={LABELLED} className="text-on-primary-container" areaClassName="fill-on-primary-container/15" />
+      </div>
+      <div className="h-40 w-80 rounded-2xl bg-surface-container p-4">
+        <SparklineLine data={LABELLED} className="text-tertiary" areaClassName="fill-tertiary/15" />
+      </div>
+    </div>
+  ),
+};

--- a/src/components/ui/chart/sparkline-line/SparklineLine.test.tsx
+++ b/src/components/ui/chart/sparkline-line/SparklineLine.test.tsx
@@ -1,0 +1,43 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SparklineLine } from "./SparklineLine";
+
+afterEach(cleanup);
+
+describe("SparklineLine", () => {
+  it("renders an svg with a (no-fill) line path", () => {
+    const { container } = render(<SparklineLine data={[1, 5, 3, 8, 4]} endDot={false} />);
+    expect(container.querySelector("svg")).not.toBeNull();
+    expect(container.querySelector('path[fill="none"]')).not.toBeNull();
+  });
+
+  it("renders an area path only when `areaClassName` is set", () => {
+    const { container, rerender } = render(<SparklineLine data={[1, 2, 3]} />);
+    expect(container.querySelectorAll("path")).toHaveLength(1); // line only
+    rerender(<SparklineLine data={[1, 2, 3]} areaClassName="fill-primary/15" />);
+    expect(container.querySelectorAll("path")).toHaveLength(2); // area + line
+  });
+
+  it("renders the end dot by default; `endDot={false}` drops it", () => {
+    const { container, rerender } = render(<SparklineLine data={[1, 2, 3]} />);
+    expect(container.querySelectorAll("span.rounded-full")).toHaveLength(1);
+    rerender(<SparklineLine data={[1, 2, 3]} endDot={false} />);
+    expect(container.querySelectorAll("span.rounded-full")).toHaveLength(0);
+  });
+
+  it("returns null for empty data", () => {
+    const { container } = render(<SparklineLine data={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("pops a portaled chip on hover and clears it on leave", () => {
+    const { container } = render(<SparklineLine data={[10, 20, 30]} endDot={false} />);
+    expect(screen.queryByText("30")).toBeNull();
+    // jsdom's getBoundingClientRect returns zeros, so the nearest-point math
+    // clamps to the last index — the chip should show its value ("30").
+    fireEvent.mouseMove(container.querySelector("svg")!, { clientX: 50, clientY: 5 });
+    expect(screen.getByText("30")).toBeInTheDocument(); // rendered into <body>
+    fireEvent.mouseLeave(container.querySelector("svg")!);
+    expect(screen.queryByText("30")).toBeNull();
+  });
+});

--- a/src/components/ui/chart/sparkline-line/SparklineLine.tsx
+++ b/src/components/ui/chart/sparkline-line/SparklineLine.tsx
@@ -1,0 +1,137 @@
+import { useRef, useState, type MouseEvent as ReactMouseEvent } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "SparklineLine",
+  description:
+    "A tiny line / area sparkline that fills its container — values are auto-scaled to the available height; the line + end-dot + hover-dot share the wrapper's text colour (`text-…`). Hovering shows the nearest point's value in a chip portaled to <body> so it isn't clipped. Sibling of <Sparkline>.",
+};
+
+/** One point: a raw value (auto-scaled to the container's height), optionally
+ *  with a `label` for the hover chip (defaults to the value). */
+export type SparklineLinePoint = number | { value: number; label?: string };
+
+const pointValue = (p: SparklineLinePoint) => (typeof p === "number" ? p : p.value);
+const pointLabel = (p: SparklineLinePoint) =>
+  typeof p === "number" ? String(p) : (p.label ?? String(p.value));
+
+export interface SparklineLineProps {
+  data: ReadonlyArray<SparklineLinePoint>;
+  /** Optional area-fill class painted under the line (e.g. `"fill-primary/15"`).
+   *  Omit for a bare line. */
+  areaClassName?: string;
+  /** Show a static dot at the latest value. Default true. */
+  endDot?: boolean;
+  /** Classes for the floating hover chip. Default `"bg-on-surface text-surface"`. */
+  chipClassName?: string;
+  /** Wrapper classes — use `text-…` to set the line / dot colour.
+   *  Default `"text-primary"`. */
+  className?: string;
+}
+
+export function SparklineLine({
+  data,
+  areaClassName,
+  endDot = true,
+  chipClassName,
+  className,
+}: SparklineLineProps) {
+  // The chip is portaled to <body> so a clipping/overflow-hidden ancestor
+  // (e.g. a MetricBlock cell or a NotchGrid notch) can't cut it off.
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [hover, setHover] = useState<{ index: number; x: number; y: number } | null>(null);
+  if (data.length === 0) return null;
+
+  // Project values into a 0–100 viewBox; `preserveAspectRatio="none"` stretches
+  // it to fill the container, and `vector-effect="non-scaling-stroke"` keeps
+  // the stroke a uniform width regardless of aspect.
+  const values = data.map(pointValue);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const n = values.length;
+  const pts = values.map((v, i): readonly [number, number] => [
+    n === 1 ? 50 : (i / (n - 1)) * 100,
+    (1 - (v - min) / range) * 100,
+  ]);
+  const linePath = pts
+    .map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`)
+    .join(" ");
+  const areaPath = areaClassName
+    ? `${linePath} L${pts.at(-1)![0].toFixed(2)},100 L${pts[0][0].toFixed(2)},100 Z`
+    : null;
+
+  const onMove = (e: ReactMouseEvent<SVGSVGElement>) => {
+    const r = svgRef.current?.getBoundingClientRect();
+    if (!r) return;
+    const xPct = (e.clientX - r.left) / r.width;
+    const idx = Math.max(0, Math.min(n - 1, Math.round(xPct * (n - 1))));
+    setHover((prev) =>
+      prev?.index === idx && prev.x === e.clientX && prev.y === e.clientY
+        ? prev
+        : { index: idx, x: e.clientX, y: e.clientY },
+    );
+  };
+
+  const hovered = hover != null ? data[hover.index] : undefined;
+  const chip =
+    hovered !== undefined && typeof document !== "undefined"
+      ? createPortal(
+          <span
+            className={cn(
+              "pointer-events-none fixed z-50 -translate-x-1/2 -translate-y-full whitespace-nowrap rounded px-1.5 py-0.5 text-[10px] font-medium shadow-md",
+              chipClassName ?? "bg-on-surface text-surface",
+            )}
+            style={{ left: hover!.x || 0, top: (hover!.y || 0) - 10 }}
+          >
+            {pointLabel(hovered)}
+          </span>,
+          document.body,
+        )
+      : null;
+
+  const last = pts.at(-1)!;
+  const hoverPt = hover != null ? pts[hover.index] : null;
+
+  return (
+    <div className={cn("relative h-full w-full text-primary", className)}>
+      <svg
+        ref={svgRef}
+        viewBox="0 0 100 100"
+        preserveAspectRatio="none"
+        className="block h-full w-full cursor-default"
+        aria-hidden="true"
+        onMouseMove={onMove}
+        onMouseLeave={() => setHover(null)}
+      >
+        {areaPath && <path d={areaPath} className={areaClassName} />}
+        <path
+          d={linePath}
+          fill="none"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+          className="stroke-current"
+        />
+      </svg>
+      {/* Dots are HTML overlays — `preserveAspectRatio="none"` would squish SVG
+       *  circles into ellipses. */}
+      {endDot && (
+        <span
+          className="pointer-events-none absolute size-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-current"
+          style={{ left: `${last[0]}%`, top: `${last[1]}%` }}
+        />
+      )}
+      {hoverPt && (
+        <span
+          className="pointer-events-none absolute size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-current"
+          style={{ left: `${hoverPt[0]}%`, top: `${hoverPt[1]}%` }}
+        />
+      )}
+      {chip}
+    </div>
+  );
+}

--- a/src/components/ui/chart/sparkline-line/SparklineLine.tsx
+++ b/src/components/ui/chart/sparkline-line/SparklineLine.tsx
@@ -52,9 +52,12 @@ export function SparklineLine({
   const max = Math.max(...values);
   const range = max - min || 1;
   const n = values.length;
+  // Inset the y range so Catmull-Rom overshoot at sharp peaks / troughs doesn't
+  // clip at the viewBox edges (the smooth curve can bulge past the data points).
+  const PAD_Y = 8;
   const pts = values.map((v, i): readonly [number, number] => [
     n === 1 ? 50 : (i / (n - 1)) * 100,
-    (1 - (v - min) / range) * 100,
+    PAD_Y + (1 - (v - min) / range) * (100 - 2 * PAD_Y),
   ]);
   // Smooth Catmull-Rom → cubic-bezier, matching LineChart's curve.
   const f = (x: number) => x.toFixed(2);
@@ -108,6 +111,7 @@ export function SparklineLine({
         ref={svgRef}
         viewBox="0 0 100 100"
         preserveAspectRatio="none"
+        overflow="visible"
         className="block h-full w-full cursor-default"
         aria-hidden="true"
         onMouseMove={onMove}

--- a/src/components/ui/chart/sparkline-line/SparklineLine.tsx
+++ b/src/components/ui/chart/sparkline-line/SparklineLine.tsx
@@ -56,11 +56,18 @@ export function SparklineLine({
     n === 1 ? 50 : (i / (n - 1)) * 100,
     (1 - (v - min) / range) * 100,
   ]);
-  const linePath = pts
-    .map(([x, y], i) => `${i === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`)
-    .join(" ");
+  // Smooth Catmull-Rom → cubic-bezier, matching LineChart's curve.
+  const f = (x: number) => x.toFixed(2);
+  let linePath = `M${f(pts[0][0])},${f(pts[0][1])}`;
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[i - 1] ?? pts[i];
+    const p1 = pts[i];
+    const p2 = pts[i + 1];
+    const p3 = pts[i + 2] ?? p2;
+    linePath += ` C${f(p1[0] + (p2[0] - p0[0]) / 6)},${f(p1[1] + (p2[1] - p0[1]) / 6)} ${f(p2[0] - (p3[0] - p1[0]) / 6)},${f(p2[1] - (p3[1] - p1[1]) / 6)} ${f(p2[0])},${f(p2[1])}`;
+  }
   const areaPath = areaClassName
-    ? `${linePath} L${pts.at(-1)![0].toFixed(2)},100 L${pts[0][0].toFixed(2)},100 Z`
+    ? `${linePath} L${f(pts.at(-1)![0])},100 L${f(pts[0][0])},100 Z`
     : null;
 
   const onMove = (e: ReactMouseEvent<SVGSVGElement>) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -246,3 +246,8 @@ export {
   type SparklineProps,
   type SparklinePoint,
 } from "./components/ui/chart/sparkline/Sparkline";
+export {
+  SparklineLine,
+  type SparklineLineProps,
+  type SparklineLinePoint,
+} from "./components/ui/chart/sparkline-line/SparklineLine";


### PR DESCRIPTION
Adds **`SparklineLine`** — sibling of `Sparkline` (#180), as a separate component (rather than a `variant` on `Sparkline`, since the rendering, hover model, and color props differ enough that a combined API would have two disjoint sets of props gated by a flag).

- a tiny line / area sparkline that **fills its container**; values are **auto-scaled** to the available height (vs `Sparkline`'s 0–100 percentages)
- optional `areaClassName` (e.g. `"fill-primary/15"`) for a tinted area under the line
- static end-dot at the latest value (`endDot`, default true) + a cursor-following hover dot
- hover → `label · value` chip portaled to `document.body` so a clipping ancestor (e.g. a `MetricBlock` cell or `NotchGrid` notch) can't cut it off
- line + dot colour driven by the wrapper's `text-…` (default `text-primary`)
- Story `UI/Chart/SparklineLine` (Playground, WithArea, Tones); 5 tests; typecheck clean

Stacked on #180 (Sparkline) only for a clean review diff — independent; re-targets to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)