### PR TITLE
feat(graph-side): groups query system + OptionList primitive + showTags as nodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/graph/graph-layout/GraphLayout.stories.tsx
+++ b/src/components/layout/graph/graph-layout/GraphLayout.stories.tsx
@@ -328,30 +328,40 @@ export const WithGraphAndSettings: Story = {
     const graphRef = useRef<GraphHandle>(null);
     const [view, setView] = useState<SideView>(null);
     const [groups, setGroups] = useState<GraphSideGroupItem[]>([
-      { id: "user", name: "User", color: "#f5c14a" },
-      { id: "core", name: "Core", color: "#a8d8a8" },
-      { id: "project", name: "Project", color: "#cbb6e5" },
-      { id: "crm", name: "CRM", color: "#f4a8a8" },
-      { id: "daily", name: "Daily", color: "#fbb6ce" },
-      { id: "balance", name: "Balance", color: "#8db8e8" },
-      { id: "commerce", name: "Commerce", color: "#6ee7b7" },
+      { id: "user", name: "User", query: "user", color: "#f5c14a" },
+      { id: "core", name: "Core", query: "core", color: "#a8d8a8" },
+      { id: "project", name: "Project", query: "project", color: "#cbb6e5" },
+      { id: "crm", name: "CRM", query: "crm", color: "#f4a8a8" },
+      { id: "daily", name: "Daily", query: "daily", color: "#fbb6ce" },
+      { id: "balance", name: "Balance", query: "balance", color: "#8db8e8" },
+      { id: "commerce", name: "Commerce", query: "commerce", color: "#6ee7b7" },
     ]);
     const [setting, setSetting] = useState<GraphSideSettingValue>({
       nodeSize: 1,
       lineSize: 1,
-      showLabels: true,
+      showTags: false,
       repulsion: 1500,
       linkDistance: 70,
     });
     const [search, setSearch] = useState("");
     const [playing, setPlaying] = useState(false);
-    // Default group matching: substring-search the group's name across each
-    // node's fields in priority order — Title (label) > Tags > Description
-    // (summary) > Content (markdown body). The highest-priority field that
-    // any group matches wins, breaking ties by group list order. The
-    // structured-query version (path:, tag:, [property:]) ships in a
-    // follow-up PR.
+    // Platform sources exposed to GraphSideGroup. Lowercase by convention
+    // so they match the input casing as the user types.
+    const nodeSources = useMemo(
+      () => ["apps", "account", "crm", "daily", "balance", "projectify"],
+      [],
+    );
+    // Default group matching: substring-search the group's `query` (falling
+    // back to `name` if empty) across each node's fields in priority order —
+    // Title (label) > Tags > Description (summary) > Content (markdown). The
+    // highest-priority field that any group matches wins, breaking ties by
+    // group list order. Known operator prefixes (`source:`, `name:`,
+    // `description:`, `content:`) are stripped before matching so picking a
+    // value from the popover Just Works; the structured per-field parser
+    // ships in a follow-up PR.
     const colors = useMemo(() => {
+      const stripOperator = (q: string) =>
+        q.replace(/^(?:source|name|description|content):\s*/i, "");
       const resolve = (n: GraphNode): string | undefined => {
         const d = NODE_DETAILS[n.id];
         const fieldsByPriority = [n.label, n.tag, d?.summary, d?.content];
@@ -359,7 +369,8 @@ export const WithGraphAndSettings: Story = {
           if (!field) continue;
           const f = field.toLowerCase();
           for (const g of groups) {
-            const q = g.name.trim().toLowerCase();
+            const raw = (g.query?.trim() || g.name);
+            const q = stripOperator(raw).trim().toLowerCase();
             if (q && f.includes(q)) return g.color;
           }
         }
@@ -392,7 +403,7 @@ export const WithGraphAndSettings: Story = {
             onNodeClick={(id) => setView({ type: "node", id })}
             nodeSize={setting.nodeSize}
             lineSize={setting.lineSize}
-            showLabels={setting.showLabels}
+            showTags={setting.showTags}
             repulsion={setting.repulsion}
             linkDistance={setting.linkDistance}
             colors={colors}
@@ -439,6 +450,7 @@ export const WithGraphAndSettings: Story = {
                           <GraphSideGroup
                             groups={groups}
                             onChange={setGroups}
+                            sources={nodeSources}
                           />
                         ),
                       },

--- a/src/components/ui/graph/graph-side/GraphSide.tsx
+++ b/src/components/ui/graph/graph-side/GraphSide.tsx
@@ -16,6 +16,7 @@ export {
 } from "./GraphSideSetting";
 export {
   GraphSideGroup,
+  DEFAULT_GROUP_PALETTE,
   type GraphSideGroupProps,
   type GraphSideGroupItem,
 } from "./GraphSideGroup";

--- a/src/components/ui/graph/graph-side/GraphSideContent.stories.tsx
+++ b/src/components/ui/graph/graph-side/GraphSideContent.stories.tsx
@@ -38,7 +38,7 @@ const WithSearchGroupAndSetting = () => {
   const [setting, setSetting] = useState<GraphSideSettingValue>({
     nodeSize: 1,
     lineSize: 1,
-    showLabels: true,
+    showTags: false,
     repulsion: 1500,
     linkDistance: 70,
   });

--- a/src/components/ui/graph/graph-side/GraphSideGroup.tsx
+++ b/src/components/ui/graph/graph-side/GraphSideGroup.tsx
@@ -1,58 +1,212 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { cn } from "@/utils/cn";
 import { Button } from "@/components/ui/actions/button/Button";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+import { FloatingLabelInput } from "@/components/ui/inputs/floating-label-input/FloatingLabelInput";
+import {
+  OptionList,
+  type OptionListItem,
+} from "@/components/ui/surfaces/option-list/OptionList";
 import type { ComponentMeta } from "@/types/component-meta";
 
 export const meta: ComponentMeta = {
   name: "GraphSideGroup",
   description:
-    "Editor for the Graph's colored groups — each row binds a name and a color used to tint nodes that belong to the group.",
+    "Editor for the Graph's colored groups. Each row has a query input (xs FloatingLabelInput) plus a color. Focusing the input opens a popover (portaled to body) showing filter operators; when the input starts with `source:` the popover swaps to the consumer-provided sources list. Picking an operator/source writes the query through the same `onChange` path as typing.",
 };
 
 export interface GraphSideGroupItem {
   id: string;
+  /** Stable display name. Used as the fallback matching term when `query` is empty. */
   name: string;
+  /** Match query; empty falls back to `name`. Operator prefixes are recognized hints — see `QUERY_OPERATORS`. */
+  query?: string;
   color: string;
 }
+
+/** Default 10-color palette for new groups. */
+export const DEFAULT_GROUP_PALETTE = [
+  "#f5c14a", // amber
+  "#a8d8a8", // mint
+  "#cbb6e5", // lavender
+  "#f4a8a8", // rose
+  "#8db8e8", // sky
+  "#6ee7b7", // teal
+  "#fb923c", // orange
+  "#fda4af", // coral
+  "#a5b4fc", // indigo
+  "#fcd34d", // yellow
+];
+
+const SOURCE_PREFIX = "source:";
+const NAME_PREFIX = "name:";
+const DESCRIPTION_PREFIX = "description:";
+const CONTENT_PREFIX = "content:";
+
+const QUERY_OPERATORS: OptionListItem[] = [
+  { value: SOURCE_PREFIX, description: "match the node's source" },
+  { value: NAME_PREFIX, description: "match the node's title" },
+  { value: DESCRIPTION_PREFIX, description: "match the node's description" },
+  { value: CONTENT_PREFIX, description: "match the node's content" },
+];
+
+const POPOVER_WIDTH = 280;
+const POPOVER_VIEWPORT_PAD = 8;
 
 export interface GraphSideGroupProps {
   groups: GraphSideGroupItem[];
   onChange: (groups: GraphSideGroupItem[]) => void;
-  /** Color used by "New group" for the new row. */
-  defaultNewColor?: string;
+  /** Override the 10-color default palette `New group` cycles through. */
+  palette?: string[];
+  /** Source values shown when the input starts with `source:`. */
+  sources?: string[];
   className?: string;
 }
 
 export function GraphSideGroup({
   groups,
   onChange,
-  defaultNewColor = "#1976d2",
+  palette = DEFAULT_GROUP_PALETTE,
+  sources = [],
   className,
 }: GraphSideGroupProps) {
+  const [focusedRowId, setFocusedRowId] = useState<string | null>(null);
+  const [, forceUpdate] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+
+  // Tick on scroll/resize while focused so the inline position math re-runs.
+  useEffect(() => {
+    if (!focusedRowId) return;
+    const tick = () => forceUpdate((c) => c + 1);
+    window.addEventListener("scroll", tick, true);
+    window.addEventListener("resize", tick);
+    return () => {
+      window.removeEventListener("scroll", tick, true);
+      window.removeEventListener("resize", tick);
+    };
+  }, [focusedRowId]);
+
+  // Close on click outside the editor AND outside the portaled popover.
+  // Matches the kit's existing Combobox/DropdownMenu pattern (reliable on
+  // touch devices, no setTimeout race).
+  useEffect(() => {
+    const handle = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (containerRef.current?.contains(target)) return;
+      if (popoverRef.current?.contains(target)) return;
+      setFocusedRowId(null);
+    };
+    document.addEventListener("mousedown", handle);
+    return () => document.removeEventListener("mousedown", handle);
+  }, []);
+
   const update = (id: string, patch: Partial<GraphSideGroupItem>) =>
     onChange(groups.map((g) => (g.id === id ? { ...g, ...patch } : g)));
 
   const remove = (id: string) => onChange(groups.filter((g) => g.id !== id));
 
-  const add = () =>
+  const pickNextColor = (): string => {
+    const used = new Set(groups.map((g) => g.color.toLowerCase()));
+    return palette.find((c) => !used.has(c.toLowerCase())) ?? palette[0];
+  };
+
+  const add = () => {
     onChange([
       ...groups,
       {
         id: `g-${Date.now()}`,
         name: `Group ${groups.length + 1}`,
-        color: defaultNewColor,
+        query: "",
+        color: pickNextColor(),
       },
     ]);
+  };
+
+  const focusedGroup = focusedRowId
+    ? groups.find((g) => g.id === focusedRowId)
+    : null;
+
+  // Popover mode is derived directly from the input value — no state, no race.
+  const inputValue = focusedGroup?.query ?? "";
+  const isSourceMode = inputValue.toLowerCase().startsWith(SOURCE_PREFIX);
+
+  const operatorItems = QUERY_OPERATORS.filter((op) =>
+    op.value.toLowerCase().startsWith(inputValue.toLowerCase()),
+  );
+  const sourceItems = isSourceMode
+    ? (() => {
+        const term = inputValue.slice(SOURCE_PREFIX.length).toLowerCase();
+        return sources
+          .filter((s) => s.toLowerCase().includes(term))
+          .map((s) => ({ value: s }));
+      })()
+    : [];
+
+  // Always show something while focused; fall back to the full operator
+  // list when nothing matches so the menu doesn't blink out.
+  const popoverItems: OptionListItem[] = isSourceMode
+    ? sourceItems
+    : operatorItems.length > 0
+      ? operatorItems
+      : QUERY_OPERATORS;
+  const popoverTitle = isSourceMode ? "Sources" : "Search options";
+
+  const handleSelect = (item: OptionListItem) => {
+    if (!focusedGroup) return;
+    if (isSourceMode) {
+      update(focusedGroup.id, { query: `${SOURCE_PREFIX}${item.value}` });
+      setFocusedRowId(null);
+      return;
+    }
+    if (item.value === SOURCE_PREFIX) {
+      // Switch into sources mode by writing the prefix; the next render
+      // recomputes `isSourceMode` → popover swaps to the sources list.
+      update(focusedGroup.id, { query: SOURCE_PREFIX });
+      return;
+    }
+    update(focusedGroup.id, { query: item.value });
+    setFocusedRowId(null);
+  };
+
+  // Compute popover position inline from the focused row's rect.
+  let popoverPos: { top: number; left: number } | null = null;
+  if (focusedGroup) {
+    const el = rowRefs.current.get(focusedGroup.id);
+    if (el) {
+      const rect = el.getBoundingClientRect();
+      const left = Math.max(
+        POPOVER_VIEWPORT_PAD,
+        Math.min(
+          rect.right - POPOVER_WIDTH,
+          window.innerWidth - POPOVER_WIDTH - POPOVER_VIEWPORT_PAD,
+        ),
+      );
+      popoverPos = { top: rect.bottom + 4, left };
+    }
+  }
 
   return (
-    <div className={cn("flex flex-col gap-1.5", className)}>
+    <div ref={containerRef} className={cn("flex flex-col gap-1.5", className)}>
       {groups.map((g) => (
-        <div key={g.id} className="flex items-center gap-2.5">
-          <input
-            type="text"
-            value={g.name}
-            onChange={(e) => update(g.id, { name: e.target.value })}
-            className="flex-1 min-w-0 h-8 px-2 text-sm bg-transparent text-on-surface border border-outline-variant rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
+        <div
+          key={g.id}
+          ref={(el) => {
+            if (el) rowRefs.current.set(g.id, el);
+            else rowRefs.current.delete(g.id);
+          }}
+          className="flex items-center gap-2.5"
+        >
+          <FloatingLabelInput
+            label={g.name}
+            hideLabel
+            size="xs"
+            value={g.query ?? ""}
+            onChange={(e) => update(g.id, { query: e.target.value })}
+            onFocus={() => setFocusedRowId(g.id)}
+            containerClassName="flex-1 min-w-0"
           />
           <div className="flex items-center shrink-0 gap-0.5">
             <label
@@ -87,6 +241,28 @@ export function GraphSideGroup({
       >
         New group
       </Button>
+      {focusedGroup &&
+        popoverPos &&
+        createPortal(
+          <div
+            ref={popoverRef}
+            style={{
+              position: "fixed",
+              top: popoverPos.top,
+              left: popoverPos.left,
+              width: POPOVER_WIDTH,
+              zIndex: 999,
+            }}
+          >
+            <OptionList
+              title={popoverTitle}
+              showInfo={!isSourceMode}
+              items={popoverItems}
+              onSelect={handleSelect}
+            />
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/src/components/ui/graph/graph-side/GraphSideSetting.stories.tsx
+++ b/src/components/ui/graph/graph-side/GraphSideSetting.stories.tsx
@@ -24,7 +24,7 @@ const Controlled = () => {
   const [value, setValue] = useState<GraphSideSettingValue>({
     nodeSize: 1,
     lineSize: 1,
-    showLabels: true,
+    showTags: false,
     repulsion: 1500,
     linkDistance: 70,
   });

--- a/src/components/ui/graph/graph-side/GraphSideSetting.tsx
+++ b/src/components/ui/graph/graph-side/GraphSideSetting.tsx
@@ -6,7 +6,7 @@ import type { ComponentMeta } from "@/types/component-meta";
 export const meta: ComponentMeta = {
   name: "GraphSideSetting",
   description:
-    "Form for the Graph's display settings — node size, line thickness, label visibility, repulsion strength, and link distance.",
+    "Form for the Graph's display settings — node size, line thickness, tag visibility (labels always show), repulsion strength, and link distance.",
 };
 
 export interface GraphSideSettingValue {
@@ -14,8 +14,8 @@ export interface GraphSideSettingValue {
   nodeSize: number;
   /** Multiplier on edge stroke width. */
   lineSize: number;
-  /** Show the text label under each node. */
-  showLabels: boolean;
+  /** Render each node's tag text below its always-visible label. Default off. */
+  showTags: boolean;
   /** Force-sim pairwise repulsion strength. */
   repulsion: number;
   /** Force-sim edge spring rest length. */
@@ -53,12 +53,12 @@ export function GraphSideSetting({
   return (
     <div className={cn("flex flex-col gap-2", className)}>
       <label className="flex items-center justify-between gap-2 py-2 text-sm text-on-surface">
-        <span>Show labels</span>
+        <span>Show tags</span>
         <Switch
           size="sm"
-          checked={value.showLabels}
-          onChange={(checked) => set("showLabels", checked)}
-          aria-label="Show labels"
+          checked={value.showTags}
+          onChange={(checked) => set("showTags", checked)}
+          aria-label="Show tags"
         />
       </label>
       <SliderRow

--- a/src/components/ui/graph/graph/Graph.tsx
+++ b/src/components/ui/graph/graph/Graph.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from "react";
 import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
 import type { ComponentMeta } from "@/types/component-meta";
 
 export const meta: ComponentMeta = {
@@ -64,8 +65,8 @@ export interface GraphProps {
   nodeSize?: number;
   /** Multiplier applied to edge stroke width. Default 1. */
   lineSize?: number;
-  /** Whether to render the text label under each node. Default true. */
-  showLabels?: boolean;
+  /** Render each node's tag below its always-visible label. Default false. */
+  showTags?: boolean;
   /** Pairwise repulsion strength. Default 1500. */
   repulsion?: number;
   /** Spring rest length for edges. Default 70. */
@@ -197,6 +198,15 @@ const DEFAULT_H = 400;
 // when revealedRef changes.
 const REVEAL_TRANSITION_STYLE = { transition: "opacity 200ms ease" };
 
+// Shared text-style object so we don't allocate a new `{ fontSize }` literal
+// per node per frame.
+const LABEL_TEXT_STYLE = { fontSize: 10 };
+
+// Prefix used for synthetic "tag nodes" spawned when `showTags` is true.
+// One tag node per unique tag value in the consumer's nodes prop, each
+// connected via virtual edges to the real nodes carrying that tag.
+const TAG_PREFIX = "__tag:";
+
 export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
   {
     nodes,
@@ -206,7 +216,7 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
     selectedId,
     nodeSize = 1,
     lineSize = 1,
-    showLabels = true,
+    showTags = false,
     repulsion = DEFAULT_REPULSION,
     linkDistance = DEFAULT_LINK_DISTANCE,
     colors,
@@ -256,6 +266,43 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
   const sizeRef = useRef(size);
   sizeRef.current = size;
 
+  // When `showTags` is on we synthesize one virtual tag node per unique
+  // tag value in the consumer's nodes, plus an edge from each tagged node
+  // to its tag node. The sim and render treat them like any other node;
+  // the only difference is the prefixed id, which we use at render time
+  // to flip to an outline style and at click time to suppress onNodeClick.
+  const allNodes = useMemo<GraphNode[]>(() => {
+    if (!showTags) return nodes;
+    if (isDev) {
+      const collision = nodes.find((n) => n.id.startsWith(TAG_PREFIX));
+      if (collision) {
+        console.warn(
+          `[Graph] node id "${collision.id}" collides with the synthetic ` +
+            `tag-node prefix "${TAG_PREFIX}". Tag rendering and ` +
+            `onNodeClick will misbehave for this node.`,
+        );
+      }
+    }
+    const uniqueTags = new Set<string>();
+    for (const n of nodes) if (n.tag) uniqueTags.add(n.tag);
+    const tagNodes: GraphNode[] = Array.from(uniqueTags).map((tag) => ({
+      id: `${TAG_PREFIX}${tag}`,
+      label: tag,
+    }));
+    return [...nodes, ...tagNodes];
+  }, [nodes, showTags]);
+
+  const allEdges = useMemo<GraphEdge[]>(() => {
+    if (!showTags) return edges;
+    const tagEdges: GraphEdge[] = [];
+    for (const n of nodes) {
+      if (n.tag) {
+        tagEdges.push({ source: n.id, target: `${TAG_PREFIX}${n.tag}` });
+      }
+    }
+    return [...edges, ...tagEdges];
+  }, [nodes, edges, showTags]);
+
   const seededFor = useRef<{ nodes: GraphNode[]; edges: GraphEdge[] } | null>(
     null,
   );
@@ -266,10 +313,10 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
   // Rebuild node positions, byId map, and degree counts. Used both inline
   // when topology identity changes and from the replay-key effect.
   const rebuildSim = (w: number, h: number) => {
-    nodesRef.current = seed(nodes, w, h);
+    nodesRef.current = seed(allNodes, w, h);
     const map = new Map<string, Sim>();
     for (const n of nodesRef.current) map.set(n.id, n);
-    for (const e of edges) {
+    for (const e of allEdges) {
       const a = map.get(e.source);
       const b = map.get(e.target);
       if (a) a.degree += 1;
@@ -280,11 +327,11 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
 
   if (
     seededFor.current === null ||
-    seededFor.current.nodes !== nodes ||
-    seededFor.current.edges !== edges
+    seededFor.current.nodes !== allNodes ||
+    seededFor.current.edges !== allEdges
   ) {
     rebuildSim(W, H);
-    seededFor.current = { nodes, edges };
+    seededFor.current = { nodes: allNodes, edges: allEdges };
   }
 
   const [, setFrame] = useState(0);
@@ -310,13 +357,13 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
 
   const neighborsOf = useMemo(() => {
     const m = new Map<string, Set<string>>();
-    for (const n of nodes) m.set(n.id, new Set());
-    for (const e of edges) {
+    for (const n of allNodes) m.set(n.id, new Set());
+    for (const e of allEdges) {
       m.get(e.source)?.add(e.target);
       m.get(e.target)?.add(e.source);
     }
     return m;
-  }, [nodes, edges]);
+  }, [allNodes, allEdges]);
 
   // Pre-build a per-node style object so every <circle> reuses the same
   // reference across renders. Without this each frame would allocate a new
@@ -332,8 +379,8 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
 
   // RAF loop reads edges from a ref so a new array identity from the
   // consumer doesn't tear down and restart the simulation.
-  const edgesRef = useRef(edges);
-  edgesRef.current = edges;
+  const edgesRef = useRef(allEdges);
+  edgesRef.current = allEdges;
   // Physics tunables are read via refs so changing them never tears down
   // the RAF loop or restarts the simulation.
   const repulsionRef = useRef(repulsion);
@@ -364,7 +411,7 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
   // Playback (sequential reveal) state. Default: every node visible.
   // `replay()` empties the set and adds nodes one-by-one in BFS order from
   // the first pinned node; `stop()` cancels and re-fills the set.
-  const revealedRef = useRef<Set<string>>(new Set(nodes.map((n) => n.id)));
+  const revealedRef = useRef<Set<string>>(new Set(allNodes.map((n) => n.id)));
   const [, setRevealFrame] = useState(0);
   const revealTimerRef = useRef<number | null>(null);
   const onPlaybackEndRef = useRef(onPlaybackEnd);
@@ -373,7 +420,7 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
   // BFS order from the first pinned node (root). Unconnected nodes go at
   // the end so they still appear during playback.
   const revealOrder = useMemo(() => {
-    const root = nodes.find((n) => n.pin || n.fixed)?.id ?? nodes[0]?.id;
+    const root = allNodes.find((n) => n.pin || n.fixed)?.id ?? allNodes[0]?.id;
     if (!root) return [];
     const order: string[] = [];
     const visited = new Set<string>();
@@ -388,9 +435,9 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
         for (const nb of ns) if (!visited.has(nb)) queue.push(nb);
       }
     }
-    for (const n of nodes) if (!visited.has(n.id)) order.push(n.id);
+    for (const n of allNodes) if (!visited.has(n.id)) order.push(n.id);
     return order;
-  }, [nodes, neighborsOf]);
+  }, [allNodes, neighborsOf]);
 
   // Reset revealed set whenever the nodes prop identity changes, aborting
   // any in-progress playback. Also covers component unmount cleanup.
@@ -399,7 +446,7 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
       window.clearTimeout(revealTimerRef.current);
       revealTimerRef.current = null;
     }
-    revealedRef.current = new Set(nodes.map((n) => n.id));
+    revealedRef.current = new Set(allNodes.map((n) => n.id));
     setRevealFrame((f) => f + 1);
     return () => {
       if (revealTimerRef.current !== null) {
@@ -407,7 +454,7 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
         revealTimerRef.current = null;
       }
     };
-  }, [nodes]);
+  }, [allNodes]);
 
   const startReveal = useCallback(() => {
     if (revealTimerRef.current !== null) {
@@ -436,9 +483,9 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
       window.clearTimeout(revealTimerRef.current);
       revealTimerRef.current = null;
     }
-    revealedRef.current = new Set(nodes.map((n) => n.id));
+    revealedRef.current = new Set(allNodes.map((n) => n.id));
     setRevealFrame((f) => f + 1);
-  }, [nodes]);
+  }, [allNodes]);
 
   useEffect(() => {
     if (reseedKey === 0) return;
@@ -592,7 +639,12 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
     }
     setDraggingId(null);
     draggingIdRef.current = null;
-    if (opts.fireClick && !pointerMovedRef.current && onNodeClickRef.current) {
+    if (
+      opts.fireClick &&
+      !pointerMovedRef.current &&
+      onNodeClickRef.current &&
+      !id.startsWith(TAG_PREFIX)
+    ) {
       onNodeClickRef.current(id);
     }
     pointerStartRef.current = null;
@@ -707,7 +759,7 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
           transform={`translate(${view.panX} ${view.panY}) scale(${view.zoom})`}
         >
           <g stroke="currentColor" className="text-on-surface-variant">
-            {edges.map((e, i) => {
+            {allEdges.map((e, i) => {
               const a = byIdRef.current.get(e.source);
               const b = byIdRef.current.get(e.target);
               if (!a || !b) return null;
@@ -734,14 +786,17 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
             {nodesRef.current.map((n) => {
               const lit = isLit(n.id);
               const isFocused = n.id === focused;
+              const isTagNode = n.id.startsWith(TAG_PREFIX);
               const r =
                 (4 + Math.min(n.degree, 6) + (isFocused ? 2 : 0)) * nodeSize;
               const nodeStyle = !isFocused ? nodeStyles?.[n.id] : undefined;
-              const fillClass = isFocused
-                ? "fill-primary"
-                : nodeStyle
-                  ? undefined
-                  : "fill-on-surface-variant";
+              const circleClass = isTagNode
+                ? "fill-none stroke-on-surface-variant"
+                : isFocused
+                  ? "fill-primary"
+                  : nodeStyle
+                    ? undefined
+                    : "fill-on-surface-variant";
               const revealed = revealedRef.current.has(n.id);
               return (
                 <g
@@ -760,20 +815,19 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
                     cx={n.x}
                     cy={n.y}
                     r={r}
-                    className={fillClass}
-                    style={nodeStyle}
+                    className={circleClass}
+                    strokeWidth={isTagNode ? 1.25 / view.zoom : undefined}
+                    style={isTagNode ? undefined : nodeStyle}
                   />
-                  {showLabels && (
-                    <text
-                      x={n.x}
-                      y={n.y + r + 12}
-                      textAnchor="middle"
-                      className="fill-on-surface-variant pointer-events-none"
-                      style={{ fontSize: 10 }}
-                    >
-                      {n.label}
-                    </text>
-                  )}
+                  <text
+                    x={n.x}
+                    y={n.y + r + 12}
+                    textAnchor="middle"
+                    className="fill-on-surface-variant pointer-events-none"
+                    style={LABEL_TEXT_STYLE}
+                  >
+                    {n.label}
+                  </text>
                 </g>
               );
             })}

--- a/src/components/ui/graph/index.ts
+++ b/src/components/ui/graph/index.ts
@@ -12,6 +12,7 @@ export {
   GraphSideContent,
   GraphSideSetting,
   GraphSideGroup,
+  DEFAULT_GROUP_PALETTE,
   GraphSideSearch,
   GraphSideNodeSummary,
   GraphSideNodeDetail,

--- a/src/components/ui/inputs/floating-label-input/FloatingLabelInput.tsx
+++ b/src/components/ui/inputs/floating-label-input/FloatingLabelInput.tsx
@@ -13,7 +13,7 @@ export const meta: ComponentMeta = {
     "Text input or textarea with floating label animation, password toggle, and character counter.",
 };
 
-export type FloatingLabelInputSize = "sm" | "md";
+export type FloatingLabelInputSize = "xs" | "sm" | "md";
 
 type BaseProps = {
   label: string;
@@ -101,10 +101,15 @@ export function FloatingLabelInput(props: FloatingLabelInputProps) {
     originalOnBlur?.(e);
   };
 
+  const isXs = size === "xs";
   const isSmall = size === "sm";
 
   const fieldClassName = cn(
     "peer w-full rounded-lg bg-transparent border-0 outline-none transition-colors disabled:cursor-not-allowed",
+    // Hide the native WebKit search-cancel button (the 3D-looking `x` that
+    // appears on `<input type="search">` when it has text). Consumers can
+    // render their own flat clear button if needed.
+    "[&::-webkit-search-cancel-button]:appearance-none [&::-webkit-search-decoration]:appearance-none",
     inverse
       ? "text-inverse-on-surface placeholder:text-inverse-on-surface/40"
       : "text-on-surface",
@@ -113,12 +118,12 @@ export function FloatingLabelInput(props: FloatingLabelInputProps) {
       : inverse
         ? "focus:text-inverse-on-surface"
         : "focus:text-primary",
-    isSmall ? "px-3 text-sm" : "px-4",
+    isXs ? "px-2 text-sm" : isSmall ? "px-3 text-sm" : "px-4",
     multiline
       ? showCounter
         ? "pt-3 pb-6 resize-none"
         : "pt-3 pb-2 resize-none"
-      : isSmall ? "py-2.5" : "py-4",
+      : isXs ? "py-1.5" : isSmall ? "py-2.5" : "py-4",
     !multiline && showPasswordToggle && type === "password" && "pr-12",
     className,
   );
@@ -139,9 +144,11 @@ export function FloatingLabelInput(props: FloatingLabelInputProps) {
     "absolute z-10 font-normal px-1 rounded-md transition-all duration-200 ease-in-out",
     "origin-top-left pointer-events-none",
     inverse ? "bg-inverse-surface" : "bg-surface-container-low",
-    isSmall
-      ? "text-sm left-3 top-2.5 peer-focus:scale-75 peer-focus:top-0 peer-focus:-translate-y-1/2 peer-focus:left-2.5 peer-[:not(:placeholder-shown)]:scale-75 peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:-translate-y-1/2 peer-[:not(:placeholder-shown)]:left-2.5"
-      : "text-base left-4 top-4 peer-focus:scale-75 peer-focus:top-0 peer-focus:-translate-y-1/2 peer-focus:left-3 peer-[:not(:placeholder-shown)]:scale-75 peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:-translate-y-1/2 peer-[:not(:placeholder-shown)]:left-3",
+    isXs
+      ? "text-sm left-2 top-1.5 peer-focus:scale-90 peer-focus:top-0 peer-focus:-translate-y-1/2 peer-focus:left-2 peer-[:not(:placeholder-shown)]:scale-90 peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:-translate-y-1/2 peer-[:not(:placeholder-shown)]:left-2"
+      : isSmall
+        ? "text-sm left-3 top-2.5 peer-focus:scale-75 peer-focus:top-0 peer-focus:-translate-y-1/2 peer-focus:left-2.5 peer-[:not(:placeholder-shown)]:scale-75 peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:-translate-y-1/2 peer-[:not(:placeholder-shown)]:left-2.5"
+        : "text-base left-4 top-4 peer-focus:scale-75 peer-focus:top-0 peer-focus:-translate-y-1/2 peer-focus:left-3 peer-[:not(:placeholder-shown)]:scale-75 peer-[:not(:placeholder-shown)]:top-0 peer-[:not(:placeholder-shown)]:-translate-y-1/2 peer-[:not(:placeholder-shown)]:left-3",
     error
       ? "text-error peer-focus:text-error"
       : inverse

--- a/src/components/ui/surfaces/option-list/OptionList.stories.tsx
+++ b/src/components/ui/surfaces/option-list/OptionList.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { OptionList } from "./OptionList";
+
+const meta: Meta<typeof OptionList> = {
+  title: "UI/Surfaces/OptionList",
+  component: OptionList,
+  decorators: [
+    (Story) => (
+      <div style={{ width: 320 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof OptionList>;
+
+const QUERY_OPS = [
+  { value: "tag:", description: "match the node's tag" },
+  { value: "name:", description: "match the node's title" },
+  { value: "description:", description: "match the node's description" },
+  { value: "content:", description: "match the node's content" },
+];
+
+export const Default: Story = {
+  args: {
+    title: "Search options",
+    showInfo: true,
+    items: QUERY_OPS,
+    onSelect: (item) => console.log("selected", item.value),
+  },
+};
+
+export const Highlighted: Story = {
+  args: {
+    title: "Search options",
+    items: QUERY_OPS,
+    activeIndex: 1,
+    onSelect: (item) => console.log("selected", item.value),
+  },
+};
+
+export const NoTitle: Story = {
+  args: {
+    items: [
+      { value: "user" },
+      { value: "core" },
+      { value: "balance" },
+    ],
+    onSelect: (item) => console.log("selected", item.value),
+  },
+};

--- a/src/components/ui/surfaces/option-list/OptionList.tsx
+++ b/src/components/ui/surfaces/option-list/OptionList.tsx
@@ -1,0 +1,110 @@
+import { type ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import { Icon } from "@/components/ui/media/icon/Icon";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "OptionList",
+  description:
+    "Floating popover that lists named options with optional descriptions. Used as a wide query-suggestion dropdown beside narrow inputs. Consumer owns positioning, open state, and click-outside.",
+};
+
+export interface OptionListItem {
+  /** The string value passed back to `onSelect`. */
+  value: string;
+  /** Display label. Falls back to `value` if absent. */
+  label?: ReactNode;
+  /** Muted text rendered to the right of `label`. */
+  description?: string;
+}
+
+export interface OptionListProps {
+  items: OptionListItem[];
+  onSelect: (item: OptionListItem) => void;
+  /** Optional header text above the list. */
+  title?: string;
+  /** Optional info icon shown next to the title (decorative; no click handler). */
+  showInfo?: boolean;
+  /**
+   * Index of the highlighted item (for keyboard navigation by the consumer).
+   * Pass `-1` for none. Defaults to `-1`.
+   */
+  activeIndex?: number;
+  className?: string;
+}
+
+export function OptionList({
+  items,
+  onSelect,
+  title,
+  showInfo = false,
+  activeIndex = -1,
+  className,
+}: OptionListProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-outline-variant bg-surface-container-low shadow-lg overflow-hidden",
+        className,
+      )}
+      role="listbox"
+    >
+      {title && (
+        <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-outline-variant">
+          <span className="text-sm font-medium text-on-surface">{title}</span>
+          {showInfo && (
+            <Icon
+              name="info"
+              size={16}
+              className="text-on-surface-variant"
+              aria-hidden
+            />
+          )}
+        </div>
+      )}
+      <ul className="py-1">
+        {items.length === 0 ? (
+          <li
+            role="option"
+            aria-selected={false}
+            className="px-3 py-1.5 text-sm text-on-surface-variant italic"
+          >
+            No matches
+          </li>
+        ) : (
+          items.map((item, i) => {
+            const highlighted = i === activeIndex;
+            return (
+              <li
+                key={item.value}
+                role="option"
+                aria-selected={highlighted}
+                onMouseDown={(e) => {
+                  // Prevent the trigger input from losing focus before we
+                  // can fire onSelect.
+                  e.preventDefault();
+                  onSelect(item);
+                }}
+                className={cn(
+                  "flex items-baseline gap-2 px-3 py-1.5 text-sm cursor-pointer",
+                  highlighted
+                    ? "bg-on-surface/8 text-on-surface"
+                    : "text-on-surface hover:bg-on-surface/8",
+                )}
+              >
+                <span className="font-medium shrink-0">
+                  {item.label ?? item.value}
+                </span>
+                {item.description && (
+                  <span className="text-xs text-on-surface-variant truncate">
+                    {item.description}
+                  </span>
+                )}
+              </li>
+            );
+          })
+        )}
+      </ul>
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,11 @@ export {
   type CardProps,
 } from "./components/ui/surfaces/card/Card";
 export {
+  OptionList,
+  type OptionListProps,
+  type OptionListItem,
+} from "./components/ui/surfaces/option-list/OptionList";
+export {
   Avatar,
   type AvatarProps,
   type AvatarSize,
@@ -273,6 +278,7 @@ export {
   GraphSideContent,
   GraphSideSetting,
   GraphSideGroup,
+  DEFAULT_GROUP_PALETTE,
   GraphSideSearch,
   GraphSideNodeSummary,
   GraphSideNodeDetail,


### PR DESCRIPTION
## Summary

Three concurrent changes in the graph-side surface, plus one new kit primitive:

### 1. Groups query system (`GraphSideGroup` rewrite)

- `GraphSideGroupItem` gains optional `query?: string`. Empty falls back to `name`. Operator prefixes (`source:`, `name:`, `description:`, `content:`) are recognized hints — the kit doesn't parse them, but the row's popover offers them as suggestions.
- Each row replaces the plain `<input>` with a `FloatingLabelInput size=\"xs\" hideLabel` editing `query`.
- Focusing a row opens a **portal-rendered OptionList popover** (280px wide, position computed from row rect, clamped to viewport). Click-outside via `document.mousedown` listener matching the kit's Combobox/DropdownMenu pattern.
- Popover content **derived from the input value**:
  - Operators mode: filter `QUERY_OPERATORS` by `startsWith(input)`; falls back to the full list if no match (so the menu doesn't blink out).
  - Sources mode (input starts with `source:`): filter `sources` prop by substring of the text after the colon.
- Click `source:` → input becomes `\"source:\"`, popover swaps to sources. Click a source value → input becomes `\"source:<value>\"`, popover closes. Click any other operator → input becomes the prefix, popover closes.
- New `palette?: string[]` prop with kit-exported `DEFAULT_GROUP_PALETTE` (10 MD3 mid-tones, light + dark friendly). `New group` cycles through palette skipping colors already used.

### 2. New OptionList primitive (`surfaces/option-list`)

- Pure popover content: title + optional info icon + list of items (`value` + optional `label` + optional `description`). Consumer owns positioning, open state, click-outside.
- Items use `onMouseDown` + `preventDefault` so the trigger input doesn't lose focus before `onSelect` runs.
- Empty state: \"No matches\" placeholder.
- Re-export: `OptionList`, `OptionListProps`, `OptionListItem`.

### 3. Show tags as nodes (`Graph` + `GraphSideSetting`)

- `showLabels` removed (labels always render). New `showTags?: boolean` (default `false`).
- When `showTags=true`, Graph synthesizes virtual **tag nodes** (id prefix `__tag:`) — one per unique tag value — and edges connecting each tagged node to its tag node. The sim treats them like regular nodes; render uses outline style (`fill-none stroke-on-surface-variant`).
- `onNodeClick` is suppressed for synthetic ids so consumers don't see `__tag:*` leak. `isDev` warns on collision.
- `GraphSideSettingValue.showLabels` renamed to `showTags`; row label \"Show labels\" → \"Show tags\". Breaking pre-1.0.

### 4. Misc kit changes

- `FloatingLabelInput` gains an `xs` size variant (in addition to `sm`/`md`) and hides the native `<input type=\"search\">` cancel button via CSS so the X is flat.
- Story passes lowercase platform sources (`apps`, `account`, `crm`, `daily`, `balance`, `projectify`). Color matcher strips known operator prefixes before substring-all priority match. Setting seed: `showLabels: true` → `showTags: false`.

Version: 0.2.17 → 0.2.18.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `/story/layout-graph--with-graph-and-settings`:
  - [ ] Open Settings → groups panel
  - [ ] Focus an empty query input → \"Search options\" popover shows 4 operators
  - [ ] Click `source:` → input becomes `\"source:\"`, popover swaps to \"Sources\" with the 6 platforms
  - [ ] Click a source (e.g. `balance`) → input becomes `\"source:balance\"`, popover closes, Balance node tints
  - [ ] Click outside the editor → popover closes
  - [ ] Edit/delete a group → updates flow through `onChange` (snackbar wiring point for future dirty-tracking)
  - [ ] Delete all groups, add new ones → palette cycles, no color repeat until palette exhausted
  - [ ] Flip Show tags toggle ON → outline circles appear for each unique tag, connected to their nodes
  - [ ] Drag a tag node → moves under the sim like other nodes
  - [ ] Click a tag node → no `onNodeClick` fires (no console activity)
- [ ] `/story/ui-surfaces-optionlist--default` + `--highlighted` + `--no-title`
- [ ] Search X in the settings search input → flat icon (no native WebKit 3D X)

🤖 Generated with [Claude Code](https://claude.com/claude-code)