### PR TITLE
feat(dialog): built-in close button + outline border

### DIFF
--- a/src/components/ui/surfaces/dialog/Dialog.stories.tsx
+++ b/src/components/ui/surfaces/dialog/Dialog.stories.tsx
@@ -76,3 +76,53 @@ export const NoTitle: Story = {
     actions: [{ label: "OK", onClick: () => {}, variant: "filled" }],
   },
 };
+
+/**
+ * The built-in X close button renders at the top-right whenever `onClose` is
+ * provided. It anchors to the outer wrapper, not the scrollable inner box, so
+ * it never gets clipped when the body overflows.
+ */
+export const WithCloseButton: Story = {
+  args: {
+    title: "Module detail",
+    onClose: () => {},
+    children: (
+      <p className="text-on-surface-variant text-sm">
+        The close affordance in the corner is provided by Dialog itself — no
+        extra JSX required at the call site. Pass <code className="font-mono">onClose</code> and it appears.
+      </p>
+    ),
+    actions: [
+      { label: "Close", onClick: () => {} },
+      { label: "Install", onClick: () => {}, variant: "filled" },
+    ],
+  },
+};
+
+/**
+ * Pass `hideCloseButton` to suppress the built-in X — useful for hard-confirm
+ * flows where Escape / backdrop dismissal is also disabled and the only valid
+ * exit is one of the action buttons.
+ */
+export const HideCloseButton: Story = {
+  args: {
+    title: "Confirm permanent deletion",
+    onClose: () => {},
+    hideCloseButton: true,
+    children: (
+      <p className="text-on-surface-variant text-sm">
+        With <code className="font-mono">hideCloseButton</code> the user must
+        choose one of the actions — no X in the corner.
+      </p>
+    ),
+    actions: [
+      { label: "Cancel", onClick: () => {} },
+      {
+        label: "Delete",
+        onClick: () => {},
+        variant: "filled",
+        color: "error",
+      },
+    ],
+  },
+};

--- a/src/components/ui/surfaces/dialog/Dialog.tsx
+++ b/src/components/ui/surfaces/dialog/Dialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useId, type ReactNode } from "react";
 import { cn } from "@/utils/cn";
 import type { ComponentMeta } from "@/types/component-meta";
 import { Button, type ButtonProps } from "@/components/ui/actions/button/Button";
+import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 
 export const meta: ComponentMeta = {
   name: "Dialog",
@@ -25,6 +26,9 @@ export interface DialogProps {
   children?: ReactNode;
   actions?: DialogAction[];
   className?: string;
+  /** Hide the built-in X close button in the top-right corner. The X is
+   *  rendered by default whenever `onClose` is provided. */
+  hideCloseButton?: boolean;
 }
 
 let scrollLockCount = 0;
@@ -48,6 +52,7 @@ export function Dialog({
   children,
   actions,
   className,
+  hideCloseButton = false,
 }: DialogProps) {
   const titleId = useId();
   const dialogRef = useRef<HTMLDivElement>(null);
@@ -128,43 +133,57 @@ export function Dialog({
       />
       <div className="!m-0 fixed inset-0 z-[60] flex items-center justify-center pointer-events-none">
         <div
-          ref={dialogRef}
-          tabIndex={-1}
           className={cn(
-            "bg-surface rounded-2xl p-6 max-w-sm w-full mx-4 shadow-xl outline-none pointer-events-auto max-h-[90vh] overflow-y-auto",
+            "relative pointer-events-auto max-w-sm w-full mx-4",
             className,
           )}
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby={title ? titleId : undefined}
         >
-          {title && (
-            <h3
-              id={titleId}
-              className="text-lg font-semibold text-on-surface mb-4"
-            >
-              {title}
-            </h3>
+          {onClose && !hideCloseButton && (
+            <IconButton
+              icon="close"
+              variant="filled"
+              size="sm"
+              className="absolute top-0 right-0 -translate-y-1/2 translate-x-1/2 z-10 shadow-md"
+              aria-label="Close"
+              onClick={onClose}
+            />
           )}
+          <div
+            ref={dialogRef}
+            tabIndex={-1}
+            className="bg-surface rounded-2xl border border-outline-variant p-6 shadow-xl outline-none max-h-[90vh] overflow-y-auto"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={title ? titleId : undefined}
+          >
+            {title && (
+              <h3
+                id={titleId}
+                className="text-lg font-semibold text-on-surface mb-4 pr-8"
+              >
+                {title}
+              </h3>
+            )}
 
-          {children}
+            {children}
 
-          {actions && actions.length > 0 && (
-            <div className="flex justify-end gap-3 mt-4">
-              {actions.map((action, i) => (
-                <Button
-                  key={`${i}-${action.label}`}
-                  variant={action.variant ?? "text"}
-                  color={action.color}
-                  onClick={action.onClick}
-                  loading={action.loading}
-                  disabled={action.disabled}
-                >
-                  {action.label}
-                </Button>
-              ))}
-            </div>
-          )}
+            {actions && actions.length > 0 && (
+              <div className="flex justify-end gap-3 mt-4">
+                {actions.map((action, i) => (
+                  <Button
+                    key={`${i}-${action.label}`}
+                    variant={action.variant ?? "text"}
+                    color={action.color}
+                    onClick={action.onClick}
+                    loading={action.loading}
+                    disabled={action.disabled}
+                  >
+                    {action.label}
+                  </Button>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </>


### PR DESCRIPTION
## Summary

- New built-in X close button rendered at the dialog's top-right whenever \`onClose\` is provided. Opt out with the new \`hideCloseButton: true\` prop.
- Position is anchored to the *outer* wrapper, not the scrollable inner box, so the X half-overflows the corner without being clipped by \`overflow-y-auto\`. Required splitting the single div into wrapper (positioning + width) and inner (visual + scroll).
- Dialog box now has \`border border-outline-variant\` so its edge is visible against the dimmed backdrop.
- Title gets \`pr-8\` so it never overlaps the X.

## Why

Every Dialog consumer was either bolting on an inline X via \`absolute -top-2 -right-2\` or relying solely on Escape / backdrop click to dismiss. Centralizing the X in the kit means future consumers get it for free with no extra JSX, and the wrapper/inner split fixes the long-standing \"X gets clipped\" problem.

## Test plan

- [x] \`pnpm typecheck\` clean
- [ ] Visual: confirm X renders at top-right and isn't clipped, with and without \`title\`
- [ ] \`hideCloseButton\` suppresses the X (useful for hard-confirm flows)
- [ ] Existing dialogs (ReauthDialog, TypeToConfirmDialog) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)