### PR TITLE
feat(notch-grid): BlockShape — render a notched surface from a grid mask

### DIFF
--- a/src/components/ui/surfaces/notch-grid/BlockShape.test.tsx
+++ b/src/components/ui/surfaces/notch-grid/BlockShape.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { BlockShape, BLOCK_SIZE } from "./BlockShape";
+
+afterEach(cleanup);
+
+const SHAPE = [
+  [0, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 0],
+];
+
+describe("BlockShape", () => {
+  it("sizes the wrapper to cols×rows blocks", () => {
+    const { container } = render(<BlockShape shape={SHAPE} block={50} />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.width).toBe(`${4 * 50}px`);
+    expect(root.style.height).toBe(`${3 * 50}px`);
+  });
+
+  it("defaults the block size to BLOCK_SIZE (96px)", () => {
+    const { container } = render(<BlockShape shape={[[1]]} />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.width).toBe(`${BLOCK_SIZE}px`);
+    expect(BLOCK_SIZE).toBe(96);
+  });
+
+  it("renders an SVG outline path", () => {
+    const { container } = render(<BlockShape shape={SHAPE} />);
+    const path = container.querySelector("svg path[fill]");
+    expect(path).not.toBeNull();
+    expect(path!.getAttribute("d")!.startsWith("M ")).toBe(true);
+    expect(path!.getAttribute("fill-rule")).toBe("evenodd");
+  });
+
+  it("grows the shape with the tier — a tier-2 cell is empty at tier 1", () => {
+    const tiered = [
+      [1, 2],
+      [1, 1],
+    ];
+    const { container: c1 } = render(<BlockShape shape={tiered} tier={1} block={40} />);
+    const { container: c2 } = render(<BlockShape shape={tiered} tier={2} block={40} />);
+    const d1 = c1.querySelector("svg path[fill]")!.getAttribute("d")!;
+    const d2 = c2.querySelector("svg path[fill]")!.getAttribute("d")!;
+    // tier 1 = an L-shape (6 corners); tier 2 = a full 2×2 square (4 corners).
+    expect((d1.match(/ A /g) ?? []).length).toBe(6);
+    expect((d2.match(/ A /g) ?? []).length).toBe(4);
+  });
+
+  it("renders content on top of the shape", () => {
+    const { getByText } = render(
+      <BlockShape shape={[[1]]}>
+        <span>hello</span>
+      </BlockShape>,
+    );
+    expect(getByText("hello")).toBeInTheDocument();
+  });
+
+  it("clips the content layer to the outline by default; noClip removes it", () => {
+    const { container, rerender } = render(<BlockShape shape={[[1]]}>x</BlockShape>);
+    const content = () =>
+      (container.firstElementChild as HTMLElement).lastElementChild as HTMLElement;
+    expect(content().style.clipPath).toMatch(/^url\(#block-shape-clip-/);
+    rerender(
+      <BlockShape shape={[[1]]} noClip>
+        x
+      </BlockShape>,
+    );
+    expect(content().style.clipPath).toBe("");
+  });
+});

--- a/src/components/ui/surfaces/notch-grid/BlockShape.tsx
+++ b/src/components/ui/surfaces/notch-grid/BlockShape.tsx
@@ -1,0 +1,130 @@
+import { useId, useMemo, type CSSProperties, type ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
+import type { ComponentMeta } from "@/types/component-meta";
+import {
+  gridOutlinePath,
+  maskCols,
+  maskFromShape,
+} from "@/utils/grid-outline";
+
+export const meta: ComponentMeta = {
+  name: "BlockShape",
+  description:
+    "A notched surface whose outline follows a grid of 96px blocks, with content layered on top",
+};
+
+/** Default block edge in px — matches Tailwind's `w-24` / `h-24` (6rem). */
+export const BLOCK_SIZE = 96;
+
+export interface BlockShapeProps {
+  /**
+   * Footprint matrix. Cell values:
+   *  - `0`  — always empty (a notch / hole)
+   *  - `1`  — part of the shape at every size tier
+   *  - `2+` — joins the shape only once that tier is reached (responsive growth)
+   *
+   * e.g. `[[0,1,1,1],[1,1,1,1],[1,1,1,0]]` — a base shape with two corners cut.
+   */
+  shape: ReadonlyArray<ReadonlyArray<number>>;
+  /** Active size tier (>= 1). Cells whose value exceeds `tier` render as empty. */
+  tier?: number;
+  /** Block edge length in px. Default {@link BLOCK_SIZE}. */
+  block?: number;
+  /** Erode the outline by `gap / 2` px (outer edges in, notch holes out) so
+   *  neighbours / nested items leave a `gap`-px space. Footprint size is
+   *  unchanged. Normally set by the parent `NotchGrid`; default 0. */
+  gap?: number;
+  /** Convex corner radius (px). Default 24. */
+  radius?: number;
+  /** Concave / notch corner radius (px). Default 32. */
+  inverseRadius?: number;
+  /** Outline fill — a CSS color, or `"none"` to disable. */
+  fill?: string;
+  /** Outline stroke — a CSS color, or `"none"` to disable. */
+  stroke?: string;
+  strokeWidth?: number;
+  /** Content rendered on top of the shape (clipped to the shape's outline). */
+  children?: ReactNode;
+  /** Padding (px) on the content layer. Default 16. */
+  pad?: number;
+  /** Skip clipping the content layer to the outline. */
+  noClip?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export function BlockShape({
+  shape,
+  tier = 1,
+  block = BLOCK_SIZE,
+  gap = 0,
+  radius = 24,
+  inverseRadius = 32,
+  fill = "var(--color-surface-container-low)",
+  stroke = "var(--color-outline-variant)",
+  strokeWidth = 1,
+  children,
+  pad = 16,
+  noClip = false,
+  className,
+  style,
+}: BlockShapeProps) {
+  const reactId = useId();
+  const clipId = `block-shape-clip-${reactId.replace(/[^a-zA-Z0-9_-]/g, "")}`;
+
+  const rows = shape.length;
+  const cols = maskCols(shape);
+  if (isDev && (rows === 0 || cols === 0)) {
+    console.warn("[BlockShape] empty shape matrix — nothing to render");
+  }
+
+  const mask = useMemo(() => maskFromShape(shape, tier), [shape, tier]);
+  const w = cols * block;
+  const h = rows * block;
+  const pathD = useMemo(
+    () => gridOutlinePath(mask, { cell: block, gap, radius, inverseRadius }),
+    [mask, block, gap, radius, inverseRadius],
+  );
+  const inset = strokeWidth / 2;
+
+  return (
+    <div
+      className={cn("relative", className)}
+      style={{ width: w, height: h, ...style }}
+    >
+      <svg
+        width={w}
+        height={h}
+        viewBox={`${-inset} ${-inset} ${w + strokeWidth} ${h + strokeWidth}`}
+        className="pointer-events-none absolute inset-0"
+        aria-hidden="true"
+      >
+        {!noClip && (
+          <defs>
+            <clipPath id={clipId} clipPathUnits="userSpaceOnUse">
+              <path d={pathD} />
+            </clipPath>
+          </defs>
+        )}
+        <path
+          d={pathD}
+          fill={fill}
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+          vectorEffect="non-scaling-stroke"
+          fillRule="evenodd"
+        />
+      </svg>
+      <div
+        className={cn("absolute inset-0", !noClip && "overflow-hidden")}
+        style={{
+          padding: pad,
+          clipPath: noClip ? undefined : `url(#${clipId})`,
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Third slice of #186. **Stacked on top of #189 (layout) which is stacked on #188 (grid-outline).**

## What

A thin React adapter over `@/utils/grid-outline`. Takes a tier-encoded `shape` matrix (0 = notch, 1 = always filled, 2+ = joins at that tier), renders the rounded SVG outline via `gridOutlinePath`, and layers `children` on top clipped to that outline via SVG `clipPath`. Default fill / stroke use the surface tokens (`--color-surface-container-low` / `--color-outline-variant`) so a panel reads as part of the kit out of the box.

`gap` is forwarded to the outline tracer's erosion (so neighbours sit `gap` apart whether edge-to-edge or nestled into a notch). `noClip` skips the clip-path + overflow-hidden on the content layer for cases where something inside needs to extend past the chrome (used later in the sub-drag's cursor-follow visual).

## /simplify pass (3-agent)

Candidates flagged:
- Memoize `clipId` (regex runs every render). Trivial work on a constant — kept as-is.
- Document the stable-shape-reference contract or stringify the memo key. Kept memos; NotchGrid already passes a stable matrix from its layout useMemo, so the caches warm up.
- Extract `SURFACE_DEFAULTS` shared with `Notch.tsx`. Two callers today, premature — not extracted.
- Test selector fragility (`firstElementChild.lastElementChild`). Tests pass; left as-is.

No must-fix changes applied — the component is a 130-line adapter and the agents' efficiency suggestions don't move the needle at notch-grid sizes.

## Tests

`pnpm test src/components/ui/surfaces/notch-grid/BlockShape` — 6 tests pass.
`pnpm typecheck` — clean.

Part of the #186 split. Next: NotchGrid (no drag), then the three drag layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)