### PR TITLE
feat(notch-grid): outer-grid drag-to-place

### DIFF
--- a/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
@@ -45,13 +45,13 @@ function PrimaryTile({ icon, label, value }: { icon: string; label: string; valu
  * An overview page laid out by hand (explicit `col`/`row`) so the notched
  * pieces interlock cleanly: 1×1 tiles drop into the L-hero's notch and into all
  * four of the plus's corners and the chart's notch; the `subItems={[[1,1],[2,2]]}`
- * panel is an L of its own. `nest` (default) keeps notches fillable so nothing
- * reserves empty corners.
+ * panel is an L of its own. `nest` (default) keeps notches fillable — nothing
+ * reserves empty corners — and `draggable` lets you re-arrange it.
  */
 export const OverviewPage: Story = {
   render: () => (
     <div className="bg-background p-6">
-      <NotchGrid cols={7}>
+      <NotchGrid cols={7} draggable>
         {/* L-shaped ("knife") hero: 3×3 with the bottom-right block notched out. */}
         <NotchGridItem
           col={0}
@@ -213,6 +213,44 @@ export const SubItemPanels: Story = {
           ]}
           subCols={2}
         />
+      </NotchGrid>
+    </div>
+  ),
+};
+
+/** `draggable` — grab any tile and drop it onto a different block cell; it
+ *  becomes pinned there and the rest re-flow around it (and into its notches). */
+export const Draggable: Story = {
+  args: { cols: 6, draggable: true },
+  render: (args) => (
+    <div className="bg-background p-6">
+      <NotchGrid {...args}>
+        <NotchGridItem
+          shape={[
+            [1, 1, 1],
+            [1, 1, 0],
+          ]}
+          fill="var(--color-primary-container)"
+          stroke="none"
+        >
+          <Tile icon="drag_indicator" label="Drag me" value="hero" />
+        </NotchGridItem>
+        <NotchGridItem shape={[[1]]}><Tile icon="apps" label="Installs" value="1,240" /></NotchGridItem>
+        <NotchGridItem shape={[[1]]}><Tile icon="payments" label="Earned" value="$84" /></NotchGridItem>
+        <NotchGridItem shape={[[1, 1]]}>
+          <div className="flex h-full items-center gap-2">
+            <Icon name="bolt" size={16} className="text-primary" />
+            <span className="text-xs text-on-surface-variant">live · 2.1k req/min</span>
+          </div>
+        </NotchGridItem>
+        <NotchGridItem shape={[[1], [1]]}>
+          <div className="flex h-full flex-col gap-1">
+            <p className="text-sm font-medium text-on-surface">Recent</p>
+            <p className="text-xs text-on-surface-variant">v0.3.1 published</p>
+            <p className="text-xs text-on-surface-variant">installed by @anna</p>
+          </div>
+        </NotchGridItem>
+        <NotchGridItem shape={[[1]]}><Tile icon="calendar_today" label="Created" value="May" /></NotchGridItem>
       </NotchGrid>
     </div>
   ),

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -1,12 +1,14 @@
 import {
   Children,
   isValidElement,
+  useCallback,
   useLayoutEffect,
   useMemo,
   useRef,
   useState,
   type CSSProperties,
   type Key,
+  type PointerEvent as ReactPointerEvent,
   type ReactNode,
   type RefObject,
 } from "react";
@@ -17,6 +19,7 @@ import { maskCols, maskFromShape, maxTier } from "@/utils/grid-outline";
 import { BlockShape, BLOCK_SIZE } from "./BlockShape";
 import {
   NOTCH_BREAKPOINTS,
+  rectMatrix,
   resolveShapeMatrix,
   type NotchBreakpoints,
 } from "./breakpoints";
@@ -67,6 +70,11 @@ export interface NotchGridProps {
   nest?: boolean;
   /** Items as data (in addition to / instead of `<NotchGridItem>` children). */
   items?: NotchGridItemProps[];
+  /** Let the user drag items onto a different block cell. Dropped items become
+   *  pinned and the rest re-flow around them. */
+  draggable?: boolean;
+  /** Called after a drag drops an item, with its new block position. */
+  onItemMove?: (key: Key, col: number, row: number) => void;
   children?: ReactNode;
   className?: string;
   style?: CSSProperties;
@@ -74,6 +82,19 @@ export interface NotchGridProps {
 
 /** Clamp a value to a whole block count `>= 1`. */
 const blocks = (n: number) => Math.max(1, Math.floor(n));
+
+interface DragState {
+  key: Key;
+  pointerId: number;
+  startX: number;
+  startY: number;
+  originCol: number;
+  originRow: number;
+  /** The dragged item's footprint width in blocks (to clamp the drop column). */
+  originCols: number;
+  dx: number;
+  dy: number;
+}
 
 /** Measure an element's content-box width (whole px), re-measuring on resize.
  *  Returns 0 until first layout (and stays 0 where `ResizeObserver` is
@@ -127,6 +148,8 @@ export function NotchGrid({
   pad,
   nest = true,
   items,
+  draggable = false,
+  onItemMove,
   children,
   className,
   style,
@@ -140,6 +163,38 @@ export function NotchGrid({
   // Items sit on a plain `block` lattice; `gap` is applied by eroding each
   // item's outline, so the column count is just `floor(width / block)`.
   const colCount = cols ?? Math.max(1, Math.floor(width / block));
+
+  // Drag-to-place: positions the user has dropped items at (pinned), plus the
+  // live drag offset for visual feedback.
+  const [overrides, setOverrides] = useState<Map<Key, { col: number; row: number }>>(new Map());
+  const [drag, setDrag] = useState<DragState | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+  dragRef.current = drag;
+
+  const handlePointerMove = useCallback((e: ReactPointerEvent) => {
+    const d = dragRef.current;
+    if (!d || e.pointerId !== d.pointerId) return;
+    setDrag({ ...d, dx: e.clientX - d.startX, dy: e.clientY - d.startY });
+  }, []);
+
+  const endDrag = useCallback(
+    (e: ReactPointerEvent) => {
+      const d = dragRef.current;
+      if (!d || e.pointerId !== d.pointerId) return;
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        /* pointer may already be released */
+      }
+      const maxCol = Math.max(0, colCount - d.originCols);
+      const nextCol = Math.min(maxCol, Math.max(0, d.originCol + Math.round(d.dx / block)));
+      const nextRow = Math.max(0, d.originRow + Math.round(d.dy / block));
+      setDrag(null);
+      setOverrides((prev) => new Map(prev).set(d.key, { col: nextCol, row: nextRow }));
+      onItemMove?.(d.key, nextCol, nextRow);
+    },
+    [block, colCount, onItemMove],
+  );
 
   const { placed, gridCols, gridRows } = useMemo(() => {
     // Gather item configs: `<NotchGridItem>` children, then the `items` prop.
@@ -192,24 +247,33 @@ export function NotchGrid({
       return { props, key, matrix, tier: props.tier ?? maxTier(matrix) };
     });
 
-    const toInput = (r: ResolvedItem): LayoutInput<ResolvedItem> => ({
-      item: r,
-      // `nest`: reserve only the shape's filled cells (lets others sit in the
-      // notches); otherwise reserve the whole bounding box (no overlaps).
-      mask: nest
-        ? maskFromShape(r.matrix, r.tier)
-        : rectMask(Math.max(1, maskCols(r.matrix)), Math.max(1, r.matrix.length)),
-      col: r.props.col,
-      row: r.props.row,
-    });
-    const packed = packItems(resolved.map(toInput), colCount);
+    const toInput = (r: ResolvedItem): LayoutInput<ResolvedItem> => {
+      const pinned = overrides.get(r.key);
+      return {
+        item: r,
+        // `nest`: reserve only the shape's filled cells (lets others sit in the
+        // notches); otherwise reserve the whole bounding box (no overlaps).
+        mask: nest
+          ? maskFromShape(r.matrix, r.tier)
+          : rectMask(Math.max(1, maskCols(r.matrix)), Math.max(1, r.matrix.length)),
+        col: pinned?.col ?? r.props.col,
+        row: pinned?.row ?? r.props.row,
+      };
+    };
+    // Drag-dropped (overridden) items are packed first so they win their cell;
+    // anything they'd overlap re-flows around them.
+    const inputs: LayoutInput<ResolvedItem>[] = [
+      ...resolved.filter((r) => overrides.has(r.key)).map(toInput),
+      ...resolved.filter((r) => !overrides.has(r.key)).map(toInput),
+    ];
+    const packed = packItems(inputs, colCount);
     if (isDev && packed.overflowed.length > 0) {
       console.warn(
         `[NotchGrid] ${packed.overflowed.length} item(s) have a footprint wider than ${colCount} column(s) — overflowing`,
       );
     }
     return { placed: packed.placed, gridCols: packed.cols, gridRows: packed.rows };
-  }, [children, items, width, colCount, bps, nest]);
+  }, [children, items, width, colCount, bps, nest, overrides]);
 
   return (
     <div ref={ref} className={cn("w-full", className)} style={style}>
@@ -217,9 +281,10 @@ export function NotchGrid({
         className="relative"
         style={{ width: gridCols * block, height: gridRows * block }}
       >
-        {placed.map(({ item, col, row }) => {
+        {placed.map(({ item, col, row, cols: itemCols }) => {
           const { props, key, matrix, tier, subPlaced } = item;
           const itemBlock = props.block ?? block;
+          const dragging = drag?.key === key;
 
           // A panel's content is its sub-item regions positioned at their cells
           // (the panel's BlockShape outline is the union of those footprints);
@@ -245,11 +310,41 @@ export function NotchGrid({
               ))
             : props.children;
 
+          const dragHandlers = draggable
+            ? {
+                onPointerDown: (e: ReactPointerEvent) => {
+                  if (e.button !== 0) return;
+                  e.currentTarget.setPointerCapture(e.pointerId);
+                  setDrag({
+                    key,
+                    pointerId: e.pointerId,
+                    startX: e.clientX,
+                    startY: e.clientY,
+                    originCol: col,
+                    originRow: row,
+                    originCols: itemCols,
+                    dx: 0,
+                    dy: 0,
+                  });
+                },
+                onPointerMove: handlePointerMove,
+                onPointerUp: endDrag,
+                onPointerCancel: endDrag,
+              }
+            : undefined;
+
           return (
             <div
               key={key}
-              className="absolute"
-              style={{ left: col * block, top: row * block }}
+              {...dragHandlers}
+              className={cn("absolute", draggable && "select-none touch-none")}
+              style={{
+                left: col * block,
+                top: row * block,
+                transform: dragging ? `translate(${drag.dx}px, ${drag.dy}px)` : undefined,
+                zIndex: dragging ? 20 : overrides.has(key) ? 10 : undefined,
+                cursor: draggable ? (dragging ? "grabbing" : "grab") : undefined,
+              }}
             >
               <BlockShape
                 shape={matrix}


### PR DESCRIPTION
Fifth slice of #186. **Stacked on #191 (NotchGrid no-drag).**

## What

Wrapper-level drag for whole tiles:

- `draggable` prop opts in; `onItemMove(key, col, row)` reports the drop.
- `DragState` carries pointer id + start cell + footprint width + dx/dy.
- pointer-down captures the pointer, pointer-move updates dx/dy, pointer-up rounds dx/dy to whole-block deltas, clamps to the column count, commits an `overrides` entry, and the next render packs the dropped item *first* so it wins its target cell — anything it would overlap re-flows (including into its notches when `nest` is on).
- Wrapper picks up `cursor: grab`, `cursor: grabbing` during a drag, the cursor-follow `transform`, and a higher z-index so the dragged tile floats over its neighbours.

Restores the `Draggable` story and the `draggable` flag on the OverviewPage demo.

## /simplify pass

This PR carves out the original drag implementation from the `191a1a4a` initial commit (which had its own /simplify pass in the original PR). The diff is *additions only* on top of the no-drag layout in #191 — no new patterns to flag.

## Tests

`pnpm test src/components/ui/surfaces/notch-grid` — 48 tests pass.
`pnpm typecheck` — clean.

## Coming next

- #6 — sub-item drag, promote-to-outer when dropped past parent rect, render-time auto-link of adjacent same-group tiles, ghost overlay.
- #7 — hover dim + drag-active visuals (tighter radius, forced bg, cascaded grabbing cursor on linked-drag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)