### PR TITLE
fix(agent-sidebar-header): flushSync notch tracking + equality bailout

### DIFF
--- a/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect, useCallback, useLayoutEffect } from "react";
+import { flushSync } from "react-dom";
 import { cn } from "@/utils/cn";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 import { Icon } from "@/components/ui/media/icon/Icon";
@@ -141,21 +142,28 @@ export function AgentSidebarHeader({
     const tab = activeTabRef.current;
     const header = headerRef.current;
     if (!tab || !header) { setActiveTabRect(null); return; }
-    const update = () => {
+    const measure = () => {
       const tRect = tab.getBoundingClientRect();
       const hRect = header.getBoundingClientRect();
-      setActiveTabRect({ left: tRect.left - hRect.left, width: tRect.width });
+      return { left: tRect.left - hRect.left, width: tRect.width };
     };
-    update();
-    // ResizeObserver keeps the notch shape locked to the active tab even
-    // during a live sidebar drag — sidebarWidth (prop) only updates on
-    // drag release, so without this the notch would lag behind the
-    // flex-shrunk tab DOM until the user let go.
+    setActiveTabRect(measure());
     if (typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(update);
+    // flushSync commits the notch position in the same frame the
+    // ResizeObserver fired — without it, RO → setState → render lags
+    // one frame behind the tab DOM during a live sidebar drag, which
+    // reads as a soft trailing curve on the notch.
+    const observer = new ResizeObserver(() => {
+      const next = measure();
+      flushSync(() =>
+        setActiveTabRect((prev) =>
+          prev && prev.left === next.left && prev.width === next.width ? prev : next,
+        ),
+      );
+    });
     observer.observe(tab);
     return () => observer.disconnect();
-  }, [activeTabId, visibleCount, sidebarWidth, tabs.length]);
+  }, [activeTabId, visibleCount, tabs.length]);
 
   useLayoutEffect(() => {
     if (!showOverflow || !ddContentRef.current) return;


### PR DESCRIPTION
## Summary

\`ResizeObserver\` fires after layout but before paint; \`setState\` from inside it commits one frame later, which reads as a soft trailing curve on the active-tab notch during a live sidebar drag. \`flushSync\` forces React to commit synchronously in the same frame the RO fired, so the notch SVG and the tab DOM update together.

- Wrap \`setActiveTabRect\` in \`flushSync\` inside the ResizeObserver callback so the commit happens before the next paint.
- **Equality bailout**: compare prev vs next rect and bail with \`prev\` when unchanged. Without this, every RO fire forces a sync render even when the tab's bounding box didn't move, defeating React's normal \`Object.is\` skip.
- Drop \`sidebarWidth\` from the effect deps: RO already fires on the tab's box change. The old prop dep was just triggering disconnect + reconnect on every drag release.

## Why

Follow-up to #209 (sidebar open animation) which surfaced the notch desync as soon as the open-animation matched the drag curve — the user could see the notch lag the tab during fast drags.

## Test plan

- [x] \`pnpm typecheck\` clean
- [ ] Visual: drag the sidebar wider/narrower and confirm the notch tracks the tab edge with no trailing curve
- [ ] Open / close the sidebar and confirm no flicker
- [ ] React DevTools: confirm setState is batched normally outside drag (equality bailout works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)