### PR TITLE
feat(data): add StatCard component

### DIFF
--- a/src/components/ui/data/stat-card/StatCard.stories.tsx
+++ b/src/components/ui/data/stat-card/StatCard.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { StatCard } from "./StatCard";
+
+const meta: Meta<typeof StatCard> = {
+  title: "UI/Data/StatCard",
+  component: StatCard,
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-sm bg-background p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    icon: "apps",
+    label: "Installs",
+    value: "1,284",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof StatCard>;
+
+export const Playground: Story = {};
+
+export const NumericValue: Story = {
+  args: {
+    icon: "apps",
+    label: "Installs",
+    value: "12,840",
+  },
+};
+
+export const VersionLabel: Story = {
+  args: {
+    icon: "new_releases",
+    label: "Latest version",
+    value: "v0.4.0-beta.1",
+  },
+};
+
+export const DateValue: Story = {
+  args: {
+    icon: "calendar_today",
+    label: "Created",
+    value: "May 6, 2026",
+  },
+};
+
+export const OverviewGrid: StoryObj<typeof StatCard> = {
+  render: () => (
+    <div className="w-full max-w-3xl grid grid-cols-1 sm:grid-cols-3 gap-3">
+      <StatCard icon="apps" label="Installs" value="1,284" />
+      <StatCard icon="new_releases" label="Latest version" value="v0.4.0" />
+      <StatCard icon="calendar_today" label="Created" value="May 6, 2026" />
+    </div>
+  ),
+};

--- a/src/components/ui/data/stat-card/StatCard.test.tsx
+++ b/src/components/ui/data/stat-card/StatCard.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { describe, expect, it, afterEach } from "vitest";
+import { StatCard } from "./StatCard";
+
+afterEach(cleanup);
+
+describe("StatCard", () => {
+  it("renders label, value, and icon", () => {
+    render(<StatCard icon="apps" label="Installs" value="1,284" />);
+    expect(screen.getByText("Installs")).toBeInTheDocument();
+    expect(screen.getByText("1,284")).toBeInTheDocument();
+    expect(screen.getByText("apps")).toBeInTheDocument();
+  });
+
+  it("truncates string values", () => {
+    render(<StatCard icon="apps" label="L" value="some-long-string" />);
+    expect(screen.getByText("some-long-string")).toHaveClass("truncate");
+  });
+
+  it("does not apply truncate when value is a ReactNode", () => {
+    render(
+      <StatCard
+        icon="apps"
+        label="L"
+        value={<span data-testid="custom">x</span>}
+      />,
+    );
+    const node = screen.getByTestId("custom");
+    expect(node.parentElement).not.toHaveClass("truncate");
+  });
+
+  it("applies a custom className to the underlying Card", () => {
+    const { container } = render(
+      <StatCard icon="apps" label="L" value="v" className="my-extra" />,
+    );
+    expect(container.firstChild).toHaveClass("my-extra");
+  });
+});

--- a/src/components/ui/data/stat-card/StatCard.tsx
+++ b/src/components/ui/data/stat-card/StatCard.tsx
@@ -1,0 +1,42 @@
+import type { ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { Card } from "@/components/ui/surfaces/card/Card";
+import { Icon } from "@/components/ui/media/icon/Icon";
+
+export const meta: ComponentMeta = {
+  name: "StatCard",
+  description:
+    "Compact stat tile — material-symbol icon on the left, small label above a single value on the right. Drop into a grid for overview pages.",
+};
+
+export interface StatCardProps {
+  /** Material symbol icon name. */
+  icon: string;
+  /** Short label shown above the value (e.g. \"Installs\"). */
+  label: string;
+  /** The headline value. */
+  value: ReactNode;
+  className?: string;
+}
+
+export function StatCard({ icon, label, value, className }: StatCardProps) {
+  return (
+    <Card className={className}>
+      <div className="flex items-center gap-3">
+        <Icon name={icon} size={20} className="text-primary shrink-0" />
+        <div className="min-w-0">
+          <p className="text-xs text-on-surface-variant">{label}</p>
+          <p
+            className={cn(
+              "text-sm font-medium text-on-surface",
+              typeof value === "string" && "truncate",
+            )}
+          >
+            {value}
+          </p>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,10 @@ export {
   type ReadOnlyFieldProps,
 } from "./components/ui/data/read-only-field/ReadOnlyField";
 export {
+  StatCard,
+  type StatCardProps,
+} from "./components/ui/data/stat-card/StatCard";
+export {
   SettingRow,
   type SettingRowProps,
 } from "./components/ui/data/setting-row/SettingRow";


### PR DESCRIPTION
## Summary

- Compact stat tile: material-symbol icon (via the kit's \`Icon\`) on the left, small label above a single value on the right
- Wraps \`Card\` so border / surface tokens stay consistent
- \`value\` is a \`ReactNode\` — pass a plain string and it'll truncate, pass anything else and you control the layout

## Why

The \"Installs / Latest version / Created\" tile pattern already appears as inline JSX in /dev/module/[slug] and was duplicated in the apps.mirrorstack.ai install dialog. Single component replaces both.

## Test plan

- [x] \`pnpm typecheck\` clean
- [ ] Visual: drop three in a \`grid grid-cols-1 sm:grid-cols-3 gap-3\` and verify icon / label / value alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)