### PR TITLE
feat(data): add Markdown component

### DIFF
--- a/src/components/ui/data/markdown/Markdown.stories.tsx
+++ b/src/components/ui/data/markdown/Markdown.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Markdown } from "./Markdown";
+
+const meta: Meta<typeof Markdown> = {
+  title: "UI/Data/Markdown",
+  component: Markdown,
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-prose bg-surface p-6">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Markdown>;
+
+const KITCHEN_SINK = `## What you'll get
+
+Install **My Module** and your app picks up a new set of pages, actions, and notifications — no setup screens to fight through.
+
+## How it shows up
+
+- A new section in your sidebar where you can pick up where you left off
+- Quick actions surfaced on the relevant detail pages
+- Notifications when something happens that needs your attention
+
+## Quick start
+
+Drop a handler into another module to call into this one:
+
+\`\`\`ts
+import ms from "@mirrorstack/sdk";
+
+const result = await ms.Call("@me/my-module", "do.thing", { /* ... */ });
+\`\`\`
+
+## Notes
+
+This module is **read-only** for other modules — writes go through registered \`handlers\`, not direct table writes.`;
+
+export const Playground: Story = {
+  args: { source: KITCHEN_SINK },
+};
+
+export const Headings: Story = {
+  args: {
+    source: `# Heading level 1
+
+## Heading level 2
+
+### Heading level 3
+
+Body text follows the smallest heading.`,
+  },
+};
+
+export const ListsAndInlines: Story = {
+  args: {
+    source: `Most lines render as paragraphs with **bold** and \`code\` inline.
+
+- First bullet with a \`code\` ref
+- **Bold bullet** with emphasis
+- Plain bullet
+
+A second paragraph follows the list.`,
+  },
+};
+
+export const FencedCode: Story = {
+  args: {
+    source: `Fenced code blocks render with a monospace surface and an optional language label.
+
+\`\`\`ts
+function greet(name: string): string {
+  return \`Hello, \${name}!\`;
+}
+\`\`\``,
+  },
+};
+
+export const Empty: Story = {
+  args: { source: "" },
+};

--- a/src/components/ui/data/markdown/Markdown.test.tsx
+++ b/src/components/ui/data/markdown/Markdown.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { describe, expect, it, afterEach } from "vitest";
+import { Markdown } from "./Markdown";
+
+afterEach(cleanup);
+
+describe("Markdown", () => {
+  it("renders an h3 for a top-level heading", () => {
+    render(<Markdown source="# Hello" />);
+    const h = screen.getByRole("heading", { level: 3 });
+    expect(h).toHaveTextContent("Hello");
+  });
+
+  it("renders h4 / h5 for nested heading levels", () => {
+    render(<Markdown source={`## Two\n\n### Three`} />);
+    expect(screen.getByRole("heading", { level: 4 })).toHaveTextContent("Two");
+    expect(screen.getByRole("heading", { level: 5 })).toHaveTextContent("Three");
+  });
+
+  it("renders a paragraph for plain text", () => {
+    render(<Markdown source="Hello world." />);
+    expect(screen.getByText("Hello world.").closest("p")).toBeInTheDocument();
+  });
+
+  it("joins consecutive non-blank lines into one paragraph", () => {
+    render(<Markdown source={`first line\nsecond line`} />);
+    expect(screen.getByText("first line second line")).toBeInTheDocument();
+  });
+
+  it("renders an unordered list for - / * lines", () => {
+    render(<Markdown source={`- one\n- two\n* three`} />);
+    const list = screen.getByRole("list");
+    expect(list.tagName).toBe("UL");
+    expect(list.children).toHaveLength(3);
+  });
+
+  it("renders inline **bold** as <strong>", () => {
+    render(<Markdown source="This is **bold** text." />);
+    const strong = screen.getByText("bold");
+    expect(strong.tagName).toBe("STRONG");
+  });
+
+  it("renders inline `code` as <code>", () => {
+    render(<Markdown source="Run `npm install` first." />);
+    const code = screen.getByText("npm install");
+    expect(code.tagName).toBe("CODE");
+  });
+
+  it("renders fenced code blocks inside a <pre>", () => {
+    render(<Markdown source={"```ts\nconst x = 1;\n```"} />);
+    const pre = screen.getByText("const x = 1;").closest("pre");
+    expect(pre).toBeInTheDocument();
+  });
+
+  it("shows the language label when the fence specifies one", () => {
+    render(<Markdown source={"```ts\nx\n```"} />);
+    expect(screen.getByText("ts")).toBeInTheDocument();
+  });
+
+  it("renders nothing visible for an empty source", () => {
+    const { container } = render(<Markdown source="" />);
+    expect(container.firstChild).toBeEmptyDOMElement();
+  });
+
+  it("applies a custom className to the wrapper", () => {
+    const { container } = render(<Markdown source="Hi" className="my-extra" />);
+    expect(container.firstChild).toHaveClass("my-extra");
+  });
+});

--- a/src/components/ui/data/markdown/Markdown.tsx
+++ b/src/components/ui/data/markdown/Markdown.tsx
@@ -1,0 +1,144 @@
+import { memo, type ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "Markdown",
+  description:
+    "Minimal markdown renderer for the kit's typography tokens — headings (# / ## / ###), paragraphs, unordered lists, fenced code blocks, inline **bold** and `code`. Memoized so re-renders don't re-parse the source.",
+};
+
+export interface MarkdownProps {
+  source: string;
+  className?: string;
+}
+
+const INLINE_TOKEN_RE = /(\*\*[^*]+\*\*|`[^`]+`)/g;
+const CRLF_RE = /\r\n?/g;
+const HEADING_RE = /^(#{1,3}) (.*)$/;
+const LIST_RE = /^[-*] /;
+
+const HEADING_LEVELS: Record<
+  1 | 2 | 3,
+  { Tag: "h3" | "h4" | "h5"; cls: string }
+> = {
+  1: { Tag: "h3", cls: "text-xl font-medium text-on-surface mt-4 first:mt-0" },
+  2: { Tag: "h4", cls: "text-base font-medium text-on-surface mt-4 first:mt-0" },
+  3: { Tag: "h5", cls: "text-sm font-medium text-on-surface mt-3 first:mt-0" },
+};
+
+function renderInline(text: string): ReactNode {
+  const tokens = text.split(INLINE_TOKEN_RE);
+  return tokens.map((t, i) => {
+    if (!t) return null;
+    if (t.startsWith("**") && t.endsWith("**")) {
+      return (
+        <strong key={i} className="font-semibold text-on-surface">
+          {t.slice(2, -2)}
+        </strong>
+      );
+    }
+    if (t.startsWith("`") && t.endsWith("`")) {
+      return (
+        <code
+          key={i}
+          className="font-mono bg-surface-container text-on-surface px-1 py-0.5 rounded text-xs"
+        >
+          {t.slice(1, -1)}
+        </code>
+      );
+    }
+    return <span key={i}>{t}</span>;
+  });
+}
+
+export const Markdown = memo(function Markdown({ source, className }: MarkdownProps) {
+  const lines = source.replace(CRLF_RE, "\n").split("\n");
+  const blocks: ReactNode[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const line = lines[i];
+
+    const heading = line.match(HEADING_RE);
+    if (heading) {
+      const level = heading[1].length as 1 | 2 | 3;
+      const text = heading[2];
+      const { Tag, cls } = HEADING_LEVELS[level];
+      blocks.push(
+        <Tag key={blocks.length} className={cls}>
+          {text}
+        </Tag>,
+      );
+      i++;
+      continue;
+    }
+
+    if (line.startsWith("```")) {
+      const lang = line.slice(3);
+      const code: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].startsWith("```")) {
+        code.push(lines[i]);
+        i++;
+      }
+      i++;
+      blocks.push(
+        <pre
+          key={blocks.length}
+          className="text-xs font-mono bg-surface-container text-on-surface p-3 rounded-lg overflow-x-auto leading-relaxed"
+        >
+          {lang && (
+            <span className="block text-on-surface-variant/60 mb-1">{lang}</span>
+          )}
+          <code>{code.join("\n")}</code>
+        </pre>,
+      );
+      continue;
+    }
+
+    if (LIST_RE.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && LIST_RE.test(lines[i])) {
+        items.push(lines[i].slice(2));
+        i++;
+      }
+      blocks.push(
+        <ul
+          key={blocks.length}
+          className="list-disc pl-5 space-y-0.5 text-sm text-on-surface leading-relaxed"
+        >
+          {items.map((it, j) => (
+            <li key={j}>{renderInline(it)}</li>
+          ))}
+        </ul>,
+      );
+      continue;
+    }
+
+    if (line.trim() === "") {
+      i++;
+      continue;
+    }
+
+    const paragraph: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() !== "" &&
+      !HEADING_RE.test(lines[i]) &&
+      !lines[i].startsWith("```") &&
+      !LIST_RE.test(lines[i])
+    ) {
+      paragraph.push(lines[i]);
+      i++;
+    }
+    blocks.push(
+      <p
+        key={blocks.length}
+        className="text-sm text-on-surface-variant leading-relaxed"
+      >
+        {renderInline(paragraph.join(" "))}
+      </p>,
+    );
+  }
+  return <div className={cn("space-y-2", className)}>{blocks}</div>;
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,10 @@ export {
   type ReadOnlyFieldProps,
 } from "./components/ui/data/read-only-field/ReadOnlyField";
 export {
+  Markdown,
+  type MarkdownProps,
+} from "./components/ui/data/markdown/Markdown";
+export {
   SettingRow,
   type SettingRowProps,
 } from "./components/ui/data/setting-row/SettingRow";


### PR DESCRIPTION
## Summary

- Minimal markdown renderer styled with the kit's typography tokens
- Supports ATX headings (`#`/`##`/`###`), paragraphs, unordered lists, fenced code blocks, inline `**bold**` and `` `code` ``
- Memoized — re-renders skip the parse when `source` hasn't changed

## Why

Promoted from inline use in `apps.mirrorstack.ai`'s module-detail dialog. Extracting it makes the renderer available to any kit consumer that needs to display long-form module / version / changelog text. The current implementation is intentionally minimal (no full CommonMark spec, no GFM tables) — just enough for the in-product surfaces using it today.

## Test plan

- [x] \`pnpm typecheck\` clean
- [ ] Visual: render a source with each block type and verify tokens match (Surface, on-surface text colors)
- [ ] Memo: confirm parent re-render with same source skips parse via React DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)