### PR TITLE
feat(notch-grid): NotchGrid + NotchGridItem — layout-only (no drag)

### DIFF
--- a/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
@@ -1,0 +1,255 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Icon } from "@/components/ui/media/icon/Icon";
+import { NotchGrid } from "./NotchGrid";
+import { NotchGridItem } from "./NotchGridItem";
+
+const meta: Meta<typeof NotchGrid> = {
+  title: "UI/Notch/NotchGrid",
+  component: NotchGrid,
+  parameters: { layout: "fullscreen" },
+  args: { block: 96 },
+  argTypes: {
+    cols: { control: { type: "number", min: 1, max: 12 } },
+    block: { control: { type: "range", min: 56, max: 140, step: 4 } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof NotchGrid>;
+
+function Tile({ icon, label, value }: { icon: string; label: string; value: string }) {
+  return (
+    <div className="flex h-full flex-col justify-between">
+      <Icon name={icon} size={18} className="text-primary" />
+      <div>
+        <p className="text-xs text-on-surface-variant">{label}</p>
+        <p className="text-lg font-medium text-on-surface">{value}</p>
+      </div>
+    </div>
+  );
+}
+
+function PrimaryTile({ icon, label, value }: { icon: string; label: string; value: string }) {
+  return (
+    <div className="flex h-full flex-col justify-between">
+      <Icon name={icon} size={16} className="text-on-primary-container" />
+      <div>
+        <p className="text-xs text-on-primary-container/70">{label}</p>
+        <p className="text-base font-medium text-on-primary-container">{value}</p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * An overview page laid out by hand (explicit `col`/`row`) so the notched
+ * pieces interlock cleanly: 1×1 tiles drop into the L-hero's notch and into all
+ * four of the plus's corners and the chart's notch; the `subItems={[[1,1],[2,2]]}`
+ * panel is an L of its own. `nest` (default) keeps notches fillable so nothing
+ * reserves empty corners.
+ */
+export const OverviewPage: Story = {
+  render: () => (
+    <div className="bg-background p-6">
+      <NotchGrid cols={7}>
+        {/* L-shaped ("knife") hero: 3×3 with the bottom-right block notched out. */}
+        <NotchGridItem
+          col={0}
+          row={0}
+          shape={[
+            [1, 1, 1],
+            [1, 1, 1],
+            [1, 1, 0],
+          ]}
+          fill="var(--color-primary-container)"
+          stroke="none"
+        >
+          <div className="flex h-full flex-col justify-between">
+            <Icon name="extension" size={22} className="text-on-primary-container" />
+            <div>
+              <p className="text-xs text-on-primary-container/70">Module</p>
+              <p className="text-xl font-medium text-on-primary-container">identity-federated</p>
+              <p className="text-xs text-on-primary-container/70">@me/identity-federated · v0.3.1</p>
+            </div>
+          </div>
+        </NotchGridItem>
+        {/* drops into the hero's bottom-right notch */}
+        <NotchGridItem col={2} row={2} shape={[[1]]}>
+          <Tile icon="apps" label="Installs" value="1,240" />
+        </NotchGridItem>
+
+        {/* Plus — its four notch corners get filled by 1×1 tiles. */}
+        <NotchGridItem
+          col={3}
+          row={0}
+          shape={[
+            [0, 1, 0],
+            [1, 1, 1],
+            [0, 1, 0],
+          ]}
+        >
+          <div className="flex h-full flex-col items-center justify-center text-center">
+            <Icon name="bolt" size={18} className="text-primary" />
+            <p className="mt-1 text-sm font-medium text-on-surface">Status</p>
+            <p className="text-xs text-on-surface-variant">live · healthy</p>
+          </div>
+        </NotchGridItem>
+        <NotchGridItem col={3} row={0} shape={[[1]]} fill="var(--color-primary-container)" stroke="none">
+          <PrimaryTile icon="payments" label="Earned" value="$84" />
+        </NotchGridItem>
+        <NotchGridItem col={5} row={0} shape={[[1]]}><Tile icon="new_releases" label="Version" value="v0.3.1" /></NotchGridItem>
+        <NotchGridItem col={3} row={2} shape={[[1]]}><Tile icon="groups" label="Tenants" value="37" /></NotchGridItem>
+        <NotchGridItem col={5} row={2} shape={[[1]]}><Tile icon="schedule" label="Pending" value="1" /></NotchGridItem>
+
+        {/* Tall recent-activity list. */}
+        <NotchGridItem col={6} row={0} shape={[[1], [1], [1]]}>
+          <div className="flex h-full flex-col gap-2">
+            <p className="text-sm font-medium text-on-surface">Recent</p>
+            {["v0.3.1 published", "installed by @anna", "deps reviewed", "tunnel up 4h"].map((t) => (
+              <p key={t} className="text-xs text-on-surface-variant">{t}</p>
+            ))}
+          </div>
+        </NotchGridItem>
+
+        {/* 4×2 chart with a notch in its top-right corner. */}
+        <NotchGridItem
+          col={0}
+          row={3}
+          shape={[
+            [1, 1, 1, 0],
+            [1, 1, 1, 1],
+          ]}
+        >
+          <div className="flex h-full flex-col">
+            <p className="text-sm font-medium text-on-surface">Usage — last 30 days</p>
+            <div className="mt-2 flex flex-1 items-end gap-1">
+              {[40, 65, 50, 80, 55, 70, 90, 60, 75, 95, 85, 100].map((h, i) => (
+                <div key={i} className="flex-1 rounded-t bg-primary/60" style={{ height: `${h}%` }} />
+              ))}
+            </div>
+          </div>
+        </NotchGridItem>
+        {/* drops into the chart's notch */}
+        <NotchGridItem col={3} row={3} shape={[[1]]}><Tile icon="build" label="Builds" value="312" /></NotchGridItem>
+
+        {/* A component made of a 1×1 + a 2×2 sub-item — `subItems={[[1,1],[2,2]]}`;
+            the two pack into the panel's own L footprint. Theme set once on the panel. */}
+        <NotchGridItem
+          col={4}
+          row={3}
+          fill="var(--color-primary-container)"
+          subItems={[
+            { cost: [1, 1], content: <PrimaryTile icon="schedule" label="Cron" value="6×" /> },
+            { cost: [2, 2], content: <PrimaryTile icon="insights" label="Calls / day" value="128k" /> },
+          ]}
+        />
+      </NotchGrid>
+    </div>
+  ),
+};
+
+/** A component built from sub-items, each with a `[cols, rows]` block cost —
+ *  the panel's notched footprint is the union of where the grid packs them.
+ *  e.g. `subItems={[[1,1],[2,2]]}` → a 1×1 widget beside a 2×2 one. */
+export const SubItemPanels: Story = {
+  args: { cols: 7 },
+  render: (args) => (
+    <div className="bg-background p-6">
+      <NotchGrid {...args}>
+        {/* [[2,2],[1,1]] → a 2×2 chart with a 1×1 stat tucked under it (L-shape).
+            Theme set once on the panel; both sub-items inherit it. */}
+        <NotchGridItem
+          fill="var(--color-primary-container)"
+          stroke="none"
+          subItems={[
+            {
+              cost: [2, 2],
+              content: (
+                <div className="flex h-full flex-col">
+                  <p className="text-sm font-medium text-on-primary-container">Usage</p>
+                  <div className="mt-2 flex flex-1 items-end gap-1">
+                    {[40, 70, 55, 85, 60, 95, 75].map((h, i) => (
+                      <div key={i} className="flex-1 rounded-t bg-on-primary-container/35" style={{ height: `${h}%` }} />
+                    ))}
+                  </div>
+                </div>
+              ),
+            },
+            { cost: [1, 1], content: <PrimaryTile icon="payments" label="Earned" value="$84" /> },
+          ]}
+        />
+        {/* [[1,1],[1,1],[2,1]] → two stat tiles over a wide 2×1 footer. */}
+        <NotchGridItem
+          subItems={[
+            { cost: [1, 1], content: <Tile icon="apps" label="Installs" value="1,240" /> },
+            { cost: [1, 1], content: <Tile icon="new_releases" label="Version" value="v0.3.1" /> },
+            {
+              cost: [2, 1],
+              content: (
+                <div className="flex h-full items-center gap-2">
+                  <Icon name="bolt" size={16} className="text-primary" />
+                  <span className="text-xs text-on-surface-variant">tunnel up · 2.1k req/min · p99 142ms</span>
+                </div>
+              ),
+            },
+          ]}
+        />
+        {/* [[1,2],[1,1],[1,1]] → a tall list beside two stacked tiles. */}
+        <NotchGridItem
+          subItems={[
+            {
+              cost: [1, 2],
+              content: (
+                <div className="flex h-full flex-col gap-1.5">
+                  <p className="text-sm font-medium text-on-surface">Recent</p>
+                  {["v0.3.1 published", "installed by @anna", "deps reviewed", "tunnel up 4h"].map((t) => (
+                    <p key={t} className="text-xs text-on-surface-variant">{t}</p>
+                  ))}
+                </div>
+              ),
+            },
+            { cost: [1, 1], content: <Tile icon="groups" label="Tenants" value="37" /> },
+            { cost: [1, 1], content: <Tile icon="schedule" label="Pending" value="1" /> },
+          ]}
+          subCols={2}
+        />
+      </NotchGrid>
+    </div>
+  ),
+};
+
+/** Items declare candidate `[cols, rows]` block costs — `{ sizes: [...] }` —
+ *  and the grid auto-picks the largest that fits as you drag the width. */
+export const BlockCostSizes: Story = {
+  render: () => (
+    <div className="bg-background p-6">
+      <div
+        className="resize-x overflow-auto rounded-2xl border border-dashed border-outline-variant p-2"
+        style={{ width: 720, minWidth: 220, maxWidth: "100%" }}
+      >
+        <NotchGrid>
+          <NotchGridItem
+            shape={{ sizes: [[1, 1], [2, 2], [3, 2]] }}
+            fill="var(--color-primary-container)"
+            stroke="none"
+          >
+            <Tile icon="dashboard" label="Hero" value="1·1 → 2·2 → 3·2" />
+          </NotchGridItem>
+          <NotchGridItem shape={{ sizes: [[1, 1], [2, 1]] }}>
+            <Tile icon="apps" label="Installs" value="1·1 → 2·1" />
+          </NotchGridItem>
+          <NotchGridItem shape={{ sizes: [[1, 1]] }}>
+            <Tile icon="payments" label="Earned" value="1·1" />
+          </NotchGridItem>
+          <NotchGridItem shape={{ sizes: [[1, 1], [1, 2]] }}>
+            <Tile icon="new_releases" label="Version" value="1·1 → 1·2" />
+          </NotchGridItem>
+          <NotchGridItem shape={{ sizes: [[1, 1], [2, 1]] }}>
+            <Tile icon="history" label="Activity" value="1·1 → 2·1" />
+          </NotchGridItem>
+        </NotchGrid>
+      </div>
+    </div>
+  ),
+};
+

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.test.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.test.tsx
@@ -1,0 +1,128 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { NotchGrid } from "./NotchGrid";
+import { NotchGridItem } from "./NotchGridItem";
+
+afterEach(cleanup);
+
+/** Each placed item is wrapped in `<div class="absolute" style="left/top">`
+ *  (BlockShape's own internal `.absolute` content layer has no `left`). */
+const positioned = (container: HTMLElement) =>
+  [...container.querySelectorAll<HTMLElement>("div.absolute")]
+    .filter((el) => el.style.left !== "")
+    .map((el) => ({ left: el.style.left, top: el.style.top }));
+
+describe("NotchGrid", () => {
+  it("renders one positioned BlockShape per NotchGridItem child", () => {
+    const { container } = render(
+      <NotchGrid cols={2} block={50} gap={0}>
+        <NotchGridItem shape={[[1]]}>a</NotchGridItem>
+        <NotchGridItem shape={[[1]]}>b</NotchGridItem>
+        <NotchGridItem shape={[[1]]}>c</NotchGridItem>
+      </NotchGrid>,
+    );
+    expect(positioned(container)).toEqual([
+      { left: "0px", top: "0px" },
+      { left: "50px", top: "0px" },
+      { left: "0px", top: "50px" }, // wrapped to row 1
+    ]);
+  });
+
+  it("applies `gap` by eroding each item's outline, not by moving items", () => {
+    const grid = (gap: number) =>
+      render(
+        <NotchGrid cols={1} block={100} gap={gap}>
+          <NotchGridItem shape={[[1]]}>x</NotchGridItem>
+        </NotchGrid>,
+      );
+    const path = (c: HTMLElement) =>
+      c.querySelector("svg path[fill]")!.getAttribute("d")!;
+
+    const a = grid(0);
+    const b = grid(20);
+    // Same position + footprint either way…
+    expect(positioned(a.container)).toEqual(positioned(b.container));
+    expect((a.container.querySelector("div.relative") as HTMLElement).style.width).toBe(
+      (b.container.querySelector("div.relative") as HTMLElement).style.width,
+    );
+    // …but the gap=20 outline is the eroded (smaller) one.
+    expect(path(a.container)).not.toBe(path(b.container));
+  });
+
+  it("honours explicit { col, row } placement", () => {
+    const { container } = render(
+      <NotchGrid cols={3} block={40} gap={0}>
+        <NotchGridItem shape={[[1]]} col={2} row={1}>
+          pinned
+        </NotchGridItem>
+        <NotchGridItem shape={[[1]]}>flow</NotchGridItem>
+      </NotchGrid>,
+    );
+    const pos = positioned(container);
+    expect(pos).toContainEqual({ left: "80px", top: "40px" }); // pinned at (2,1)
+    expect(pos).toContainEqual({ left: "0px", top: "0px" }); // flow lands at (0,0)
+  });
+
+  it("sizes the inner grid box to cols×rows blocks", () => {
+    const { container } = render(
+      <NotchGrid cols={2} block={50} gap={0}>
+        <NotchGridItem shape={[[1]]}>a</NotchGridItem>
+        <NotchGridItem shape={[[1]]}>b</NotchGridItem>
+        <NotchGridItem shape={[[1]]}>c</NotchGridItem>
+      </NotchGrid>,
+    );
+    const box = container.querySelector("div.relative") as HTMLElement;
+    expect(box.style.width).toBe("100px"); // 2 cols × 50
+    expect(box.style.height).toBe("100px"); // 2 rows × 50
+  });
+
+  it("accepts items via the `items` prop too", () => {
+    const { container } = render(
+      <NotchGrid cols={4} block={30} items={[{ shape: [[1]] }, { shape: [[1]] }]} />,
+    );
+    expect(positioned(container)).toHaveLength(2);
+  });
+
+  it("renders the content passed to each item", () => {
+    const { getByText } = render(
+      <NotchGrid cols={2}>
+        <NotchGridItem shape={[[1]]}>
+          <span>hello grid</span>
+        </NotchGridItem>
+      </NotchGrid>,
+    );
+    expect(getByText("hello grid")).toBeInTheDocument();
+  });
+
+  it("renders a panel item as positioned sub-item regions", () => {
+    const { container, getByText } = render(
+      <NotchGrid cols={6} block={40}>
+        <NotchGridItem
+          subItems={[
+            { cost: [2, 2], content: <span>big</span> },
+            { cost: [1, 1], content: <span>small</span> },
+          ]}
+        />
+      </NotchGrid>,
+    );
+    expect(getByText("big")).toBeInTheDocument();
+    expect(getByText("small")).toBeInTheDocument();
+    // Aims for a square-ish panel: subCols = max(2, ceil(√5)) = 3 ⇒
+    // 2×2 at (0,0), 1×1 at (col 2, row 0). Sub-wrappers are at panel-relative px.
+    const subPositions = positioned(container).map((p) => `${p.left},${p.top}`);
+    expect(subPositions).toContain("0px,0px"); // 2×2 sub
+    expect(subPositions).toContain("80px,0px"); // 1×1 sub beside it (col 2 × 40)
+  });
+
+  it("resolves a responsive shape to its base variant when width is unmeasured", () => {
+    // jsdom has no ResizeObserver / layout, so width stays 0 ⇒ `base`.
+    const { container } = render(
+      <NotchGrid cols={4} block={20}>
+        <NotchGridItem shape={{ base: [[1]], md: [[1, 1], [1, 1]] }}>x</NotchGridItem>
+      </NotchGrid>,
+    );
+    const box = container.querySelector("div.relative") as HTMLElement;
+    // base = 1×1 ⇒ grid is at least 4 cols wide (the requested colCount) × 1 row.
+    expect(box.style.height).toBe("20px");
+  });
+});

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -1,0 +1,277 @@
+import {
+  Children,
+  isValidElement,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type Key,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
+import type { ComponentMeta } from "@/types/component-meta";
+import { maskCols, maskFromShape, maxTier } from "@/utils/grid-outline";
+import { BlockShape, BLOCK_SIZE } from "./BlockShape";
+import {
+  NOTCH_BREAKPOINTS,
+  resolveShapeMatrix,
+  type NotchBreakpoints,
+} from "./breakpoints";
+import {
+  optimalPlacement,
+  packItems,
+  placementToMask,
+  rectMask,
+  type LayoutInput,
+} from "./layout";
+import {
+  asSubItem,
+  NotchGridItem,
+  type NotchGridItemProps,
+  type NotchSubItem,
+} from "./NotchGridItem";
+
+export const meta: ComponentMeta = {
+  name: "NotchGrid",
+  description:
+    "Responsive block-aligned layout of notched BlockShapes — measures its width, picks each item's breakpoint shape (or packs its sub-items), and lays them out",
+};
+
+export interface NotchGridProps {
+  /** Fixed column count. Omit to auto-fit `floor(width / block)`. */
+  cols?: number;
+  /** Block edge in px. Default {@link BLOCK_SIZE} (96). */
+  block?: number;
+  /** Gap (px) between items — each item's outline is eroded by `gap / 2`, so
+   *  the spacing is the same whether items sit edge-to-edge or one nestles into
+   *  another's notch. Default 8. */
+  gap?: number;
+  /** Override / extend the Tailwind-style breakpoint thresholds (min container
+   *  width in px) used to resolve each item's responsive `shape`. */
+  breakpoints?: NotchBreakpoints;
+  /** Default corner radius forwarded to every item. */
+  radius?: number;
+  /** Default notch corner radius forwarded to every item. */
+  inverseRadius?: number;
+  fill?: string;
+  stroke?: string;
+  strokeWidth?: number;
+  pad?: number;
+  /** When `true` (default), an item reserves only its *filled* cells, so a
+   *  complementary shape can nestle into another's notch (interlocking layout).
+   *  Set `false` to reserve each item's whole bounding box — boxes never
+   *  overlap, at the cost of notches staying empty. */
+  nest?: boolean;
+  /** Items as data (in addition to / instead of `<NotchGridItem>` children). */
+  items?: NotchGridItemProps[];
+  children?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+/** Clamp a value to a whole block count `>= 1`. */
+const blocks = (n: number) => Math.max(1, Math.floor(n));
+
+/** Measure an element's content-box width (whole px), re-measuring on resize.
+ *  Returns 0 until first layout (and stays 0 where `ResizeObserver` is
+ *  unavailable, e.g. jsdom / SSR — pass `cols` there for a deterministic
+ *  layout). Rounds to an integer and skips no-op updates so sub-pixel layout
+ *  churn doesn't trigger re-renders. */
+function useMeasuredWidth(ref: RefObject<HTMLElement | null>): number {
+  const [width, setWidth] = useState(0);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const read = () => {
+      const w = Math.round(el.getBoundingClientRect().width);
+      setWidth((prev) => (prev === w ? prev : w));
+    };
+    read();
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(read);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [ref]);
+  return width;
+}
+
+interface PlacedSub {
+  sub: NotchSubItem;
+  key: Key;
+  col: number;
+  row: number;
+}
+
+interface ResolvedItem {
+  props: NotchGridItemProps;
+  key: Key;
+  matrix: number[][];
+  tier: number;
+  /** Packed sub-items when this item is a panel; otherwise undefined. */
+  subPlaced?: PlacedSub[];
+}
+
+export function NotchGrid({
+  cols,
+  block = BLOCK_SIZE,
+  gap = 8,
+  breakpoints,
+  radius,
+  inverseRadius,
+  fill,
+  stroke,
+  strokeWidth,
+  pad,
+  nest = true,
+  items,
+  children,
+  className,
+  style,
+}: NotchGridProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const width = useMeasuredWidth(ref);
+  const bps = useMemo(
+    () => (breakpoints ? { ...NOTCH_BREAKPOINTS, ...breakpoints } : NOTCH_BREAKPOINTS),
+    [breakpoints],
+  );
+  // Items sit on a plain `block` lattice; `gap` is applied by eroding each
+  // item's outline, so the column count is just `floor(width / block)`.
+  const colCount = cols ?? Math.max(1, Math.floor(width / block));
+
+  const { placed, gridCols, gridRows } = useMemo(() => {
+    // Gather item configs: `<NotchGridItem>` children, then the `items` prop.
+    const configs: { props: NotchGridItemProps; key: Key }[] = [];
+    Children.forEach(children, (child, i) => {
+      if (isValidElement(child) && child.type === NotchGridItem) {
+        configs.push({ props: child.props as NotchGridItemProps, key: child.key ?? `c${i}` });
+      } else if (isDev && child != null && child !== false) {
+        console.warn("[NotchGrid] children must be <NotchGridItem> — other nodes are ignored");
+      }
+    });
+    (items ?? []).forEach((p, i) => configs.push({ props: p, key: p.key ?? `i${i}` }));
+
+    const resolved: ResolvedItem[] = configs.map(({ props, key }) => {
+      if (props.subItems && props.subItems.length > 0) {
+        const subs = props.subItems.map((s, i) => ({ ...asSubItem(s), _i: i }));
+        const cw = (s: { cost: readonly [number, number] }) => Math.max(1, Math.floor(s.cost[0]));
+        const maxSubW = Math.max(1, ...subs.map(cw));
+        const subInputs: LayoutInput<{ sub: NotchSubItem; key: Key }>[] = subs.map((sub) => ({
+          item: { sub, key: sub.key ?? `s${sub._i}` },
+          mask: rectMask(sub.cost[0], sub.cost[1]),
+          col: sub.col,
+          row: sub.row,
+        }));
+        // When `subCols` is pinned, pack at exactly that width; otherwise search
+        // column counts × orderings for the most compact arrangement.
+        const subPlaced = (
+          props.subCols != null
+            ? packItems(subInputs, props.subCols)
+            : optimalPlacement(subInputs, {
+                maxCols: Math.max(maxSubW, colCount),
+                minCols: maxSubW,
+                targetAspect: props.subAspect,
+              })
+        ).placed;
+        const matrix = placementToMask(subPlaced).map((row) => row.map((b) => (b ? 1 : 0)));
+        return {
+          props,
+          key,
+          matrix,
+          tier: 1,
+          subPlaced: subPlaced.map((p) => ({ sub: p.item.sub, key: p.item.key, col: p.col, row: p.row })),
+        };
+      }
+      const matrix = resolveShapeMatrix(props.shape ?? [[1]], {
+        width,
+        columns: colCount,
+        breakpoints: bps,
+      });
+      return { props, key, matrix, tier: props.tier ?? maxTier(matrix) };
+    });
+
+    const toInput = (r: ResolvedItem): LayoutInput<ResolvedItem> => ({
+      item: r,
+      // `nest`: reserve only the shape's filled cells (lets others sit in the
+      // notches); otherwise reserve the whole bounding box (no overlaps).
+      mask: nest
+        ? maskFromShape(r.matrix, r.tier)
+        : rectMask(Math.max(1, maskCols(r.matrix)), Math.max(1, r.matrix.length)),
+      col: r.props.col,
+      row: r.props.row,
+    });
+    const packed = packItems(resolved.map(toInput), colCount);
+    if (isDev && packed.overflowed.length > 0) {
+      console.warn(
+        `[NotchGrid] ${packed.overflowed.length} item(s) have a footprint wider than ${colCount} column(s) — overflowing`,
+      );
+    }
+    return { placed: packed.placed, gridCols: packed.cols, gridRows: packed.rows };
+  }, [children, items, width, colCount, bps, nest]);
+
+  return (
+    <div ref={ref} className={cn("w-full", className)} style={style}>
+      <div
+        className="relative"
+        style={{ width: gridCols * block, height: gridRows * block }}
+      >
+        {placed.map(({ item, col, row }) => {
+          const { props, key, matrix, tier, subPlaced } = item;
+          const itemBlock = props.block ?? block;
+
+          // A panel's content is its sub-item regions positioned at their cells
+          // (the panel's BlockShape outline is the union of those footprints);
+          // a plain item just renders its own children.
+          const content = subPlaced
+            ? subPlaced.map(({ sub, key: subKey, col: sc, row: sr }) => (
+                <div
+                  key={subKey}
+                  className={cn("absolute overflow-hidden", sub.className)}
+                  style={{
+                    left: sc * itemBlock,
+                    top: sr * itemBlock,
+                    width: blocks(sub.cost[0]) * itemBlock,
+                    height: blocks(sub.cost[1]) * itemBlock,
+                    padding: sub.pad ?? props.pad ?? pad ?? 16,
+                    borderRadius: (sub.radius ?? props.radius ?? radius ?? 24) * 0.75,
+                    background: sub.fill && sub.fill !== "none" ? sub.fill : undefined,
+                    ...sub.style,
+                  }}
+                >
+                  {sub.content}
+                </div>
+              ))
+            : props.children;
+
+          return (
+            <div
+              key={key}
+              className="absolute"
+              style={{ left: col * block, top: row * block }}
+            >
+              <BlockShape
+                shape={matrix}
+                tier={tier}
+                block={itemBlock}
+                gap={gap}
+                radius={props.radius ?? radius}
+                inverseRadius={props.inverseRadius ?? inverseRadius}
+                fill={props.fill ?? fill}
+                stroke={props.stroke ?? stroke}
+                strokeWidth={props.strokeWidth ?? strokeWidth}
+                pad={subPlaced ? 0 : props.pad ?? pad}
+                noClip={subPlaced ? undefined : props.noClip}
+                className={props.className}
+                style={props.style}
+              >
+                {content}
+              </BlockShape>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/surfaces/notch-grid/NotchGridItem.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGridItem.tsx
@@ -1,0 +1,149 @@
+import type { CSSProperties, Key, ReactNode } from "react";
+import type { ComponentMeta } from "@/types/component-meta";
+import { maxTier } from "@/utils/grid-outline";
+import { BlockShape } from "./BlockShape";
+import { resolveShapeMatrix, type NotchShape } from "./breakpoints";
+
+export const meta: ComponentMeta = {
+  name: "NotchGridItem",
+  description:
+    "One cell of a NotchGrid — a (responsive) block-shape footprint, or a panel of sub-items each with a block cost, plus content; the grid positions it",
+};
+
+export type { NotchShape };
+
+/** A widget inside a {@link NotchGridItem} panel. Costs `[cols, rows]` blocks;
+ *  the parent's notched footprint is the union of its sub-items' positions. A
+ *  bare `[cols, rows]` tuple is shorthand for `{ cost: [cols, rows] }`. */
+export interface NotchSubItem {
+  key?: Key;
+  /** Block cost `[cols, rows]`. */
+  cost: readonly [number, number];
+  /** Explicit position within the panel (block units). Auto-flowed when omitted. */
+  col?: number;
+  row?: number;
+  fill?: string;
+  stroke?: string;
+  strokeWidth?: number;
+  radius?: number;
+  inverseRadius?: number;
+  pad?: number;
+  noClip?: boolean;
+  className?: string;
+  style?: CSSProperties;
+  content?: ReactNode;
+}
+
+export type NotchSubItemInput = NotchSubItem | readonly [number, number];
+
+export interface NotchGridItemProps {
+  /** React key when supplied via the `items` prop array. */
+  key?: Key;
+  /**
+   * The block footprint — one of:
+   *  - a matrix `[[0,1],[1,1]]` (`0` notch/empty, `1` filled, `2+` tier-encoded);
+   *  - a breakpoint map of matrices, `{ base: …, md: … }` or px keys `{ 0: …, 900: … }`;
+   *  - candidate `[cols, rows]` block costs `{ sizes: [[1,1],[2,2]] }` — the grid
+   *    picks the largest that fits, so the component grows when there's room;
+   *  - preferred matrices in priority order `{ prefer: [bigShape, smallerShape, …] }`
+   *    — the grid uses the first that fits the column count, else the narrowest.
+   *
+   * Ignored when {@link subItems} is given (the footprint is derived from those).
+   */
+  shape?: NotchShape;
+  /**
+   * Build this item as a panel of sub-widgets, each with a `[cols, rows]` block
+   * cost — `[[1,1],[2,2]]` is a 1×1 sub-item beside a 2×2 one. The grid packs
+   * them (into {@link subCols} columns) and the panel's notched footprint is the
+   * union of their positions.
+   */
+  subItems?: ReadonlyArray<NotchSubItemInput>;
+  /** Pin the column count the sub-items pack into. Omit to let the grid search
+   *  column counts × orderings for the most compact arrangement. */
+  subCols?: number;
+  /** Preferred width ÷ height for the auto-arranged sub-item layout — the
+   *  tie-breaker between equally-compact options. Default 1.6 (gently landscape).
+   *  Ignored when `subCols` is set. */
+  subAspect?: number;
+  /** Explicit grid position in block units. Auto-flowed when omitted. */
+  col?: number;
+  row?: number;
+  /** Tier selector for a tier-encoded matrix. Default: every tier (`maxTier`). */
+  tier?: number;
+  /** Block edge in px (normally inherited from the parent `NotchGrid`). */
+  block?: number;
+  radius?: number;
+  inverseRadius?: number;
+  fill?: string;
+  stroke?: string;
+  strokeWidth?: number;
+  pad?: number;
+  noClip?: boolean;
+  className?: string;
+  style?: CSSProperties;
+  children?: ReactNode;
+}
+
+/** Normalise a {@link NotchSubItemInput} to a {@link NotchSubItem}. */
+export function asSubItem(input: NotchSubItemInput): NotchSubItem {
+  return Array.isArray(input) ? { cost: input as readonly [number, number] } : (input as NotchSubItem);
+}
+
+/**
+ * Inside a {@link NotchGrid} this component is *not* rendered directly — the
+ * grid reads these props, packs sub-items / resolves the responsive shape, and
+ * renders the positioned `BlockShape`s itself.
+ *
+ * Rendered standalone, it falls back to its largest defined shape variant (or,
+ * with `subItems`, just renders its `children`) so it still shows something
+ * useful in isolation / tests.
+ */
+export function NotchGridItem({
+  shape,
+  subItems,
+  tier,
+  block,
+  radius,
+  inverseRadius,
+  fill,
+  stroke,
+  strokeWidth,
+  pad,
+  noClip,
+  className,
+  style,
+  children,
+}: NotchGridItemProps) {
+  if (subItems && subItems.length > 0) {
+    // Standalone: the sub-item packing happens inside a NotchGrid; here we just
+    // surface the content.
+    return (
+      <div className={className} style={style}>
+        {children}
+      </div>
+    );
+  }
+  const matrix = resolveShapeMatrix(shape ?? [[1]], {
+    width: Number.POSITIVE_INFINITY,
+    columns: Number.MAX_SAFE_INTEGER,
+  });
+  const resolvedTier = tier ?? maxTier(matrix);
+  return (
+    <BlockShape
+      shape={matrix}
+      tier={resolvedTier}
+      block={block}
+      radius={radius}
+      inverseRadius={inverseRadius}
+      fill={fill}
+      stroke={stroke}
+      strokeWidth={strokeWidth}
+      pad={pad}
+      noClip={noClip}
+      className={className}
+      style={style}
+    >
+      {children}
+    </BlockShape>
+  );
+}


### PR DESCRIPTION
Fourth slice of #186. **Stacked on #190 (BlockShape), #189 (layout), #188 (grid-outline).**

## What

The notched-layout composition surface, without any interactivity:

- `NotchGrid` measures its container width, resolves each item's responsive `shape` (Tailwind-style breakpoint map / `{ sizes }` / `{ prefer }`), and bin-packs everything via `packItems`. `nest` (default) reserves only an item's filled cells so a complementary shape can drop into another's notch.
- `NotchGridItem` is the declarative item — a footprint (`shape`) or a panel of sub-items (`subItems` with `[cols, rows]` block costs), plus optional explicit `{ col, row }`. The grid reads its props and renders the positioned `BlockShape` itself; rendered standalone it falls back to a sensible default (used for storybook-without-grid demos).
- `NotchSubItem` for sub-items: `[cols, rows]` block cost, optional explicit sub-cell position, theme overrides, and `content`.

The stories cover the overview-page layout (explicit hand-placed L-hero / plus / chart with 1×1 tiles nestled into their notches), sub-item panels (1×1 + 2×2 → L-shaped footprint), responsive shapes (breakpoint map, `sizes`, `prefer`), and the `subAspect` / `subCols` knobs.

## /simplify pass

This PR carves out the layout-only shape from the original `191a1a4a` initial commit (which already had a /simplify pass from the original PR). The carve-out is *deletions only* — no new code, just the drag-related state / handlers / props / styles removed. Visual review confirms nothing new to flag.

## Tests

`pnpm test src/components/ui/surfaces/notch-grid` — 8 NotchGrid tests pass, 40 in the wider notch-grid module.
`pnpm typecheck` — clean.

## Coming next

- #5 `feat/notch-grid-drag` — `draggable` / `onItemMove` and the wrapper-level drag.
- #6 `feat/notch-grid-sub-drag` — sub-item drag, promote-to-outer when dropped past parent rect, render-time auto-link of adjacent same-group tiles, ghost overlay.
- #7 `feat/notch-grid-drag-visuals` — hover dim + drag-active visuals (tighter radius, forced bg, cascaded grabbing cursor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)