### PR TITLE
feat(app-shell): animate sidebar open/close width (push-left)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/app-shell/AppShell.tsx
@@ -189,65 +189,61 @@ function AppShellInner({
         </div>
       </div>
 
-      {/* Right: agent sidebar */}
-      {sidebarWidth > 0 && (
-        <div
-          className={cn(
-            "flex justify-end shrink-0",
-            isOverlaying
-              ? "fixed top-0 right-0 h-screen z-30"
-              : "relative z-50",
-            !isResizing && "transition-all duration-300",
-          )}
-          style={isOverlaying ? undefined : { width: `${sidebarWidth + 10}px` }}
-        >
-          {isOverlaying && (
-            <div
-              className="fixed inset-0 bg-black/20 -z-10"
-              onClick={handleClose}
+      {/* Right: agent sidebar. Always mounted so width animates 0 ↔ N on
+          open/close — conditional render would snap into place with no
+          "from" value to interpolate. */}
+      <div
+        className={cn(
+          "flex justify-end shrink-0 overflow-hidden",
+          isOverlaying ? "fixed top-0 right-0 h-screen z-30" : "relative z-50",
+          !isResizing && "transition-all duration-300",
+        )}
+        style={isOverlaying ? undefined : { width: sidebarWidth > 0 ? sidebarWidth + 10 : 0 }}
+        aria-hidden={sidebarWidth === 0}
+      >
+        {isOverlaying && (
+          <div className="fixed inset-0 bg-black/20 -z-10" onClick={handleClose} />
+        )}
+
+        <div className="flex">
+          <div
+            className="w-2 flex cursor-ew-resize z-20 rounded-full hover:bg-primary-container transition-colors shrink-0"
+            onMouseDown={startResize}
+          />
+
+          <div
+            ref={sidebarElRef}
+            className="overflow-hidden relative my-2 mr-2 flex flex-col"
+            style={{ width: `${sidebarWidth}px`, height: "calc(100vh - 1rem)" }}
+          >
+            <AgentSidebarHeader
+              sidebarWidth={sidebarWidth}
+              onToggleCollapse={handleToggleCollapse}
+              onClose={handleClose}
+              history={agentHistory}
+              onSelectHistoryItem={onSelectAgentHistoryItem}
             />
-          )}
 
-          <div className="flex">
-            <div
-              className="w-2 flex cursor-ew-resize z-20 rounded-full hover:bg-primary-container transition-colors shrink-0"
-              onMouseDown={startResize}
-            />
-
-            <div
-              ref={sidebarElRef}
-              className="overflow-hidden relative my-2 mr-2 flex flex-col"
-              style={{ width: `${sidebarWidth}px`, height: "calc(100vh - 1rem)" }}
-            >
-              <AgentSidebarHeader
-                sidebarWidth={sidebarWidth}
-                onToggleCollapse={handleToggleCollapse}
-                onClose={handleClose}
-                history={agentHistory}
-                onSelectHistoryItem={onSelectAgentHistoryItem}
-              />
-
-              <div className="rounded-2xl bg-on-background flex-1 min-h-0 flex flex-col">
-                <div className="flex-1 overflow-y-auto overflow-x-hidden p-4">
-                  {agentSidebarContent}
-                </div>
-
-                {agentPendingContent && (
-                  <div className="shrink-0 mx-3 mt-2 mb-1 rounded-xl bg-inverse-on-surface/[0.06] backdrop-blur-md border border-inverse-on-surface/[0.08] p-3">
-                    {agentPendingContent}
-                  </div>
-                )}
-
-                <AgentSidebarInput
-                  onSend={onAgentSend}
-                  onAttachFile={onAgentAttachFile}
-                  onMic={onAgentMic}
-                />
+            <div className="rounded-2xl bg-on-background flex-1 min-h-0 flex flex-col">
+              <div className="flex-1 overflow-y-auto overflow-x-hidden p-4">
+                {agentSidebarContent}
               </div>
+
+              {agentPendingContent && (
+                <div className="shrink-0 mx-3 mt-2 mb-1 rounded-xl bg-inverse-on-surface/[0.06] backdrop-blur-md border border-inverse-on-surface/[0.08] p-3">
+                  {agentPendingContent}
+                </div>
+              )}
+
+              <AgentSidebarInput
+                onSend={onAgentSend}
+                onAttachFile={onAgentAttachFile}
+                onMic={onAgentMic}
+              />
             </div>
           </div>
         </div>
-      )}
+      </div>
 
       {/* Agent toggle button */}
       {sidebarWidth === 0 && (


### PR DESCRIPTION
Replaces closed #207 with a tighter implementation.

## Problem

The agent sidebar wrapper was conditionally rendered (\`{sidebarWidth > 0 && ...}\`). Opening snap-mounted it at full width — the existing \`transition-all duration-300\` had no \"from\" value to interpolate, so the main content jump-reflowed instead of sliding left.

## Change

Always mount the wrapper. Width style: \`sidebarWidth > 0 ? sidebarWidth + 10 : 0\`. \`overflow-hidden\` on the wrapper so collapsed children clip. \`aria-hidden\` when closed so screen readers skip the empty region.

Net diff: 47 + / 51 − (most of the line count is the indent shift from removing the conditional braces). No visible change when the sidebar is open; only the open/close transition is added.

## Version

0.2.19 → **0.2.20** (patch per [pre-1.0 web-ui-kit convention](memory)). \`release\` label set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)