### PR TITLE
refactor(nav-item): reduce vertical padding py-3 → py-2.5

### DIFF
--- a/src/components/ui/navigation/nav-item/NavItem.tsx
+++ b/src/components/ui/navigation/nav-item/NavItem.tsx
@@ -42,7 +42,7 @@ export function NavItem({
   return (
     <button
       className={cn(
-        "w-full flex items-center gap-3 px-4 py-3 rounded-xl text-left transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed",
+        "w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-left transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed",
         active && variant === "default" ? activeStyle : variantStyles[variant],
         className,
       )}


### PR DESCRIPTION
## What

Single-line tweak to `NavItem.tsx`: vertical padding `py-3` → `py-2.5` (12px → 10px), shrinking total item height ~44px → ~40px. No API change, no prop change, no behavior change.

## Why

Tested locally against `web-account`'s settings nav — the prior height made the sidebar feel taller than necessary now that the Account section is growing (My Brain landing soon, Billing inbound). A 4px-tighter item keeps the section visually balanced against the agent sidebar's denser content.

## Verification

- `pnpm build` → `tsc + tsc-alias` clean
- No tests assert on the padding class; nothing to update
- Storybook story unaffected (renders fine at either height)

## Versioning

**No version bump in this PR** per the maintainer's preference to keep release cycles separate. Local consumers via `file:..` see the change immediately on next `pnpm install`; published consumers get it on the next release cut.

## Local-test workflow

`web-account` uses `file:../web-ui-kit` so consumers see this branch's `dist/` directly after `pnpm build` here. To preview before merge:

```bash
cd ~/Documents/MirrorStack-AI-V2/web-ui-kit-wt-nav-item-height
pnpm install && pnpm build
# Then in web-account: pnpm install && pnpm dev
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)