### PR TITLE
feat(notch-grid): salvage utilities for v2 (PR 1/7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.3.1
+
+### Internal
+
+- **notch-grid v2** — first salvage slice. Pure-lift utilities from the
+  closed v1 stack: `grid-outline.ts` (SVG outline tracer), `breakpoints.ts`
+  (responsive resolution), `BlockShape.tsx` (rounded-mask React adapter).
+  No public exports yet — these are wired up in a later slice when the
+  `<NotchGrid>` component lands. Design doc:
+  [`mirrorstack-docs/architecture/notch-grid-v2/`](https://github.com/mirrorstack-ai/mirrorstack-docs/tree/main/architecture/notch-grid-v2).
+
 ## 0.3.0
 
 ### Components

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/surfaces/notch-grid/BlockShape.test.tsx
+++ b/src/components/ui/surfaces/notch-grid/BlockShape.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { BlockShape, BLOCK_SIZE } from "./BlockShape";
+
+afterEach(cleanup);
+
+const SHAPE = [
+  [0, 1, 1, 1],
+  [1, 1, 1, 1],
+  [1, 1, 1, 0],
+];
+
+describe("BlockShape", () => {
+  it("sizes the wrapper to cols×rows blocks", () => {
+    const { container } = render(<BlockShape shape={SHAPE} block={50} />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.width).toBe(`${4 * 50}px`);
+    expect(root.style.height).toBe(`${3 * 50}px`);
+  });
+
+  it("defaults the block size to BLOCK_SIZE (96px)", () => {
+    const { container } = render(<BlockShape shape={[[1]]} />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.width).toBe(`${BLOCK_SIZE}px`);
+    expect(BLOCK_SIZE).toBe(96);
+  });
+
+  it("renders an SVG outline path", () => {
+    const { container } = render(<BlockShape shape={SHAPE} />);
+    const path = container.querySelector("svg path[fill]");
+    expect(path).not.toBeNull();
+    expect(path!.getAttribute("d")!.startsWith("M ")).toBe(true);
+    expect(path!.getAttribute("fill-rule")).toBe("evenodd");
+  });
+
+  it("grows the shape with the tier — a tier-2 cell is empty at tier 1", () => {
+    const tiered = [
+      [1, 2],
+      [1, 1],
+    ];
+    const { container: c1 } = render(<BlockShape shape={tiered} tier={1} block={40} />);
+    const { container: c2 } = render(<BlockShape shape={tiered} tier={2} block={40} />);
+    const d1 = c1.querySelector("svg path[fill]")!.getAttribute("d")!;
+    const d2 = c2.querySelector("svg path[fill]")!.getAttribute("d")!;
+    // tier 1 = an L-shape (6 corners); tier 2 = a full 2×2 square (4 corners).
+    expect((d1.match(/ A /g) ?? []).length).toBe(6);
+    expect((d2.match(/ A /g) ?? []).length).toBe(4);
+  });
+
+  it("renders content on top of the shape", () => {
+    const { getByText } = render(
+      <BlockShape shape={[[1]]}>
+        <span>hello</span>
+      </BlockShape>,
+    );
+    expect(getByText("hello")).toBeInTheDocument();
+  });
+
+  it("clips the content layer to the outline by default; noClip removes it", () => {
+    const { container, rerender } = render(<BlockShape shape={[[1]]}>x</BlockShape>);
+    const content = () =>
+      (container.firstElementChild as HTMLElement).lastElementChild as HTMLElement;
+    expect(content().style.clipPath).toMatch(/^url\(#block-shape-clip-/);
+    rerender(
+      <BlockShape shape={[[1]]} noClip>
+        x
+      </BlockShape>,
+    );
+    expect(content().style.clipPath).toBe("");
+  });
+});

--- a/src/components/ui/surfaces/notch-grid/BlockShape.tsx
+++ b/src/components/ui/surfaces/notch-grid/BlockShape.tsx
@@ -1,0 +1,130 @@
+import { useId, useMemo, type CSSProperties, type ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
+import type { ComponentMeta } from "@/types/component-meta";
+import {
+  gridOutlinePath,
+  maskCols,
+  maskFromShape,
+} from "@/utils/grid-outline";
+
+export const meta: ComponentMeta = {
+  name: "BlockShape",
+  description:
+    "A notched surface whose outline follows a grid of 96px blocks, with content layered on top",
+};
+
+/** Default block edge in px — matches Tailwind's `w-24` / `h-24` (6rem). */
+export const BLOCK_SIZE = 96;
+
+export interface BlockShapeProps {
+  /**
+   * Footprint matrix. Cell values:
+   *  - `0`  — always empty (a notch / hole)
+   *  - `1`  — part of the shape at every size tier
+   *  - `2+` — joins the shape only once that tier is reached (responsive growth)
+   *
+   * e.g. `[[0,1,1,1],[1,1,1,1],[1,1,1,0]]` — a base shape with two corners cut.
+   */
+  shape: ReadonlyArray<ReadonlyArray<number>>;
+  /** Active size tier (>= 1). Cells whose value exceeds `tier` render as empty. */
+  tier?: number;
+  /** Block edge length in px. Default {@link BLOCK_SIZE}. */
+  block?: number;
+  /** Erode the outline by `gap / 2` px (outer edges in, notch holes out) so
+   *  neighbours / nested items leave a `gap`-px space. Footprint size is
+   *  unchanged. Normally set by the parent `NotchGrid`; default 0. */
+  gap?: number;
+  /** Convex corner radius (px). Default 24. */
+  radius?: number;
+  /** Concave / notch corner radius (px). Default 32. */
+  inverseRadius?: number;
+  /** Outline fill — a CSS color, or `"none"` to disable. */
+  fill?: string;
+  /** Outline stroke — a CSS color, or `"none"` to disable. */
+  stroke?: string;
+  strokeWidth?: number;
+  /** Content rendered on top of the shape (clipped to the shape's outline). */
+  children?: ReactNode;
+  /** Padding (px) on the content layer. Default 16. */
+  pad?: number;
+  /** Skip clipping the content layer to the outline. */
+  noClip?: boolean;
+  className?: string;
+  style?: CSSProperties;
+}
+
+export function BlockShape({
+  shape,
+  tier = 1,
+  block = BLOCK_SIZE,
+  gap = 0,
+  radius = 24,
+  inverseRadius = 32,
+  fill = "var(--color-surface-container-low)",
+  stroke = "var(--color-outline-variant)",
+  strokeWidth = 1,
+  children,
+  pad = 16,
+  noClip = false,
+  className,
+  style,
+}: BlockShapeProps) {
+  const reactId = useId();
+  const clipId = `block-shape-clip-${reactId.replace(/[^a-zA-Z0-9_-]/g, "")}`;
+
+  const rows = shape.length;
+  const cols = maskCols(shape);
+  if (isDev && (rows === 0 || cols === 0)) {
+    console.warn("[BlockShape] empty shape matrix — nothing to render");
+  }
+
+  const mask = useMemo(() => maskFromShape(shape, tier), [shape, tier]);
+  const w = cols * block;
+  const h = rows * block;
+  const pathD = useMemo(
+    () => gridOutlinePath(mask, { cell: block, gap, radius, inverseRadius }),
+    [mask, block, gap, radius, inverseRadius],
+  );
+  const inset = strokeWidth / 2;
+
+  return (
+    <div
+      className={cn("relative", className)}
+      style={{ width: w, height: h, ...style }}
+    >
+      <svg
+        width={w}
+        height={h}
+        viewBox={`${-inset} ${-inset} ${w + strokeWidth} ${h + strokeWidth}`}
+        className="pointer-events-none absolute inset-0"
+        aria-hidden="true"
+      >
+        {!noClip && (
+          <defs>
+            <clipPath id={clipId} clipPathUnits="userSpaceOnUse">
+              <path d={pathD} />
+            </clipPath>
+          </defs>
+        )}
+        <path
+          d={pathD}
+          fill={fill}
+          stroke={stroke}
+          strokeWidth={strokeWidth}
+          vectorEffect="non-scaling-stroke"
+          fillRule="evenodd"
+        />
+      </svg>
+      <div
+        className={cn("absolute inset-0", !noClip && "overflow-hidden")}
+        style={{
+          padding: pad,
+          clipPath: noClip ? undefined : `url(#${clipId})`,
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/surfaces/notch-grid/breakpoints.test.ts
+++ b/src/components/ui/surfaces/notch-grid/breakpoints.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  NOTCH_BREAKPOINTS,
+  rectMatrix,
+  resolveResponsive,
+  resolveShapeMatrix,
+} from "./breakpoints";
+
+describe("resolveResponsive", () => {
+  it("returns a non-map value unchanged (incl. arrays / matrices)", () => {
+    expect(resolveResponsive(5, 800)).toBe(5);
+    const matrix = [[1, 1], [1, 0]];
+    expect(resolveResponsive(matrix, 800)).toBe(matrix);
+  });
+
+  it("picks the largest named breakpoint <= width (mobile-first cascade)", () => {
+    const v = { base: "b", md: "m", lg: "l" };
+    expect(resolveResponsive(v, 0)).toBe("b");
+    expect(resolveResponsive(v, 700)).toBe("b"); // < md (768)
+    expect(resolveResponsive(v, 768)).toBe("m"); // == md
+    expect(resolveResponsive(v, 900)).toBe("m"); // md <= 900 < lg
+    expect(resolveResponsive(v, 1200)).toBe("l");
+  });
+
+  it("accepts raw px thresholds as keys", () => {
+    const v = { 0: "s", 500: "m", 900: "l" };
+    expect(resolveResponsive(v, 100)).toBe("s");
+    expect(resolveResponsive(v, 500)).toBe("m");
+    expect(resolveResponsive(v, 1000)).toBe("l");
+  });
+
+  it("mixes named and px keys, sorting by resolved threshold", () => {
+    const v = { base: "s", 500: "m", lg: "l" }; // 0, 500, 1024
+    expect(resolveResponsive(v, 400)).toBe("s");
+    expect(resolveResponsive(v, 600)).toBe("m");
+    expect(resolveResponsive(v, 1100)).toBe("l");
+  });
+
+  it("falls back to the smallest threshold when width is below all of them", () => {
+    expect(resolveResponsive({ md: "m", lg: "l" }, 0)).toBe("m");
+  });
+
+  it("honours overridden breakpoints", () => {
+    const v = { base: "s", md: "m" };
+    // Move md down to 600 — now 650 resolves to m instead of s.
+    expect(resolveResponsive(v, 650, { ...NOTCH_BREAKPOINTS, md: 600 })).toBe("m");
+    expect(resolveResponsive(v, 650)).toBe("s");
+  });
+
+  it("treats an unknown breakpoint name as base (0)", () => {
+    expect(resolveResponsive({ weird: "w", lg: "l" }, 10)).toBe("w");
+  });
+});
+
+describe("rectMatrix", () => {
+  it("builds a solid cols×rows matrix of 1s", () => {
+    expect(rectMatrix(2, 3)).toEqual([
+      [1, 1],
+      [1, 1],
+      [1, 1],
+    ]);
+  });
+  it("clamps to at least 1×1", () => {
+    expect(rectMatrix(0, 0)).toEqual([[1]]);
+  });
+});
+
+describe("resolveShapeMatrix", () => {
+  it("passes a bare matrix through", () => {
+    const m = [[1, 0], [1, 1]];
+    expect(resolveShapeMatrix(m, { width: 800, columns: 4 })).toBe(m);
+  });
+
+  it("cascades a breakpoint map by width", () => {
+    const shape = { base: [[1]], md: [[1, 1], [1, 1]] };
+    expect(resolveShapeMatrix(shape, { width: 400, columns: 4 })).toEqual([[1]]);
+    expect(resolveShapeMatrix(shape, { width: 900, columns: 4 })).toEqual([
+      [1, 1],
+      [1, 1],
+    ]);
+  });
+
+  it("picks the largest size-candidate whose width fits the column count", () => {
+    const shape = { sizes: [[1, 1], [2, 2], [3, 2]] as const };
+    expect(resolveShapeMatrix(shape, { width: 0, columns: 1 })).toEqual([[1]]);
+    expect(resolveShapeMatrix(shape, { width: 0, columns: 2 })).toEqual([
+      [1, 1],
+      [1, 1],
+    ]);
+    // columns=4 ⇒ the 3×2 candidate fits and is the largest.
+    expect(resolveShapeMatrix(shape, { width: 0, columns: 4 })).toEqual([
+      [1, 1, 1],
+      [1, 1, 1],
+    ]);
+  });
+
+  it("falls back to the smallest size-candidate when none fit", () => {
+    const shape = { sizes: [[3, 1], [4, 1]] as const };
+    expect(resolveShapeMatrix(shape, { width: 0, columns: 1 })).toEqual([[1, 1, 1]]);
+  });
+
+  it("picks the first `prefer` matrix that fits the column count", () => {
+    const big = [[1, 1, 1], [1, 1, 0]];
+    const mid = [[1, 1], [1, 1]];
+    const small = [[1]];
+    const shape = { prefer: [big, mid, small] };
+    expect(resolveShapeMatrix(shape, { width: 0, columns: 4 })).toBe(big);
+    expect(resolveShapeMatrix(shape, { width: 0, columns: 2 })).toBe(mid);
+    expect(resolveShapeMatrix(shape, { width: 0, columns: 1 })).toBe(small);
+  });
+
+  it("falls back to the narrowest `prefer` matrix when none fit", () => {
+    const wide = [[1, 1, 1]];
+    const narrower = [[1, 1]];
+    expect(resolveShapeMatrix({ prefer: [wide, narrower] }, { width: 0, columns: 1 })).toBe(narrower);
+  });
+
+  it("returns a 1×1 for an empty `prefer` list", () => {
+    expect(resolveShapeMatrix({ prefer: [] }, { width: 0, columns: 4 })).toEqual([[1]]);
+  });
+});

--- a/src/components/ui/surfaces/notch-grid/breakpoints.ts
+++ b/src/components/ui/surfaces/notch-grid/breakpoints.ts
@@ -1,0 +1,123 @@
+// Tailwind-style responsive resolution for the notch grid.
+//
+// A "responsive" value can be a single value, or a map keyed by breakpoint name
+// (`base`, `sm`, `md`, …) or a raw min-width in px (`0`, `560`, `900`, …). At a
+// given container width, the entry with the largest threshold `<= width` wins —
+// exactly the mobile-first cascade Tailwind uses.
+
+import { maskCols } from "@/utils/grid-outline";
+
+/** Default breakpoint thresholds (min container width, px). Mirrors Tailwind.
+ *  Override per-grid via `<NotchGrid breakpoints={…}>`. */
+export const NOTCH_BREAKPOINTS = {
+  base: 0,
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  "2xl": 1536,
+} as const;
+
+export type NotchBreakpointName = keyof typeof NOTCH_BREAKPOINTS;
+
+/** Breakpoint name → min container width (px). */
+export type NotchBreakpoints = Record<string, number>;
+
+/** A value that may vary by breakpoint. Map keys are breakpoint names or raw
+ *  px thresholds (as numbers or numeric strings). `base` / `0` = no minimum. */
+export type Responsive<T> = T | { [key: string]: T };
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v != null && typeof v === "object" && !Array.isArray(v);
+}
+
+function thresholdPx(key: string, breakpoints: NotchBreakpoints): number {
+  if (key in breakpoints) return breakpoints[key];
+  const n = Number(key);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * Resolve a {@link Responsive} value for `width`. Returns `value` itself when it
+ * is not a breakpoint map. For a map, picks the entry whose threshold is the
+ * largest one `<= width`, falling back to the entry with the smallest threshold.
+ */
+export function resolveResponsive<T>(
+  value: Responsive<T>,
+  width: number,
+  breakpoints: NotchBreakpoints = NOTCH_BREAKPOINTS,
+): T {
+  if (!isPlainObject(value)) return value as T;
+  const entries = Object.entries(value)
+    .map(([key, val]) => [thresholdPx(key, breakpoints), val] as const)
+    .sort((a, b) => a[0] - b[0]);
+  if (entries.length === 0) return value as unknown as T; // degenerate empty map
+  let chosen = entries[0][1];
+  for (const [px, val] of entries) {
+    if (width >= px) chosen = val;
+    else break;
+  }
+  return chosen;
+}
+
+// --- Shape resolution -------------------------------------------------------
+
+/** A shape's block footprint matrix. `0` = empty/notch, `1` = filled, `2+` =
+ *  tier-encoded (joins via `tier`). */
+export type ShapeMatrix = number[][];
+
+/** Candidate `[cols, rows]` block costs — the grid picks the largest whose
+ *  `cols` still fits the available column count, so the component grows when
+ *  there's room. e.g. `{ sizes: [[1, 1], [2, 2]] }`. Order doesn't matter. */
+export type ShapeSizes = { readonly sizes: ReadonlyArray<readonly number[]> };
+
+/** Candidate footprint matrices in **priority order** (most-preferred first) —
+ *  the grid uses the first one whose width fits the column count, falling back
+ *  to the narrowest. e.g. `{ prefer: [[[1,1,1],[1,1,0]], [[1,1],[1,1]], [[1]]] }`. */
+export type ShapePreferences = { readonly prefer: ReadonlyArray<ShapeMatrix> };
+
+/** Every form a {@link NotchGridItem} `shape` can take. */
+export type NotchShape = Responsive<ShapeMatrix> | ShapeSizes | ShapePreferences;
+
+export function isShapeSizes(v: NotchShape): v is ShapeSizes {
+  return isPlainObject(v) && Array.isArray((v as ShapeSizes).sizes);
+}
+
+export function isShapePreferences(v: NotchShape): v is ShapePreferences {
+  return isPlainObject(v) && Array.isArray((v as ShapePreferences).prefer);
+}
+
+/** Solid `cols × rows` matrix (all `1`s). */
+export function rectMatrix(cols: number, rows: number): ShapeMatrix {
+  const c = Math.max(1, Math.floor(cols));
+  const r = Math.max(1, Math.floor(rows));
+  return Array.from({ length: r }, () => Array<number>(c).fill(1));
+}
+
+/**
+ * Collapse any {@link NotchShape} to a plain matrix for the current container
+ * `width` and column `columns` count:
+ *  - `{ prefer: [m0, m1, …] }` — the first matrix that fits `columns`, else the narrowest;
+ *  - `{ sizes: [[c,r], …] }` — the biggest `[cols,rows]` that fits `columns`, else the smallest;
+ *  - `{ base: …, md: … }` — the Tailwind-style cascade against `width`;
+ *  - a bare matrix — passes through.
+ */
+export function resolveShapeMatrix(
+  shape: NotchShape,
+  ctx: { width: number; columns: number; breakpoints?: NotchBreakpoints },
+): ShapeMatrix {
+  if (isShapePreferences(shape)) {
+    const cands = shape.prefer.filter((m) => m.length > 0 && maskCols(m) > 0);
+    if (cands.length === 0) return [[1]];
+    const fits = cands.find((m) => maskCols(m) <= ctx.columns);
+    return fits ?? cands.reduce((best, m) => (maskCols(m) < maskCols(best) ? m : best));
+  }
+  if (isShapeSizes(shape)) {
+    const dims = shape.sizes.map((s) => [s[0] ?? 1, s[1] ?? s[0] ?? 1] as const);
+    const sorted = [...dims].sort((a, b) => a[0] - b[0]);
+    let chosen = sorted[0] ?? ([1, 1] as const);
+    for (const size of sorted) if (size[0] <= ctx.columns) chosen = size;
+    return rectMatrix(chosen[0], chosen[1]);
+  }
+  return resolveResponsive(shape, ctx.width, ctx.breakpoints);
+}

--- a/src/utils/grid-outline.test.ts
+++ b/src/utils/grid-outline.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+  gridOutlinePath,
+  maskCols,
+  maskFromShape,
+  maxTier,
+} from "./grid-outline";
+
+/** Count subpaths (each closed loop emits exactly one `M ... Z`). */
+const loopCount = (d: string) => (d.match(/Z/g) ?? []).length;
+/** Count distinct corner anchors: every corner emits an `A` arc (radius > 0). */
+const arcCount = (d: string) => (d.match(/ A /g) ?? []).length;
+
+describe("maskCols", () => {
+  it("returns the widest row length", () => {
+    expect(maskCols([[1, 1], [1, 1, 1], [1]])).toBe(3);
+    expect(maskCols([])).toBe(0);
+  });
+});
+
+describe("maskFromShape", () => {
+  it("fills cells with value between 1 and tier inclusive", () => {
+    const shape = [
+      [0, 1, 2],
+      [1, 2, 3],
+    ];
+    expect(maskFromShape(shape, 1)).toEqual([
+      [false, true, false],
+      [true, false, false],
+    ]);
+    expect(maskFromShape(shape, 2)).toEqual([
+      [false, true, true],
+      [true, true, false],
+    ]);
+    expect(maskFromShape(shape, 3)).toEqual([
+      [false, true, true],
+      [true, true, true],
+    ]);
+  });
+});
+
+describe("maxTier", () => {
+  it("is 1 for a plain 0/1 matrix", () => {
+    expect(maxTier([[0, 1], [1, 1]])).toBe(1);
+  });
+  it("returns the highest tier referenced", () => {
+    expect(maxTier([[1, 2], [3, 0]])).toBe(3);
+  });
+});
+
+describe("gridOutlinePath", () => {
+  it("returns empty string for an empty mask", () => {
+    expect(gridOutlinePath([], { cell: 10 })).toBe("");
+    expect(gridOutlinePath([[false]], { cell: 10 })).toBe("");
+  });
+
+  it("traces a single block as one closed loop with 4 rounded corners", () => {
+    const d = gridOutlinePath([[true]], { cell: 100 });
+    expect(d.startsWith("M ")).toBe(true);
+    expect(d.trim().endsWith("Z")).toBe(true);
+    expect(loopCount(d)).toBe(1);
+    expect(arcCount(d)).toBe(4);
+  });
+
+  it("merges collinear cells — a 1x3 row still has only 4 corners", () => {
+    expect(arcCount(gridOutlinePath([[true, true, true]], { cell: 50 }))).toBe(4);
+  });
+
+  it("an L-shape has 6 corners (5 convex + 1 concave)", () => {
+    const d = gridOutlinePath(
+      [
+        [true, false],
+        [true, true],
+      ],
+      { cell: 40 },
+    );
+    expect(loopCount(d)).toBe(1);
+    expect(arcCount(d)).toBe(6);
+  });
+
+  it("the user's example shape has 8 corners (one notch on each cut corner)", () => {
+    const d = gridOutlinePath(
+      maskFromShape(
+        [
+          [0, 1, 1, 1],
+          [1, 1, 1, 1],
+          [1, 1, 1, 0],
+        ],
+        1,
+      ),
+      { cell: 30 },
+    );
+    expect(loopCount(d)).toBe(1);
+    // 6 convex corners of the staircase rectangle outline + 2 concave notch
+    // corners (one per cut block) = 8.
+    expect(arcCount(d)).toBe(8);
+  });
+
+  it("a donut traces two loops (outer ring + interior hole)", () => {
+    const d = gridOutlinePath(
+      [
+        [true, true, true],
+        [true, false, true],
+        [true, true, true],
+      ],
+      { cell: 20 },
+    );
+    expect(loopCount(d)).toBe(2);
+    // outer square (4) + inner square (4) = 8
+    expect(arcCount(d)).toBe(8);
+  });
+
+  it("clamps corner radii so adjacent corners on a short edge don't overlap", () => {
+    // A single 10px block with radius 12: each of the 4 corners would want
+    // 12px but the edge is only 10px, so radius clamps to 5.
+    const d = gridOutlinePath([[true]], { cell: 10, radius: 12 });
+    expect(d).toContain("A 5 5 ");
+  });
+
+  it("erodes the shape by gap/2 — outer edges pull inward", () => {
+    // 200×100 rect, gap 20 ⇒ eroded by 10 ⇒ corners at (10,10)…(190,90).
+    const d = gridOutlinePath([[true, true]], { cell: 100, gap: 20, radius: 10 });
+    expect(arcCount(d)).toBe(4); // still a rectangle
+    expect(d).toMatch(/\b190\b/);
+    expect(d).toMatch(/\b90\b/);
+    expect(d).not.toMatch(/\b200\b/); // the un-eroded edge is gone
+  });
+
+  it("clamps gap below `cell` so the shape can't collapse", () => {
+    // gap 1000 with cell 100 ⇒ erosion clamps to (100−2)/2 = 49, leaving a sliver.
+    const d = gridOutlinePath([[true]], { cell: 100, gap: 1000 });
+    expect(d).not.toBe("");
+    expect(arcCount(d)).toBe(4);
+  });
+
+  it("respects a notch on a shape edge as a concave (sweep 0) corner", () => {
+    const d = gridOutlinePath(
+      [
+        [true, true, true],
+        [true, false, true],
+        [true, true, true],
+      ],
+      { cell: 30 },
+    );
+    // interior hole corners are concave from the filled region's perspective
+    expect(d).toMatch(/A \d+(\.\d+)? \d+(\.\d+)? 0 0 0 /); // at least one sweep-0 arc
+    expect(d).toMatch(/A \d+(\.\d+)? \d+(\.\d+)? 0 0 1 /); // and at least one sweep-1 arc
+  });
+});

--- a/src/utils/grid-outline.ts
+++ b/src/utils/grid-outline.ts
@@ -1,0 +1,255 @@
+// Turns a boolean block-grid into a rounded SVG outline path.
+//
+// A "notched surface" is a grid of square blocks. A `true` cell is part of the
+// shape; a `false` cell is a hole / notch cut-out. This walks the rectilinear
+// boundary of the `true` region(s) and emits an SVG path `d` string with
+// rounded corners — convex corners use `radius`, concave (notch) corners use
+// `inverseRadius` — mirroring the look of the rectangle-with-one-notch `Notch`
+// component but for an arbitrary shape.
+//
+// A `gap` *erodes* the shape by `gap / 2` on every boundary: the outer edges
+// pull inward (so neighbouring items leave a gap between them) and notch holes
+// grow outward by the same amount (so an item nestled into a notch keeps that
+// gap). One uniform offset everywhere ⇒ a consistent visual gap regardless of
+// where the boundary is.
+//
+// Limitations: regions must be edge-connected. Two blocks touching only at a
+// corner (e.g. `[[1,0],[0,1]]`) is ambiguous and not supported — interior
+// holes and edge notches are. Render the result with `fillRule="evenodd"` so
+// interior holes carve out correctly.
+
+export interface GridOutlineOptions {
+  /** Pixels per grid cell. */
+  cell: number;
+  /** Convex corner radius (px). Default 24. */
+  radius?: number;
+  /** Concave / notch corner radius (px). Default 32 — rounder than the outer
+   *  corners so notch curves read openly. */
+  inverseRadius?: number;
+  /** Erode the whole boundary by `gap / 2` px, opening a `gap`-px space between
+   *  this shape and anything flush against it (incl. items in its notches).
+   *  Clamped below `cell` so the shape can't collapse. Default 0. */
+  gap?: number;
+}
+
+type Pt = readonly [number, number];
+
+const ptKey = (x: number, y: number) => `${x},${y}`;
+
+/** Largest column count across all rows of a matrix. */
+export function maskCols(matrix: readonly { readonly length: number }[]): number {
+  let cols = 0;
+  for (const row of matrix) cols = Math.max(cols, row.length);
+  return cols;
+}
+
+/** Build a `boolean[][]` from a tiered shape matrix: a cell is filled at `tier`
+ *  iff `1 <= value <= tier`. Higher values appear only as more space unlocks. */
+export function maskFromShape(
+  shape: readonly (readonly number[])[],
+  tier: number,
+): boolean[][] {
+  return shape.map((row) => row.map((v) => v >= 1 && v <= tier));
+}
+
+/** Max tier referenced by a shape matrix (so callers know how many breakpoints
+ *  it defines). Returns 1 for a plain 0/1 matrix. */
+export function maxTier(shape: readonly (readonly number[])[]): number {
+  let m = 1;
+  for (const row of shape) for (const v of row) if (v > m) m = v;
+  return m;
+}
+
+export function gridOutlinePath(
+  mask: readonly (readonly boolean[])[],
+  { cell, radius = 24, inverseRadius = 32, gap = 0 }: GridOutlineOptions,
+): string {
+  const rows = mask.length;
+  const filled = (r: number, c: number): boolean =>
+    r >= 0 && r < rows && c >= 0 && c < mask[r].length && !!mask[r][c];
+  // Keep at least a sliver of shape even when gap is set absurdly high.
+  const erosion = Math.max(0, Math.min(gap, cell - 2)) / 2;
+
+  // Directed boundary edges, oriented so the filled cell sits on the *right*
+  // of travel — every cell contributes its 4 boundary edges clockwise in
+  // y-down screen coords. Keyed by edge-start, with a *list* of out-points
+  // so a single junction (two diagonally-touching cells meeting at a corner)
+  // doesn't have one cell's edge silently overwrite the other's. The walker
+  // then naturally turns *into* the other cell's edge at the junction, so the
+  // two regions read as one shape with two concave inverse-radius arcs facing
+  // each other at the shared corner — the same path style `<Notch>` uses for
+  // its body↔tab transition.
+  const edges = new Map<string, Pt[]>();
+  const pushEdge = (from: Pt, to: Pt) => {
+    const k = ptKey(from[0], from[1]);
+    const list = edges.get(k);
+    if (list) list.push(to);
+    else edges.set(k, [to]);
+  };
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < mask[r].length; c++) {
+      if (!mask[r][c]) continue;
+      const tl: Pt = [c, r];
+      const tr: Pt = [c + 1, r];
+      const br: Pt = [c + 1, r + 1];
+      const bl: Pt = [c, r + 1];
+      if (!filled(r - 1, c)) pushEdge(tl, tr); // top
+      if (!filled(r, c + 1)) pushEdge(tr, br); // right
+      if (!filled(r + 1, c)) pushEdge(br, bl); // bottom
+      if (!filled(r, c - 1)) pushEdge(bl, tl); // left
+    }
+  }
+
+  // Walk each loop. At a junction (multiple out-edges share a start point) we
+  // pick the *most-CCW* turn from the incoming direction — i.e. we turn *into*
+  // the other cell's boundary. That keeps the merged loop closed with two
+  // concave corners at the shared point (the "double-back" the renderer wants),
+  // instead of arbitrarily picking one cell's edge and orphaning the other.
+  const visitedEdges = new Set<string>();
+  const subpaths: string[] = [];
+  const edgeKey = (from: string, to: Pt) => `${from}>${to[0]},${to[1]}`;
+  for (const [startKey, outs] of edges) {
+    const [sx0, sy0] = startKey.split(",").map(Number);
+    for (const startTo of outs) {
+      if (visitedEdges.has(edgeKey(startKey, startTo))) continue;
+      const loop: Pt[] = [];
+      let cur: Pt = [sx0, sy0];
+      let curKey = startKey;
+      let to: Pt | null = startTo;
+      let inDir: [number, number] = [0, 0];
+      while (to) {
+        const k = edgeKey(curKey, to);
+        if (visitedEdges.has(k)) break;
+        visitedEdges.add(k);
+        loop.push(cur);
+        inDir = [to[0] - cur[0], to[1] - cur[1]];
+        cur = to;
+        curKey = ptKey(to[0], to[1]);
+        // Pick the most-CCW unvisited out-edge from `cur`. y-down: cross > 0
+        // is CW, cross < 0 is CCW; we want the smallest (most-negative) cross.
+        const candidates = edges.get(curKey) ?? [];
+        let best: Pt | null = null;
+        let bestCross = Number.POSITIVE_INFINITY;
+        for (const cand of candidates) {
+          if (visitedEdges.has(edgeKey(curKey, cand))) continue;
+          const odx = cand[0] - cur[0];
+          const ody = cand[1] - cur[1];
+          const cross = inDir[0] * ody - inDir[1] * odx;
+          if (cross < bestCross) {
+            bestCross = cross;
+            best = cand;
+          }
+        }
+        to = best;
+      }
+      const corners = collinearStripped(loop).map(
+        ([x, y]) => [x * cell, y * cell] as Pt,
+      );
+      if (corners.length >= 3) {
+        const offset = erosion > 0 ? erodeRectilinear(corners, erosion) : corners;
+        subpaths.push(roundedRectilinearPath(offset, radius, inverseRadius));
+      }
+    }
+  }
+  return subpaths.join(" ");
+}
+
+function collinearStripped(loop: readonly Pt[]): Pt[] {
+  const n = loop.length;
+  const out: Pt[] = [];
+  for (let i = 0; i < n; i++) {
+    const prev = loop[(i - 1 + n) % n];
+    const p = loop[i];
+    const next = loop[(i + 1) % n];
+    const d1x = p[0] - prev[0];
+    const d1y = p[1] - prev[1];
+    const d2x = next[0] - p[0];
+    const d2y = next[1] - p[1];
+    if (d1x * d2y - d1y * d2x !== 0) out.push(p); // cross != 0 ⇒ a corner
+  }
+  return out;
+}
+
+/**
+ * Offset a closed rectilinear polygon (corners alternating H/V edges, built
+ * clockwise with the filled region on the right of each directed edge) inward
+ * by `e` px: every edge's supporting line shifts toward the filled side, then
+ * corners are recomputed as the intersection of the two adjacent shifted lines.
+ * Convex corners move inward; concave (notch) corners move outward — exactly
+ * the "shrink the shape, grow the notches" behaviour we want for gaps.
+ */
+function erodeRectilinear(corners: readonly Pt[], e: number): Pt[] {
+  const n = corners.length;
+  // Per edge i (corners[i] → corners[i+1]): which axis it's fixed in, and the
+  // shifted value of that fixed coordinate. Inward normal of a clockwise edge
+  // in y-down screen space is (−dy, dx) with dx,dy ∈ {−1,0,1}.
+  const shifted = corners.map((p, i) => {
+    const q = corners[(i + 1) % n];
+    const dx = Math.sign(q[0] - p[0]);
+    const dy = Math.sign(q[1] - p[1]);
+    const horizontal = dy === 0; // dx === 0 ⇒ vertical
+    return horizontal
+      ? { axis: "y" as const, value: p[1] + dx * e } // inward.y = dx
+      : { axis: "x" as const, value: p[0] + -dy * e }; // inward.x = -dy
+  });
+  const out: Pt[] = [];
+  for (let i = 0; i < n; i++) {
+    const incoming = shifted[(i - 1 + n) % n];
+    const outgoing = shifted[i];
+    // The two edges meeting at corner i are perpendicular: one fixes x, the
+    // other y. Take each coordinate from whichever edge fixes it.
+    const x = incoming.axis === "x" ? incoming.value : outgoing.value;
+    const y = incoming.axis === "y" ? incoming.value : outgoing.value;
+    out.push([x, y]);
+  }
+  return out;
+}
+
+function roundedRectilinearPath(
+  px: readonly Pt[],
+  radius: number,
+  inverseRadius: number,
+): string {
+  const n = px.length;
+  const parts: string[] = [];
+  for (let i = 0; i < n; i++) {
+    const a = px[(i - 1 + n) % n];
+    const v = px[i];
+    const b = px[(i + 1) % n];
+    const inLen = dist(a, v);
+    const outLen = dist(v, b);
+    const inDir = unit(a, v);
+    const outDir = unit(v, b);
+    // y-down: cross > 0 is a clockwise turn ⇒ convex corner of the filled
+    // region; cross < 0 is a notch (concave) corner.
+    const cross = inDir[0] * outDir[1] - inDir[1] * outDir[0];
+    const convex = cross > 0;
+    const rho = Math.min(convex ? radius : inverseRadius, inLen / 2, outLen / 2);
+    const p1 = [v[0] - inDir[0] * rho, v[1] - inDir[1] * rho] as const;
+    const p2 = [v[0] + outDir[0] * rho, v[1] + outDir[1] * rho] as const;
+    parts.push(`${i === 0 ? "M" : "L"} ${fmt(p1)}`);
+    if (rho > 0) parts.push(`A ${num(rho)} ${num(rho)} 0 0 ${convex ? 1 : 0} ${fmt(p2)}`);
+  }
+  parts.push("Z");
+  return parts.join(" ");
+}
+
+// The input polygon to `roundedRectilinearPath` is axis-aligned (corners
+// alternate H/V edges), so one of dx, dy is always zero — `|dx| + |dy|`
+// is exact and `Math.sign` gives the unit vector with no `Math.hypot`
+// in the corner loop's hot path.
+function dist(a: Pt, b: Pt): number {
+  return Math.abs(b[0] - a[0]) + Math.abs(b[1] - a[1]);
+}
+
+function unit(a: Pt, b: Pt): Pt {
+  return [Math.sign(b[0] - a[0]), Math.sign(b[1] - a[1])];
+}
+
+function num(n: number): string {
+  return Number.isInteger(n) ? String(n) : n.toFixed(2);
+}
+
+function fmt(p: Pt): string {
+  return `${num(p[0])},${num(p[1])}`;
+}


### PR DESCRIPTION
First slice of the notch-grid v2 stack. **Pure-lift, zero new code.** The salvaged files are unreferenced by any export until PR 4 (`<NotchGrid>` component) lands, so this PR has **no visible behavior** on its own.

Design doc: [`mirrorstack-docs/architecture/notch-grid-v2/`](https://github.com/mirrorstack-ai/mirrorstack-docs/pull/12) (PR #12).

## What's lifted

From the closed v1 PRs (kept intact on their origin branches):

| Closed PR | File | Tests |
|---|---|---|
| #188 (`feat/grid-outline`) | `src/utils/grid-outline.ts` | 14 |
| #189 (`feat/notch-grid-layout`) | `src/components/ui/surfaces/notch-grid/breakpoints.ts` | 16 |
| #190 (`feat/notch-grid-blockshape`) | `src/components/ui/surfaces/notch-grid/BlockShape.tsx` | 6 |

`layout.ts` is intentionally **NOT** included — PR 2 extends it with desire-based solver semantics per [`01-solver.md`](https://github.com/mirrorstack-ai/mirrorstack-docs/blob/docs/notch-grid-v2-architecture/architecture/notch-grid-v2/01-solver.md).

## Why this is safe to merge alone

- Three files in `src/components/ui/surfaces/notch-grid/` are not exported by any barrel file, so nothing in the kit's public surface changes.
- `src/utils/grid-outline.ts` is added but unused by any existing component.
- All three lifted modules have their tests bundled and passing.
- /simplify already ran on each of the closed PRs at lift time; small follow-ups get visual review only per the workspace's iteration convention.

## Verification

```
pnpm typecheck                                                          # clean
pnpm test src/utils/grid-outline src/components/ui/surfaces/notch-grid  # 36/36 pass
```

## What follows

Per [`04-salvage.md`](https://github.com/mirrorstack-ai/mirrorstack-docs/blob/docs/notch-grid-v2-architecture/architecture/notch-grid-v2/04-salvage.md) PR sequencing:

| # | What |
|---|---|
| 2 | Extend `layout.ts` with desire-based solver (priority maps + scale + cost function) |
| 3 | Theme token mapping (`SCHEMA_TO_TOKEN`, optional `--shadow-m3-*`) |
| 4 | `<NotchGrid>` (no drag) + new stories — **graduation trigger** for the design doc |
| 5 | Outer-grid drag |
| 6 | Sub-drag + promote + auto-link |
| 7 | Drag-active visuals + linked-chrome drag |

## Test plan

- [ ] Confirm no public-surface change — `git diff --stat origin/main` shows zero changes under `src/index.ts` or any barrel file
- [ ] CI passes (typecheck + tests)
- [ ] Verify `pnpm components list` is unchanged (lifted files have no `meta` export yet — BlockShape's `meta` is exported but not re-exported anywhere)
- [ ] Patch bump `0.2.20 → 0.2.21` lands cleanly through publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)