### PR TITLE
feat(app-shell): animate sidebar open/close (push-left)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -189,65 +189,69 @@ function AppShellInner({
         </div>
       </div>
 
-      {/* Right: agent sidebar */}
-      {sidebarWidth > 0 && (
-        <div
-          className={cn(
-            "flex justify-end shrink-0",
-            isOverlaying
-              ? "fixed top-0 right-0 h-screen z-30"
-              : "relative z-50",
-            !isResizing && "transition-all duration-300",
-          )}
-          style={isOverlaying ? undefined : { width: `${sidebarWidth + 10}px` }}
-        >
-          {isOverlaying && (
-            <div
-              className="fixed inset-0 bg-black/20 -z-10"
-              onClick={handleClose}
+      {/* Right: agent sidebar. Always rendered so the open/close transition
+          shares the same animated width track as the resize handle —
+          conditional render would pop the sidebar in without animation
+          (and the main column would jump-reflow). When sidebarWidth === 0
+          the wrapper collapses to width 0 and overflow-hidden swallows
+          the content; the toggle button below takes over. */}
+      <div
+        className={cn(
+          "flex justify-end shrink-0 overflow-hidden",
+          isOverlaying
+            ? "fixed top-0 right-0 h-screen z-30"
+            : "relative z-50",
+          !isResizing && "transition-all duration-300",
+        )}
+        style={isOverlaying ? undefined : { width: sidebarWidth > 0 ? `${sidebarWidth + 10}px` : "0px" }}
+        aria-hidden={sidebarWidth === 0}
+      >
+        {isOverlaying && sidebarWidth > 0 && (
+          <div
+            className="fixed inset-0 bg-black/20 -z-10"
+            onClick={handleClose}
+          />
+        )}
+
+        <div className="flex">
+          <div
+            className="w-2 flex cursor-ew-resize z-20 rounded-full hover:bg-primary-container transition-colors shrink-0"
+            onMouseDown={startResize}
+          />
+
+          <div
+            ref={sidebarElRef}
+            className="overflow-hidden relative my-2 mr-2 flex flex-col"
+            style={{ width: `${sidebarWidth}px`, height: "calc(100vh - 1rem)" }}
+          >
+            <AgentSidebarHeader
+              sidebarWidth={sidebarWidth}
+              onToggleCollapse={handleToggleCollapse}
+              onClose={handleClose}
+              history={agentHistory}
+              onSelectHistoryItem={onSelectAgentHistoryItem}
             />
-          )}
 
-          <div className="flex">
-            <div
-              className="w-2 flex cursor-ew-resize z-20 rounded-full hover:bg-primary-container transition-colors shrink-0"
-              onMouseDown={startResize}
-            />
-
-            <div
-              ref={sidebarElRef}
-              className="overflow-hidden relative my-2 mr-2 flex flex-col"
-              style={{ width: `${sidebarWidth}px`, height: "calc(100vh - 1rem)" }}
-            >
-              <AgentSidebarHeader
-                sidebarWidth={sidebarWidth}
-                onToggleCollapse={handleToggleCollapse}
-                onClose={handleClose}
-                history={agentHistory}
-                onSelectHistoryItem={onSelectAgentHistoryItem}
-              />
-
-              <div className="rounded-2xl bg-on-background flex-1 min-h-0 flex flex-col">
-                <div className="flex-1 overflow-y-auto overflow-x-hidden p-4">
-                  {agentSidebarContent}
-                </div>
-
-                {agentPendingContent && (
-                  <div className="shrink-0 mx-3 mt-2 mb-1 rounded-xl bg-inverse-on-surface/[0.06] backdrop-blur-md border border-inverse-on-surface/[0.08] p-3">
-                    {agentPendingContent}
-                  </div>
-                )}
-
-                <AgentSidebarInput
-                  onSend={onAgentSend}
-                  onAttachFile={onAgentAttachFile}
-                  onMic={onAgentMic}
-                />
+            <div className="rounded-2xl bg-on-background flex-1 min-h-0 flex flex-col">
+              <div className="flex-1 overflow-y-auto overflow-x-hidden p-4">
+                {agentSidebarContent}
               </div>
+
+              {agentPendingContent && (
+                <div className="shrink-0 mx-3 mt-2 mb-1 rounded-xl bg-inverse-on-surface/[0.06] backdrop-blur-md border border-inverse-on-surface/[0.08] p-3">
+                  {agentPendingContent}
+                </div>
+              )}
+
+              <AgentSidebarInput
+                onSend={onAgentSend}
+                onAttachFile={onAgentAttachFile}
+                onMic={onAgentMic}
+              />
             </div>
           </div>
         </div>
-      )}
+      </div>
 
       {/* Agent toggle button */}
       {sidebarWidth === 0 && (


### PR DESCRIPTION
Toggling the agent sidebar open/closed used to pop in/out — the resize transition worked because the sidebar element existed and its width changed smoothly, but open/close conditionally rendered the whole sidebar so no transition could fire and the main column jump-reflowed.

## Fix

Always render the sidebar wrapper. Width is \`sidebarWidth + 10\` when open, \`0\` when closed; the existing \`transition-all duration-300\` track now handles both the open/close animation (push-left feel) and the resize as one continuous motion.

- \`overflow-hidden\` on the wrapper swallows content during the 0-width state and mid-transition.
- \`aria-hidden\` flips with \`width === 0\` so screen readers don't see the off-screen chrome.
- Overlay backdrop (narrow-viewport \`isOverlaying\` case) is gated on \`isOverlaying && sidebarWidth > 0\` so it doesn't paint when closed.
- Toggle button still conditionally renders when \`sidebarWidth === 0\` — no behavior change there.

## Versioning

Pre-1.0 patch bump per \`[[feedback_web_ui_kit_versioning]]\`: **0.2.19 → 0.2.20**. Tagged \`release\`.

## Test

\`pnpm typecheck\` clean. No AppShell tests existed; manual verification: toggle the sidebar with the smart_toy IconButton — it now slides in from the right (push-left effect on main content) over 300ms, matching the resize handle's animation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)