### PR TITLE
docs: seed CHANGELOG.md with 0.3.0 notes (trigger publish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+Notable API additions and breaking changes. For the full commit log, see
+[GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
+
+## 0.3.0
+
+### Components
+
+- **DropdownMenu** — new `notchWidth?` / `notchHeight?` props (default
+  52 / 46) to tune the notch tab per instance; new `useNotch?` prop
+  (default `true`) — set `false` to render a plain bordered popover
+  below the trigger (for selects, period pickers, anywhere the kit's
+  signature notch doesn't fit). Trigger wrapper `z-[51]` now conditional
+  on `open` so adjacent closed triggers no longer poke through an open
+  menu. Container padding tightened (`py-1.5 px-1` → `p-2`); item style
+  refreshed to match `AgentGreeting`'s model picker
+  (`items-baseline gap-2 rounded-lg px-2 py-1.5`).
+
+- **Graph** — playback physics fix: non-revealed nodes are now skipped
+  from force-sim during replay so the topology forms cleanly instead of
+  contorting through hidden nodes. Zoom-aware label LOD: per-node
+  opacity fades with degree, pinned/focused/hovered/tag nodes always
+  visible.
+
+- **AgentGreeting** — new `hideInput` prop for layouts that only need
+  the heading + logo without the chat input.
+
+- **NavItem** — vertical padding refresh `py-3` → `py-2.5`.
+
+### Notes
+
+All additions are backwards-compatible (new props are optional with
+defaults preserving existing behavior).


### PR DESCRIPTION
Two purposes in one small PR:

1. Adds a `CHANGELOG.md` artifact at the kit root with the 0.3.0 entry (DropdownMenu notch props + useNotch + z-index fix, Graph playback + label LOD, AgentGreeting hideInput, NavItem padding).
2. Carries the **`release` label** so the `release.yml` workflow fires on merge. The previous release-bump PR (#225) merged the version bump but landed without the label, so the workflow didn't tag / publish.

The workflow reads `package.json.version` (currently `0.3.0` on `main`) and will tag `v0.3.0`, create a GitHub Release, and publish to GitHub Packages.

After merge, downstream consumers (`web-account` billing PR, future `web-applications` bumps) can move from `file:../web-ui-kit` → `^0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)