### PR TITLE
feat(read-only-field): inline layout + prefix slot

### DIFF
--- a/src/components/ui/data/read-only-field/ReadOnlyField.stories.tsx
+++ b/src/components/ui/data/read-only-field/ReadOnlyField.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { ReadOnlyField } from "./ReadOnlyField";
 import { Badge } from "@/components/ui/feedback/badge/Badge";
+import { Icon } from "@/components/ui/media/icon/Icon";
 
 const meta: Meta<typeof ReadOnlyField> = {
   title: "UI/Data/ReadOnlyField",
@@ -12,6 +13,7 @@ const meta: Meta<typeof ReadOnlyField> = {
   argTypes: {
     mono: { control: "boolean" },
     copyable: { control: "boolean" },
+    layout: { control: "select", options: ["stacked", "inline"] },
   },
 };
 
@@ -42,5 +44,58 @@ export const Mono: Story = {
     label: "Module ID",
     value: "oauth-core-v2",
     mono: true,
+  },
+};
+
+/**
+ * `layout="inline"` puts the label on the left and the value on the right
+ * of the same row — useful for footer-style label/value pairs where
+ * vertical space matters.
+ */
+export const Inline: Story = {
+  args: {
+    label: "Published by",
+    value: "@i-am-nothing",
+    mono: true,
+    layout: "inline",
+  },
+};
+
+/**
+ * Inline + copyable + suffix all compose. The shared `valueRow` makes
+ * sure these work identically in both layouts.
+ */
+export const InlineWithCopy: Story = {
+  args: {
+    label: "API key",
+    value: "sk-live-1234567890abcdef",
+    mono: true,
+    copyable: true,
+    layout: "inline",
+  },
+};
+
+/**
+ * `prefix` is rendered before the value — useful for a leading icon or
+ * status dot.
+ */
+export const WithPrefix: Story = {
+  args: {
+    label: "Status",
+    value: "Connected",
+    prefix: <span className="size-2 rounded-full bg-success" />,
+  },
+};
+
+/**
+ * `prefix` also works in the inline layout.
+ */
+export const InlineWithPrefix: Story = {
+  args: {
+    label: "Region",
+    value: "us-east-1",
+    mono: true,
+    layout: "inline",
+    prefix: <Icon name="public" size={16} className="text-on-surface-variant" />,
   },
 };

--- a/src/components/ui/data/read-only-field/ReadOnlyField.test.tsx
+++ b/src/components/ui/data/read-only-field/ReadOnlyField.test.tsx
@@ -53,4 +53,43 @@ describe("ReadOnlyField", () => {
     );
     expect(container.firstChild).toHaveClass("mt-4");
   });
+
+  it("renders the prefix slot before the value", () => {
+    render(
+      <ReadOnlyField
+        label="Status"
+        value="Connected"
+        prefix={<span data-testid="dot">●</span>}
+      />,
+    );
+    expect(screen.getByTestId("dot")).toBeInTheDocument();
+  });
+
+  it("renders stacked layout by default (label above value)", () => {
+    const { container } = render(<ReadOnlyField label="Email" value="a@b.c" />);
+    // The outer element does not get the inline flex wrapper.
+    expect(container.firstChild).not.toHaveClass("flex");
+  });
+
+  it("renders inline layout when layout='inline' (label beside value)", () => {
+    const { container } = render(
+      <ReadOnlyField label="Email" value="a@b.c" layout="inline" />,
+    );
+    expect(container.firstChild).toHaveClass("flex");
+    expect(container.firstChild).toHaveClass("items-center");
+  });
+
+  it("supports copyable + prefix together in inline layout", () => {
+    render(
+      <ReadOnlyField
+        label="Key"
+        value="abc-123"
+        layout="inline"
+        copyable
+        prefix={<span data-testid="dot">●</span>}
+      />,
+    );
+    expect(screen.getByTestId("dot")).toBeInTheDocument();
+    expect(screen.getByLabelText("Copy Key")).toBeInTheDocument();
+  });
 });

--- a/src/components/ui/data/read-only-field/ReadOnlyField.tsx
+++ b/src/components/ui/data/read-only-field/ReadOnlyField.tsx
@@ -6,8 +6,10 @@ import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 export const meta: ComponentMeta = {
   name: "ReadOnlyField",
   description:
-    "Label/value pair display with optional copy-to-clipboard button and suffix slot",
+    "Label/value pair display with optional copy-to-clipboard button, prefix/suffix slots, and stacked or inline layout.",
 };
