### PR TITLE
feat(agent-greeting): hideInput prop + logo position tweak

### DIFF
--- a/src/components/ui/agent/greeting/AgentGreeting.tsx
+++ b/src/components/ui/agent/greeting/AgentGreeting.tsx
@@ -185,7 +185,7 @@ export function AgentGreeting({
     >
       <div className="flex items-start gap-2">
         {!hideLogo && (
-          <div className="size-14 shrink-0 -mt-4">
+          <div className={cn("size-14 shrink-0", subtitle ? "-mt-2" : "-mt-4")}>
             <Logo />
           </div>
         )}

--- a/src/components/ui/agent/greeting/AgentGreeting.tsx
+++ b/src/components/ui/agent/greeting/AgentGreeting.tsx
@@ -43,6 +43,8 @@ export interface AgentGreetingProps {
   onSelectModel?: (modelId: string) => void;
   /** Hide the MirrorStack logo above the greeting. Defaults to false. */
   hideLogo?: boolean;
+  /** Hide the chat input row — render greeting + logo only. */
+  hideInput?: boolean;
   className?: string;
 }
 
@@ -77,6 +79,7 @@ export function AgentGreeting({
   selectedModelId,
   onSelectModel,
   hideLogo = false,
+  hideInput = false,
   className,
 }: AgentGreetingProps) {
   const [text, setText] = useState("");
@@ -180,9 +183,9 @@ export function AgentGreeting({
         className,
       )}
     >
-      <div className="flex items-center gap-2">
+      <div className="flex items-start gap-2">
         {!hideLogo && (
-          <div className="size-14 shrink-0">
+          <div className="size-14 shrink-0 -mt-2">
             <Logo />
           </div>
         )}
@@ -196,6 +199,7 @@ export function AgentGreeting({
         </div>
       </div>
 
+      {!hideInput && (
       <div className="flex w-full flex-col rounded-2xl border border-outline-variant bg-surface-container-low p-3 transition-colors focus-within:border-primary">
         <textarea
           ref={textareaRef}
@@ -330,6 +334,7 @@ export function AgentGreeting({
           />
         </div>
       </div>
+      )}
     </div>
   );
 }

--- a/src/components/ui/agent/greeting/AgentGreeting.tsx
+++ b/src/components/ui/agent/greeting/AgentGreeting.tsx
@@ -185,7 +185,7 @@ export function AgentGreeting({
     >
       <div className="flex items-start gap-2">
         {!hideLogo && (
-          <div className="size-14 shrink-0 -mt-2">
+          <div className="size-14 shrink-0 -mt-4">
             <Logo />
           </div>
         )}

--- a/src/components/ui/agent/greeting/AgentGreeting.tsx
+++ b/src/components/ui/agent/greeting/AgentGreeting.tsx
@@ -183,9 +183,9 @@ export function AgentGreeting({
         className,
       )}
     >
-      <div className="flex items-start gap-2">
+      <div className={cn("flex gap-2", subtitle ? "items-start" : "items-center")}>
         {!hideLogo && (
-          <div className="size-14 shrink-0 -mt-2">
+          <div className={cn("size-14 shrink-0", subtitle && "-mt-2")}>
             <Logo />
           </div>
         )}

--- a/src/components/ui/agent/greeting/AgentGreeting.tsx
+++ b/src/components/ui/agent/greeting/AgentGreeting.tsx
@@ -183,9 +183,9 @@ export function AgentGreeting({
         className,
       )}
     >
-      <div className={cn("flex gap-2", subtitle ? "items-start" : "items-center")}>
+      <div className="flex items-start gap-2">
         {!hideLogo && (
-          <div className={cn("size-14 shrink-0", subtitle && "-mt-2")}>
+          <div className="size-14 shrink-0 -mt-2">
             <Logo />
           </div>
         )}


### PR DESCRIPTION
## Summary

- New \`hideInput?: boolean\` prop. When true, AgentGreeting renders only the logo + greeting + subtitle — the textarea / send / model picker row is suppressed.
- Logo row uses \`items-start\` and \`-mt-2\` to nudge the logo slightly above the greeting baseline — more proportional with the subtitle beneath the heading.

## Why

apps.mirrorstack.ai's /apps/new flow collapses the greeting into a left-aligned header once the user switches to manual entry — they need the hero styling without the chat input rendered. \`hideInput\` lets the consumer suppress it without forking the component.

## Test plan

- [x] \`pnpm typecheck\` clean
- [ ] Visual: render with \`hideInput\` and confirm only logo + greeting + subtitle show
- [ ] Visual: confirm logo sits slightly above the greeting baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)