### PR TITLE
fix(graph): skip unrevealed nodes from force simulation during playback

### DIFF
--- a/src/components/ui/graph/graph/Graph.tsx
+++ b/src/components/ui/graph/graph/Graph.tsx
@@ -139,10 +139,18 @@ function seed(nodes: GraphNode[], W: number, H: number): Sim[] {
   });
 }
 
+// During BFS playback, only `revealed` nodes participate in physics:
+// repulsion / spring / center / boundary forces all skip non-revealed
+// nodes. Without this guard, unrevealed nodes still pull on revealed
+// ones, distorting the intermediate-frame shape (e.g., a 7-node fully-
+// connected subset settles into a tangled cluster instead of a clean
+// heptagon because hidden facts tug on their hubs). Once playback ends
+// every node is in `revealed`, so this is a no-op for steady-state.
 function step(
   nodes: Sim[],
   byId: Map<string, Sim>,
   edges: GraphEdge[],
+  revealed: Set<string>,
   W: number,
   H: number,
   repulsion: number,
@@ -150,8 +158,10 @@ function step(
 ) {
   for (let i = 0; i < nodes.length; i++) {
     const a = nodes[i];
+    if (!revealed.has(a.id)) continue;
     for (let j = i + 1; j < nodes.length; j++) {
       const b = nodes[j];
+      if (!revealed.has(b.id)) continue;
       const dx = b.x - a.x;
       const dy = b.y - a.y;
       const dist = Math.max(20, Math.sqrt(dx * dx + dy * dy));
@@ -163,6 +173,7 @@ function step(
     }
   }
   for (const e of edges) {
+    if (!revealed.has(e.source) || !revealed.has(e.target)) continue;
     const a = byId.get(e.source);
     const b = byId.get(e.target);
     if (!a || !b) continue;
@@ -177,6 +188,7 @@ function step(
   }
   for (const n of nodes) {
     if (n.pinned) continue;
+    if (!revealed.has(n.id)) continue;
     n.vx += (W / 2 - n.x) * CENTER;
     n.vy += (H / 2 - n.y) * CENTER;
     n.vx *= DAMPING;
@@ -396,6 +408,7 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
         nodesRef.current,
         byIdRef.current,
         edgesRef.current,
+        revealedRef.current,
         s.w,
         s.h,
         repulsionRef.current,


### PR DESCRIPTION
## The bug

The BFS replay animation reveals nodes one by one, but the force simulation was running on **every** node and edge regardless of reveal state. Hidden nodes still pulled on visible ones via repulsion + spring forces, distorting the intermediate-frame shape.

**Symptom:** a fully-connected subset of a larger graph (e.g. 7 hubs out of 60+ nodes) settles into a tangled cluster instead of the clean polygon you'd expect when only those 7 are visible — because their unrevealed neighbors are still tugging on them.

Discovered while testing the My Brain page in web-account, which renders 60+ nodes but starts the replay from a 7-hub subset.

## The fix

`step()` now takes a `revealed: Set<string>` parameter and skips physics for non-revealed participants:

```diff
 function step(
   nodes: Sim[],
   byId: Map<string, Sim>,
   edges: GraphEdge[],
+  revealed: Set<string>,
   W, H, repulsion, linkDistance,
 ) {
   for (let i = 0; i < nodes.length; i++) {
     const a = nodes[i];
+    if (!revealed.has(a.id)) continue;
     for (let j = i + 1; j < nodes.length; j++) {
       const b = nodes[j];
+      if (!revealed.has(b.id)) continue;
       // … repulsion …
     }
   }
   for (const e of edges) {
+    if (!revealed.has(e.source) || !revealed.has(e.target)) continue;
     // … spring force …
   }
   for (const n of nodes) {
     if (n.pinned) continue;
+    if (!revealed.has(n.id)) continue;
     // … position update + boundary clamp …
   }
 }
```

RAF caller updated to pass `revealedRef.current`. Once playback ends, every node is in `revealed`, so the guards collapse to no-ops and steady-state physics is byte-for-byte identical.

## Public API impact

**None.** `step()` is module-private. The `Graph` component's props, ref handle (`GraphHandle.replay/stop/fit`), and exported types are unchanged. Pure internal fix.

## Verification

```
pnpm typecheck                              → clean
pnpm vitest run src/components/ui/graph/    → 14/14 pass
pnpm build                                  → clean
```

The 4 pre-existing `ThemeProvider.test.tsx` failures (`TypeError: localStorage.clear is not a function`) are an environment-level test-harness issue, verified to fail on `origin/main` without this change — out of scope here.

## Visual: before / after

Before (intermediate frame, 7-of-60+ revealed): tangled cluster pulled toward the hidden facts at the bottom of the canvas.

After: the 6 hubs settle around the pinned user at the center as a clean heptagon-ish polygon, since only their mutual repulsion + their inter-hub springs participate in physics until more nodes reveal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)