+
+export type ReadOnlyFieldLayout = "stacked" | "inline";
 
 export interface ReadOnlyFieldProps {
   label: string;
@@ -15,7 +17,12 @@ export interface ReadOnlyFieldProps {
   mono?: boolean;
   copyable?: boolean;
   onCopy?: () => void;
+  /** Slot rendered before the value (e.g. small icon). */
+  prefix?: ReactNode;
+  /** Slot rendered after the value (e.g. status badge). */
   suffix?: ReactNode;
+  /** "stacked" puts label above value (default). "inline" puts them on one row. */
+  layout?: ReadOnlyFieldLayout;
   className?: string;
 }
 
@@ -25,7 +32,9 @@ export function ReadOnlyField({
   mono = false,
   copyable = false,
   onCopy,
+  prefix,
   suffix,
+  layout = "stacked",
   className,
 }: ReadOnlyFieldProps) {
   const [copied, setCopied] = useState(false);
@@ -40,32 +49,51 @@ export function ReadOnlyField({
     }).catch(() => {});
   }, [value, onCopy]);
 
+  const valueRow = (
+    <div className="flex items-center gap-2 min-h-8 min-w-0">
+      {prefix}
+      <span
+        className={cn(
+          "text-sm truncate",
+          mono ? "font-mono text-on-surface-variant" : "text-on-surface",
+        )}
+      >
+        {value}
+      </span>
+      {copyable && (
+        <IconButton
+          icon={copied ? "check" : "content_copy"}
+          variant="text"
+          size="sm"
+          onClick={handleCopy}
+          aria-label={copied ? "Copied" : `Copy ${label}`}
+          className={cn(
+            "shrink-0",
+            copied ? "text-success" : "text-on-surface-variant",
+          )}
+        />
+      )}
+      {suffix}
+    </div>
+  );
+
+  if (layout === "inline") {
+    return (
+      <div className={cn("flex items-center gap-3", className)}>
+        <label className="text-sm font-medium text-on-surface shrink-0">
+          {label}
+        </label>
+        <div className="flex-1 min-w-0">{valueRow}</div>
+      </div>
+    );
+  }
+
   return (
     <div className={className}>
       <label className="block text-sm font-medium text-on-surface mb-1">
         {label}
       </label>
-      <div className="flex items-center gap-2 min-h-8">
-        <span
-          className={cn(
-            "text-sm truncate",
-            mono ? "font-mono text-on-surface-variant" : "text-on-surface",
-          )}
-        >
-          {value}
-        </span>
-        {copyable && (
-          <IconButton
-            icon={copied ? "check" : "content_copy"}
-            variant="text"
-            size="sm"
-            onClick={handleCopy}
-            aria-label={copied ? "Copied" : `Copy ${label}`}
-            className={cn("shrink-0", copied ? "text-success" : "text-on-surface-variant")}
-          />
-        )}
-        {suffix}
-      </div>
+      {valueRow}
     </div>
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,7 @@ export {
 export {
   ReadOnlyField,
   type ReadOnlyFieldProps,
+  type ReadOnlyFieldLayout,
 } from "./components/ui/data/read-only-field/ReadOnlyField";
 export {
   SettingRow,


### PR DESCRIPTION
## Summary

- New \`layout: \"stacked\" | \"inline\"\` prop. \`stacked\` is the existing default (label above value). \`inline\` puts label on the left, value on the right of the same row — useful for footer-style label/value pairs.
- New \`prefix?: ReactNode\` slot rendered before the value (mirrors the existing \`suffix\`). Useful for a leading icon / dot.
- \`valueRow\` is shared between both layouts so copyable / prefix / suffix all work identically.

## Why

Surfaces in the apps.mirrorstack.ai module-detail dialog needed an inline label/value pair (\"Published by @user\") without the vertical space of the stacked variant. Rather than add a one-off inline component, extend the existing one.

## Test plan

- [x] \`pnpm typecheck\` clean
- [ ] Visual: render with \`layout=\"inline\"\` and verify label sits left of value
- [ ] Verify \`copyable\` + \`prefix\` + \`suffix\` work in both layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)