### PR TITLE
feat(avatar): support up to 3-char fallback initials

### DIFF
--- a/src/components/ui/media/avatar/Avatar.stories.tsx
+++ b/src/components/ui/media/avatar/Avatar.stories.tsx
@@ -49,6 +49,26 @@ export const SquareSizes: Story = {
   ),
 };
 
+/**
+ * Fallback supports up to 3 characters. Pass "AB" for two-letter
+ * initials, "ABC" for three-letter monograms — the text size scales
+ * down per char count so each variant stays legible at every Avatar
+ * size.
+ */
+export const MultiCharFallback: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      {(["sm", "md", "lg", "xl"] as AvatarSize[]).map((size) => (
+        <div key={size} className="flex items-center gap-4">
+          <Avatar size={size} fallback="A" />
+          <Avatar size={size} fallback="AB" />
+          <Avatar size={size} fallback="ABC" />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
 export const WithImage: Story = {
   args: {
     src: "https://i.pravatar.cc/150?img=12",

--- a/src/components/ui/media/avatar/Avatar.test.tsx
+++ b/src/components/ui/media/avatar/Avatar.test.tsx
@@ -7,7 +7,33 @@ afterEach(cleanup);
 describe("Avatar", () => {
   it("renders initials fallback when no src", () => {
     render(<Avatar fallback="John" />);
-    expect(screen.getByText("J")).toBeInTheDocument();
+    expect(screen.getByText("JOH")).toBeInTheDocument();
+  });
+
+  it("uses up to 3 chars of the fallback, uppercased", () => {
+    const a = render(<Avatar fallback="A" />);
+    expect(a.getByText("A")).toBeInTheDocument();
+    a.unmount();
+
+    const ab = render(<Avatar fallback="ab" />);
+    expect(ab.getByText("AB")).toBeInTheDocument();
+    ab.unmount();
+
+    const abcde = render(<Avatar fallback="abcde" />);
+    expect(abcde.getByText("ABC")).toBeInTheDocument();
+  });
+
+  it("scales the text size down as char count grows", () => {
+    const one = render(<Avatar size="xl" fallback="A" />);
+    expect(one.getByText("A")).toHaveClass("text-2xl");
+    one.unmount();
+
+    const two = render(<Avatar size="xl" fallback="AB" />);
+    expect(two.getByText("AB")).toHaveClass("text-xl");
+    two.unmount();
+
+    const three = render(<Avatar size="xl" fallback="ABC" />);
+    expect(three.getByText("ABC")).toHaveClass("text-lg");
   });
 
   it("renders image when src provided", () => {

--- a/src/components/ui/media/avatar/Avatar.tsx
+++ b/src/components/ui/media/avatar/Avatar.tsx
@@ -11,14 +11,49 @@ export const meta: ComponentMeta = {
 
 export type AvatarSize = "sm" | "md" | "lg" | "xl";
 
-const sizeMap: Record<
-  AvatarSize,
-  { container: string; text: string; badge: string; badgeIcon: number; squareRadius: string; squareBadgeRadius: string }
-> = {
-  sm: { container: "w-8 h-8", text: "text-xs", badge: "w-5 h-5", badgeIcon: 12, squareRadius: "rounded-lg", squareBadgeRadius: "rounded-lg rounded-br-xl" },
-  md: { container: "w-10 h-10", text: "text-sm", badge: "w-6 h-6", badgeIcon: 12, squareRadius: "rounded-xl", squareBadgeRadius: "rounded-xl rounded-br-2xl" },
-  lg: { container: "w-16 h-16", text: "text-xl", badge: "w-6 h-6", badgeIcon: 14, squareRadius: "rounded-2xl", squareBadgeRadius: "rounded-2xl rounded-br-3xl" },
-  xl: { container: "w-20 h-20", text: "text-2xl", badge: "w-7 h-7", badgeIcon: 14, squareRadius: "rounded-3xl", squareBadgeRadius: "rounded-3xl rounded-br-[2rem]" },
+interface SizeSpec {
+  container: string;
+  /** [1-char, 2-char, 3-char] text size class — narrower as char count grows. */
+  text: [string, string, string];
+  badge: string;
+  badgeIcon: number;
+  squareRadius: string;
+  squareBadgeRadius: string;
+}
+
+const sizeMap: Record<AvatarSize, SizeSpec> = {
+  sm: {
+    container: "w-8 h-8",
+    text: ["text-xs", "text-[10px]", "text-[9px]"],
+    badge: "w-5 h-5",
+    badgeIcon: 12,
+    squareRadius: "rounded-lg",
+    squareBadgeRadius: "rounded-lg rounded-br-xl",
+  },
+  md: {
+    container: "w-10 h-10",
+    text: ["text-sm", "text-xs", "text-[11px]"],
+    badge: "w-6 h-6",
+    badgeIcon: 12,
+    squareRadius: "rounded-xl",
+    squareBadgeRadius: "rounded-xl rounded-br-2xl",
+  },
+  lg: {
+    container: "w-16 h-16",
+    text: ["text-xl", "text-base", "text-sm"],
+    badge: "w-6 h-6",
+    badgeIcon: 14,
+    squareRadius: "rounded-2xl",
+    squareBadgeRadius: "rounded-2xl rounded-br-3xl",
+  },
+  xl: {
+    container: "w-20 h-20",
+    text: ["text-2xl", "text-xl", "text-lg"],
+    badge: "w-7 h-7",
+    badgeIcon: 14,
+    squareRadius: "rounded-3xl",
+    squareBadgeRadius: "rounded-3xl rounded-br-[2rem]",
+  },
 };
 
 export interface AvatarProps {
@@ -46,7 +81,11 @@ export function Avatar({
 }: AvatarProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const s = sizeMap[size];
-  const initial = fallback.charAt(0).toUpperCase();
+  // Show up to 3 chars of the fallback, uppercased. Empty string falls back
+  // to the prop default "U" via destructuring, so initials is always at
+  // least length 1 unless the consumer explicitly passed "".
+  const initials = fallback.slice(0, 3).toUpperCase();
+  const textSize = s.text[Math.min(Math.max(initials.length, 1), 3) - 1];
   // Larger bottom-right radius only when editable+square (to accommodate the edit badge)
   const radius = square
     ? editable
@@ -80,8 +119,8 @@ export function Avatar({
         "bg-primary/20 flex items-center justify-center border-2 border-primary",
       )}
     >
-      {showInitial && (
-        <span className={cn("font-bold text-primary", s.text)}>{initial}</span>
+      {showInitial && initials && (
+        <span className={cn("font-bold text-primary", textSize)}>{initials}</span>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

\`fallback\` now displays up to 3 characters (uppercased) instead of just the first letter. Text size scales down per char count and per Avatar size so 1/2/3-letter initials all stay legible.

| size | 1 char | 2 chars | 3 chars |
|------|--------|---------|---------|
| sm   | text-xs   | text-[10px] | text-[9px]  |
| md   | text-sm   | text-xs     | text-[11px] |
| lg   | text-xl   | text-base   | text-sm     |
| xl   | text-2xl  | text-xl     | text-lg     |

## Why

Single-letter initials are ambiguous for users (\"J\" — John? Jane? Joel?) and especially for modules, where the first letter often collides with a sibling. 2-letter initials (\"JD\") and 3-letter module monograms (\"PAY\" for payments) are much more recognizable.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` clean — added 2 new tests (multi-char rendering + per-count text-size scaling); updated the existing \"renders initials fallback\" test from \"J\" → \"JOH\" to reflect the new behavior
- [ ] Visual: \`MultiCharFallback\` story renders all four sizes × {1, 2, 3} chars in a grid for eyeballing legibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)