### PR TITLE
feat(notch-grid): theme token resolver for v2 (PR 3/7)

### DIFF
--- a/src/components/ui/surfaces/notch-grid/theme.test.ts
+++ b/src/components/ui/surfaces/notch-grid/theme.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import { resolveNotchTheme } from "./theme";
+
+describe("resolveNotchTheme — defaults & auto resolution", () => {
+  it("undefined theme → ghost neutral (both knobs auto)", () => {
+    const r = resolveNotchTheme();
+    expect(r.background).toBe("transparent");
+    expect(r.color).toBe("var(--color-on-surface-variant)");
+    expect(r.border).toBe("none");
+    expect(r.boxShadow).toBe("none");
+  });
+
+  it("variant=primary alone → filled primary (type defaults to filled when variant set)", () => {
+    const r = resolveNotchTheme({ variant: "primary" });
+    expect(r.background).toBe("var(--color-primary-container)");
+    expect(r.color).toBe("var(--color-on-primary-container)");
+  });
+
+  it("type=auto + variant=auto → ghost neutral", () => {
+    const r = resolveNotchTheme({ type: "auto", variant: "auto" });
+    expect(r.background).toBe("transparent");
+    expect(r.color).toBe("var(--color-on-surface-variant)");
+  });
+
+  it("type=auto + variant=primary → filled primary", () => {
+    const r = resolveNotchTheme({ type: "auto", variant: "primary" });
+    expect(r.background).toBe("var(--color-primary-container)");
+    expect(r.color).toBe("var(--color-on-primary-container)");
+  });
+
+  it("variant=auto → resolves to neutral", () => {
+    const r = resolveNotchTheme({ type: "outlined", variant: "auto" });
+    expect(r.color).toBe("var(--color-on-surface-variant)");
+    expect(r.border).toBe("1px solid var(--color-outline-variant)");
+  });
+});
+
+describe("resolveNotchTheme — type=filled", () => {
+  it("primary → primary-container fill, on-primary-container text", () => {
+    const r = resolveNotchTheme({ type: "filled", variant: "primary" });
+    expect(r.background).toBe("var(--color-primary-container)");
+    expect(r.color).toBe("var(--color-on-primary-container)");
+    expect(r.border).toBe("none");
+    expect(r.boxShadow).toBe("none");
+  });
+
+  it("secondary, tertiary, error → matching container tokens", () => {
+    expect(resolveNotchTheme({ type: "filled", variant: "secondary" }).background)
+      .toBe("var(--color-secondary-container)");
+    expect(resolveNotchTheme({ type: "filled", variant: "tertiary" }).background)
+      .toBe("var(--color-tertiary-container)");
+    expect(resolveNotchTheme({ type: "filled", variant: "error" }).background)
+      .toBe("var(--color-error-container)");
+  });
+
+  it("surface → surface-container; neutral → surface-container-low", () => {
+    expect(resolveNotchTheme({ type: "filled", variant: "surface" }).background)
+      .toBe("var(--color-surface-container)");
+    expect(resolveNotchTheme({ type: "filled", variant: "neutral" }).background)
+      .toBe("var(--color-surface-container-low)");
+  });
+
+  it("warn → warning-container (schema→kit alias)", () => {
+    const r = resolveNotchTheme({ type: "filled", variant: "warn" });
+    expect(r.background).toBe("var(--color-warning-container)");
+    expect(r.color).toBe("var(--color-on-warning-container)");
+  });
+});
+
+describe("resolveNotchTheme — type=outlined", () => {
+  it("primary → transparent bg, primary text, 1px primary border", () => {
+    const r = resolveNotchTheme({ type: "outlined", variant: "primary" });
+    expect(r.background).toBe("transparent");
+    expect(r.color).toBe("var(--color-primary)");
+    expect(r.border).toBe("1px solid var(--color-primary)");
+    expect(r.boxShadow).toBe("none");
+  });
+
+  it("neutral / surface → outline-variant border", () => {
+    expect(resolveNotchTheme({ type: "outlined", variant: "neutral" }).border)
+      .toBe("1px solid var(--color-outline-variant)");
+    expect(resolveNotchTheme({ type: "outlined", variant: "surface" }).border)
+      .toBe("1px solid var(--color-outline-variant)");
+  });
+
+  it("warn → warning border (alias)", () => {
+    expect(resolveNotchTheme({ type: "outlined", variant: "warn" }).border)
+      .toBe("1px solid var(--color-warning)");
+  });
+});
+
+describe("resolveNotchTheme — type=elevated", () => {
+  it("primary → surface-container-low fill, on-surface text, m3-1 shadow", () => {
+    const r = resolveNotchTheme({ type: "elevated", variant: "primary" });
+    expect(r.background).toBe("var(--color-surface-container-low)");
+    expect(r.color).toBe("var(--color-on-surface)");
+    expect(r.boxShadow).toBe("var(--shadow-m3-1)");
+    expect(r.borderLeft).toBeUndefined();
+  });
+
+  it("neutral drops one surface tier (container-lowest)", () => {
+    const r = resolveNotchTheme({ type: "elevated", variant: "neutral" });
+    expect(r.background).toBe("var(--color-surface-container-lowest)");
+  });
+
+  it("warn → adds 4px warning border-left as color cue on lifted chrome", () => {
+    const r = resolveNotchTheme({ type: "elevated", variant: "warn" });
+    expect(r.background).toBe("var(--color-surface-container-low)");
+    expect(r.borderLeft).toBe("4px solid var(--color-warning)");
+    expect(r.boxShadow).toBe("var(--shadow-m3-1)");
+  });
+
+  it("error → 4px error border-left", () => {
+    const r = resolveNotchTheme({ type: "elevated", variant: "error" });
+    expect(r.borderLeft).toBe("4px solid var(--color-error)");
+  });
+});
+
+describe("resolveNotchTheme — type=ghost", () => {
+  it("primary → transparent bg, primary text, no border or shadow", () => {
+    const r = resolveNotchTheme({ type: "ghost", variant: "primary" });
+    expect(r.background).toBe("transparent");
+    expect(r.color).toBe("var(--color-primary)");
+    expect(r.border).toBe("none");
+    expect(r.boxShadow).toBe("none");
+  });
+
+  it("neutral → on-surface-variant text", () => {
+    expect(resolveNotchTheme({ type: "ghost", variant: "neutral" }).color)
+      .toBe("var(--color-on-surface-variant)");
+  });
+
+  it("warn → warning text (alias)", () => {
+    expect(resolveNotchTheme({ type: "ghost", variant: "warn" }).color)
+      .toBe("var(--color-warning)");
+  });
+});
+
+describe("resolveNotchTheme — gradient overlay", () => {
+  it("gradient=0 leaves filled background unchanged", () => {
+    const r = resolveNotchTheme({ type: "filled", variant: "primary", gradient: 0 });
+    expect(r.background).toBe("var(--color-primary-container)");
+  });
+
+  it("gradient>0 wraps the fill in a linear-gradient using color-mix", () => {
+    const r = resolveNotchTheme({ type: "filled", variant: "primary", gradient: 1 });
+    expect(r.background).toContain("linear-gradient(180deg");
+    expect(r.background).toContain("var(--color-primary-container)");
+    expect(r.background).toContain("color-mix(in oklab");
+    expect(r.background).toContain("white 12%");
+  });
+
+  it("gradient=0.5 → 6% white mix at top", () => {
+    const r = resolveNotchTheme({ type: "filled", variant: "primary", gradient: 0.5 });
+    expect(r.background).toContain("white 6%");
+  });
+
+  it("gradient clamped at 1 (gradient=2 still produces 12%)", () => {
+    const r = resolveNotchTheme({ type: "filled", variant: "primary", gradient: 2 });
+    expect(r.background).toContain("white 12%");
+  });
+
+  it("gradient ignored for transparent backgrounds (outlined, ghost)", () => {
+    const outlined = resolveNotchTheme({ type: "outlined", variant: "primary", gradient: 1 });
+    expect(outlined.background).toBe("transparent");
+    const ghost = resolveNotchTheme({ type: "ghost", variant: "primary", gradient: 1 });
+    expect(ghost.background).toBe("transparent");
+  });
+
+  it("gradient applies to elevated fill (it's a solid token, not transparent)", () => {
+    const r = resolveNotchTheme({ type: "elevated", variant: "primary", gradient: 1 });
+    expect(r.background).toContain("linear-gradient(180deg");
+    expect(r.background).toContain("var(--color-surface-container-low)");
+  });
+});
+
+describe("resolveNotchTheme — exhaustive type×variant matrix", () => {
+  const types = ["filled", "outlined", "elevated", "ghost"] as const;
+  const variants = [
+    "primary",
+    "secondary",
+    "tertiary",
+    "surface",
+    "neutral",
+    "warn",
+    "error",
+  ] as const;
+
+  it("every (type, variant) pair returns valid CSS-shaped strings", () => {
+    for (const type of types) {
+      for (const variant of variants) {
+        const r = resolveNotchTheme({ type, variant });
+        expect(typeof r.background).toBe("string");
+        expect(r.background.length).toBeGreaterThan(0);
+        expect(typeof r.color).toBe("string");
+        expect(r.color).toMatch(/^var\(--color-/);
+        expect(typeof r.border).toBe("string");
+        expect(typeof r.boxShadow).toBe("string");
+      }
+    }
+  });
+
+  it("elevated rows are the only chromes carrying a shadow", () => {
+    for (const variant of variants) {
+      for (const type of types) {
+        const r = resolveNotchTheme({ type, variant });
+        if (type === "elevated") {
+          expect(r.boxShadow).toBe("var(--shadow-m3-1)");
+        } else {
+          expect(r.boxShadow).toBe("none");
+        }
+      }
+    }
+  });
+});

--- a/src/components/ui/surfaces/notch-grid/theme.ts
+++ b/src/components/ui/surfaces/notch-grid/theme.ts
@@ -1,0 +1,182 @@
+// Theme token resolution for notch-grid items.
+//
+// Maps the dynamic-ui item-schema `theme` field (type × variant × gradient)
+// to CSS values referencing the kit's tokens. Renderers apply the result as
+// inline `style` (or by spreading into a `style` prop). See
+// `mirrorstack-docs/architecture/notch-grid-v2/03-theme-tokens.md`.
+
+export type ThemeType = "filled" | "outlined" | "elevated" | "ghost" | "auto";
+export type ThemeVariant =
+  | "primary"
+  | "secondary"
+  | "tertiary"
+  | "surface"
+  | "neutral"
+  | "warn"
+  | "error"
+  | "auto";
+
+export interface NotchTheme {
+  type?: ThemeType;
+  variant?: ThemeVariant;
+  /** Tonal-overlay intensity, 0–1. Ignored when fill is transparent. */
+  gradient?: number;
+}
+
+export interface ResolvedTheme {
+  /** CSS `background` — token reference, gradient, or `"transparent"`. */
+  background: string;
+  /** CSS `color` — always a token reference. */
+  color: string;
+  /** CSS `border` — `"1px solid var(...)"` or `"none"`. */
+  border: string;
+  /** CSS `border-left` for elevated warn/error (color cue layered on lift). */
+  borderLeft?: string;
+  /** CSS `box-shadow` — token reference or `"none"`. */
+  boxShadow: string;
+}
+
+const DEFAULT_VARIANT: Exclude<ThemeVariant, "auto"> = "neutral";
+
+/** Resolved (non-`auto`) variant. */
+type ConcreteVariant = Exclude<ThemeVariant, "auto">;
+/** Resolved (non-`auto`) type. */
+type ConcreteType = Exclude<ThemeType, "auto">;
+
+/** Per-variant fill background token. Schema `warn` aliases to kit `warning`;
+ *  `neutral` maps to the lowest-emphasis surface tone. */
+const FILL_BG: Record<ConcreteVariant, string> = {
+  primary: "var(--color-primary-container)",
+  secondary: "var(--color-secondary-container)",
+  tertiary: "var(--color-tertiary-container)",
+  surface: "var(--color-surface-container)",
+  neutral: "var(--color-surface-container-low)",
+  warn: "var(--color-warning-container)",
+  error: "var(--color-error-container)",
+};
+
+/** Per-variant on-fill text token (paired with FILL_BG). */
+const FILL_FG: Record<ConcreteVariant, string> = {
+  primary: "var(--color-on-primary-container)",
+  secondary: "var(--color-on-secondary-container)",
+  tertiary: "var(--color-on-tertiary-container)",
+  surface: "var(--color-on-surface)",
+  neutral: "var(--color-on-surface-variant)",
+  warn: "var(--color-on-warning-container)",
+  error: "var(--color-on-error-container)",
+};
+
+/** Per-variant accent color for outlined / ghost text and outlined border. */
+const ACCENT: Record<ConcreteVariant, string> = {
+  primary: "var(--color-primary)",
+  secondary: "var(--color-secondary)",
+  tertiary: "var(--color-tertiary)",
+  surface: "var(--color-on-surface)",
+  neutral: "var(--color-on-surface-variant)",
+  warn: "var(--color-warning)",
+  error: "var(--color-error)",
+};
+
+/** Border color for outlined chrome (surface/neutral fall back to outline-variant). */
+const OUTLINE_BORDER: Record<ConcreteVariant, string> = {
+  primary: "var(--color-primary)",
+  secondary: "var(--color-secondary)",
+  tertiary: "var(--color-tertiary)",
+  surface: "var(--color-outline-variant)",
+  neutral: "var(--color-outline-variant)",
+  warn: "var(--color-warning)",
+  error: "var(--color-error)",
+};
+
+/** Background for the elevated chrome (raised card look). Neutral drops one
+ *  surface tier lower than the rest so the lift reads even on a busy page. */
+const ELEVATED_BG: Record<ConcreteVariant, string> = {
+  primary: "var(--color-surface-container-low)",
+  secondary: "var(--color-surface-container-low)",
+  tertiary: "var(--color-surface-container-low)",
+  surface: "var(--color-surface-container-low)",
+  neutral: "var(--color-surface-container-lowest)",
+  warn: "var(--color-surface-container-low)",
+  error: "var(--color-surface-container-low)",
+};
+
+/** Resolve `auto` knobs to concrete values:
+ *  - `variant: auto` falls to `neutral`
+ *  - `type: auto` becomes `filled` when a variant is set, `ghost` otherwise */
+function resolveAuto(theme: NotchTheme): { type: ConcreteType; variant: ConcreteVariant } {
+  const rawVariant = theme.variant ?? "auto";
+  const variant: ConcreteVariant = rawVariant === "auto" ? DEFAULT_VARIANT : rawVariant;
+  const rawType = theme.type ?? "auto";
+  const type: ConcreteType =
+    rawType === "auto"
+      ? rawVariant === "auto"
+        ? "ghost"
+        : "filled"
+      : rawType;
+  return { type, variant };
+}
+
+/** Apply a tonal gradient overlay to a fill token. `gradient = 0` returns the
+ *  raw token; `gradient = 1` mixes ~12% white at the top. The overlay only
+ *  applies to filled chromes — transparent backgrounds are returned unchanged. */
+function applyGradient(bg: string, gradient: number): string {
+  if (gradient <= 0 || bg === "transparent") return bg;
+  const pct = Math.min(1, gradient) * 12;
+  return `linear-gradient(180deg, color-mix(in oklab, ${bg}, white ${pct}%) 0%, ${bg} 100%)`;
+}
+
+/**
+ * Resolve a `NotchTheme` to CSS values referencing `web-ui-kit` tokens.
+ *
+ * Schema-to-kit aliases:
+ * - `warn` → `warning` family (kit token name)
+ * - `neutral` → low-emphasis surface chrome (kit has no `neutral` family)
+ *
+ * `auto` resolution is deterministic:
+ * - `variant: auto` → `neutral`
+ * - `type: auto` + variant set → `filled`
+ * - `type: auto` + `variant: auto` → `ghost`
+ */
+export function resolveNotchTheme(theme?: NotchTheme): ResolvedTheme {
+  const t = theme ?? {};
+  const { type, variant } = resolveAuto(t);
+  const gradient = t.gradient ?? 0;
+
+  switch (type) {
+    case "filled": {
+      const bg = applyGradient(FILL_BG[variant], gradient);
+      return {
+        background: bg,
+        color: FILL_FG[variant],
+        border: "none",
+        boxShadow: "none",
+      };
+    }
+    case "outlined": {
+      return {
+        background: "transparent",
+        color: ACCENT[variant],
+        border: `1px solid ${OUTLINE_BORDER[variant]}`,
+        boxShadow: "none",
+      };
+    }
+    case "elevated": {
+      const isAlert = variant === "warn" || variant === "error";
+      return {
+        background: applyGradient(ELEVATED_BG[variant], gradient),
+        color: "var(--color-on-surface)",
+        border: "none",
+        ...(isAlert ? { borderLeft: `4px solid ${ACCENT[variant]}` } : {}),
+        boxShadow: "var(--shadow-m3-1)",
+      };
+    }
+    case "ghost": {
+      return {
+        background: "transparent",
+        color: ACCENT[variant],
+        border: "none",
+        boxShadow: "none",
+      };
+    }
+  }
+}

--- a/src/theme.css
+++ b/src/theme.css
@@ -70,6 +70,18 @@
   --color-shadow: #000000;
   --color-scrim: #000000;
 
+  /* Material Design 3 elevation — see m3.material.io/styles/elevation */
+  --shadow-m3-1: 0 1px 2px 0 color-mix(in srgb, var(--color-shadow) 30%, transparent),
+                 0 1px 3px 1px color-mix(in srgb, var(--color-shadow) 15%, transparent);
+  --shadow-m3-2: 0 1px 2px 0 color-mix(in srgb, var(--color-shadow) 30%, transparent),
+                 0 2px 6px 2px color-mix(in srgb, var(--color-shadow) 15%, transparent);
+  --shadow-m3-3: 0 1px 3px 0 color-mix(in srgb, var(--color-shadow) 30%, transparent),
+                 0 4px 8px 3px color-mix(in srgb, var(--color-shadow) 15%, transparent);
+  --shadow-m3-4: 0 2px 3px 0 color-mix(in srgb, var(--color-shadow) 30%, transparent),
+                 0 6px 10px 4px color-mix(in srgb, var(--color-shadow) 15%, transparent);
+  --shadow-m3-5: 0 4px 4px 0 color-mix(in srgb, var(--color-shadow) 30%, transparent),
+                 0 8px 12px 6px color-mix(in srgb, var(--color-shadow) 15%, transparent);
+
   /* Font */
   --font-sans: "Shantell Sans", -apple-system, BlinkMacSystemFont, "Segoe UI",
     Roboto, sans-serif;


### PR DESCRIPTION
Third slice of the notch-grid v2 stack. Adds the schema → CSS token resolver and Material 3 elevation tokens. **No public surface change** — exports are unreferenced until PR 4.

Design doc: [`mirrorstack-docs/architecture/notch-grid-v2/03-theme-tokens.md`](https://github.com/mirrorstack-ai/mirrorstack-docs/blob/main/architecture/notch-grid-v2/03-theme-tokens.md).

## What's in this PR

### `src/theme.css` — M3 elevation tokens

Five new `--shadow-m3-*` custom properties on the kit's `@theme` block. Each is layered with `color-mix(in srgb, var(--color-shadow) %, transparent)` so the shadow re-tints if the kit ever ships a non-black shadow color (dark mode). Tailwind v4 auto-generates matching `shadow-m3-1` … `shadow-m3-5` utility classes.

### `src/components/ui/surfaces/notch-grid/theme.ts` (new)

```ts
resolveNotchTheme(theme?: NotchTheme): ResolvedTheme
```

Resolves the dynamic-ui schema's `theme` field (`type` × `variant` × `gradient`) to a `{ background, color, border, borderLeft?, boxShadow }` bundle of CSS values referencing the kit's tokens.

**Schema → kit aliases handled internally:**
- `warn` → `--color-warning*` family
- `neutral` → `--color-surface-container-low` chrome + `--color-on-surface-variant` text (kit has no `neutral` family)

**Deterministic `auto` resolution:**
- `variant: auto` → `neutral`
- `type: auto` + variant set → `filled`
- `type: auto` + `variant: auto` → `ghost`

**Gradient overlay:** `gradient > 0` wraps solid fills in `linear-gradient(180deg, color-mix(in oklab, <token>, white g%) 0%, <token> 100%)` where `g = gradient * 12` (clamped). Ignored for transparent backgrounds (outlined / ghost).

**Elevated chromes** are the only ones carrying a `box-shadow`. `warn` / `error` get an additional `4px solid` `border-left` as a color cue alongside the lift.

## Resolution matrix (per the design doc)

|   | filled | outlined | elevated | ghost |
|---|---|---|---|---|
| primary | bg + on-fg | accent text, primary border | low-tier bg, m3-1 shadow | accent text |
| secondary | bg + on-fg | … | … | … |
| tertiary | bg + on-fg | … | … | … |
| surface | container fill | on-surface text, outline-variant border | … | … |
| neutral | container-low fill | on-surface-variant text, outline-variant border | container-lowest fill | … |
| warn (→warning) | warning-container | warning border | + 4px warning border-left | warning text |
| error | error-container | error border | + 4px error border-left | error text |

## Verification

```
pnpm typecheck                                                       # clean
pnpm test src/components/ui/surfaces/notch-grid                      # 82/82 pass
pnpm components validate                                             # 55/55 valid
```

| Suite | Tests |
|---|---|
| `theme.test.ts` (new) | **27** — defaults, auto resolution, each type, gradient overlay, alias resolution, exhaustive type×variant |
| `layout.test.ts` (PR 2) | 33 |
| `breakpoints.test.ts` (PR 1) | 16 |
| `BlockShape.test.tsx` (PR 1) | 6 |

The pre-existing `ThemeProvider` failures on `main` are unchanged and untouched here.

## What follows

| # | What |
|---|---|
| 4 | `<NotchGrid>` (no drag) + new stories — wires `solveLayout` + `BlockShape` + `resolveNotchTheme` together; **graduation trigger** for the design doc |
| 5–7 | Drag layers |

🤖 Generated with [Claude Code](https://claude.com/claude-code)