### PR TITLE
feat(data): add Step component

### DIFF
--- a/src/components/ui/data/step/Step.stories.tsx
+++ b/src/components/ui/data/step/Step.stories.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Step } from "./Step";
+import { Button } from "@/components/ui/actions/button/Button";
+
+const meta: Meta<typeof Step> = {
+  title: "UI/Data/Step",
+  component: Step,
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-xl bg-background p-6">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    n: 1,
+    title: "Details",
+    status: "active",
+    children: (
+      <p className="text-sm text-on-surface-variant">
+        Step body lives here. Anything from a single line to a full form.
+      </p>
+    ),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Step>;
+
+export const Active: Story = {};
+
+export const Complete: Story = {
+  args: { status: "complete" },
+};
+
+export const CompleteWithEdit: Story = {
+  args: {
+    status: "complete",
+    onEdit: () => console.log("Edit step 1"),
+    children: undefined,
+  },
+};
+
+export const Pending: Story = {
+  args: { status: "pending", n: 3, title: "Review" },
+};
+
+export const Wizard: StoryObj<typeof Step> = {
+  render: () => {
+    const [step, setStep] = useState<1 | 2 | 3>(1);
+    return (
+      <div>
+        <Step
+          n={1}
+          title="Details"
+          status={step === 1 ? "active" : "complete"}
+          onEdit={step > 1 ? () => setStep(1) : undefined}
+        >
+          {step === 1 && (
+            <div className="space-y-3">
+              <p className="text-sm text-on-surface-variant">
+                Fill in the basics. Name, slug, description.
+              </p>
+              <Button onClick={() => setStep(2)}>Next</Button>
+            </div>
+          )}
+        </Step>
+        <Step
+          n={2}
+          title="Modules"
+          status={step === 2 ? "active" : step > 2 ? "complete" : "pending"}
+          onEdit={step > 2 ? () => setStep(2) : undefined}
+        >
+          {step === 2 && (
+            <div className="space-y-3">
+              <p className="text-sm text-on-surface-variant">
+                Pick the modules you want installed on this app.
+              </p>
+              <div className="flex gap-2">
+                <Button variant="text" onClick={() => setStep(1)}>Back</Button>
+                <Button onClick={() => setStep(3)}>Next</Button>
+              </div>
+            </div>
+          )}
+        </Step>
+        <Step
+          n={3}
+          title="Review"
+          status={step === 3 ? "active" : "pending"}
+          isLast
+        >
+          {step === 3 && (
+            <div className="space-y-3">
+              <p className="text-sm text-on-surface-variant">
+                Confirm and create the app.
+              </p>
+              <div className="flex gap-2">
+                <Button variant="text" onClick={() => setStep(2)}>Back</Button>
+                <Button>Create app</Button>
+              </div>
+            </div>
+          )}
+        </Step>
+      </div>
+    );
+  },
+};

--- a/src/components/ui/data/step/Step.test.tsx
+++ b/src/components/ui/data/step/Step.test.tsx
@@ -1,0 +1,90 @@
+import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { Step } from "./Step";
+
+afterEach(cleanup);
+
+describe("Step", () => {
+  it("renders the step number when not complete", () => {
+    render(
+      <Step n={2} title="Modules" status="pending">
+        body
+      </Step>,
+    );
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("Modules")).toBeInTheDocument();
+  });
+
+  it("renders a check icon instead of the number when complete", () => {
+    render(
+      <Step n={1} title="Details" status="complete">
+        body
+      </Step>,
+    );
+    // The Icon component renders the material symbol name as text.
+    expect(screen.getByText("check")).toBeInTheDocument();
+    // The numeric label should not appear inside the circle.
+    expect(screen.queryByText("1")).not.toBeInTheDocument();
+  });
+
+  it("renders the Edit button only when complete + onEdit is provided", () => {
+    const onEdit = vi.fn();
+    const { rerender } = render(
+      <Step n={1} title="Details" status="active" onEdit={onEdit}>
+        body
+      </Step>,
+    );
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+
+    rerender(
+      <Step n={1} title="Details" status="complete" onEdit={onEdit}>
+        body
+      </Step>,
+    );
+    expect(screen.getByText("Edit")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Edit"));
+    expect(onEdit).toHaveBeenCalledOnce();
+  });
+
+  it("does not render the Edit button when complete but no onEdit is passed", () => {
+    render(
+      <Step n={1} title="Details" status="complete">
+        body
+      </Step>,
+    );
+    expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+  });
+
+  it("renders children inside the content slot", () => {
+    render(
+      <Step n={1} title="Details" status="active">
+        <span data-testid="body">step body</span>
+      </Step>,
+    );
+    expect(screen.getByTestId("body")).toBeInTheDocument();
+  });
+
+  it("omits children wrapper when no children are passed", () => {
+    render(<Step n={1} title="Details" status="active" />);
+    expect(screen.getByText("Details")).toBeInTheDocument();
+  });
+
+  it("dims the title when status is pending", () => {
+    render(
+      <Step n={3} title="Review" status="pending">
+        body
+      </Step>,
+    );
+    expect(screen.getByText("Review")).toHaveClass("text-on-surface-variant");
+  });
+
+  it("applies a custom className to the section wrapper", () => {
+    const { container } = render(
+      <Step n={1} title="Details" status="active" className="my-extra">
+        body
+      </Step>,
+    );
+    expect(container.firstChild).toHaveClass("my-extra");
+  });
+});

--- a/src/components/ui/data/step/Step.tsx
+++ b/src/components/ui/data/step/Step.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { Icon } from "@/components/ui/media/icon/Icon";
+import { Button } from "@/components/ui/actions/button/Button";
+
+export const meta: ComponentMeta = {
+  name: "Step",
+  description:
+    "Numbered wizard step with a spine line on the left. Status drives the circle styling (active / complete / pending). When complete, an optional `onEdit` surfaces an Edit affordance next to the title so the user can jump back.",
+};
+
+export type StepStatus = "active" | "complete" | "pending";
+
+export interface StepProps {
+  /** 1-based step number rendered inside the circle. */
+  n: number;
+  title: string;
+  status: StepStatus;
+  /** Suppress the connecting spine line below this step (use on the last step). */
+  isLast?: boolean;
+  /** Surfaces an Edit button next to the title when status is "complete". */
+  onEdit?: () => void;
+  children?: ReactNode;
+  className?: string;
+}
+
+export function Step({
+  n,
+  title,
+  status,
+  isLast,
+  onEdit,
+  children,
+  className,
+}: StepProps) {
+  return (
+    <section className={cn("flex gap-4", className)}>
+      <div className="flex flex-col items-center w-7 shrink-0">
+        <div className="h-10 flex items-center shrink-0">
+          <div
+            className={cn(
+              "size-7 rounded-full flex items-center justify-center text-sm font-medium shrink-0",
+              status === "pending"
+                ? "bg-surface-container text-on-surface-variant"
+                : "bg-primary text-on-primary",
+            )}
+          >
+            {status === "complete" ? <Icon name="check" size={16} /> : n}
+          </div>
+        </div>
+        {!isLast && <div className="w-px flex-1 bg-outline-variant/40" />}
+      </div>
+      <div className="flex-1 pb-6 min-w-0">
+        <div className="flex items-center gap-3 h-10">
+          <span
+            className={cn(
+              "text-base font-medium",
+              status === "pending" ? "text-on-surface-variant" : "text-on-surface",
+            )}
+          >
+            {title}
+          </span>
+          {status === "complete" && onEdit && (
+            <Button variant="text" size="sm" leftIcon="edit" onClick={onEdit}>
+              Edit
+            </Button>
+          )}
+        </div>
+        {children && <div className="mt-4">{children}</div>}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ui/data/step/Step.tsx
+++ b/src/components/ui/data/step/Step.tsx
@@ -67,7 +67,7 @@ export function Step({
             </Button>
           )}
         </div>
-        {children && <div className="mt-4">{children}</div>}
+        {children}
       </div>
     </section>
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,6 +139,11 @@ export {
   type ReadOnlyFieldProps,
 } from "./components/ui/data/read-only-field/ReadOnlyField";
 export {
+  Step,
+  type StepProps,
+  type StepStatus,
+} from "./components/ui/data/step/Step";
+export {
   SettingRow,
   type SettingRowProps,
 } from "./components/ui/data/setting-row/SettingRow";


### PR DESCRIPTION
## Summary

- Numbered wizard step with a vertical spine line on the left
- Status drives the circle: active/complete = filled primary, pending = surface-container
- When status is \`complete\` and \`onEdit\` is provided, an Edit affordance appears next to the title so the user can jump back to that step
- Last step sets \`isLast\` to suppress the connector

## Why

Promoted from the multi-step \"create app\" flow on apps.mirrorstack.ai. Same shape will likely show up in any future install / onboarding / setup wizard.

## Test plan

- [x] \`pnpm typecheck\` clean
- [ ] Visual: three steps in a vertical stack — verify spine line connects, circle states render, Edit affordance appears only when complete + onEdit

🤖 Generated with [Claude Code](https://claude.com/claude-code)