### PR TITLE
feat(section-header): bare section header primitive (+ 0.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.3.2
+
+### Components
+
+- **SectionHeader** — new bare-style section header (title + optional
+  description + optional right-aligned action). Sibling of
+  `SectionLabel` (uppercase chip) and `SettingRow` (bordered card row).
+  Use above a content area when you want the Claude-style "bold title,
+  muted description, no card chrome" treatment — sections separate by
+  parent gap only.
+
 ## 0.3.1
 
 ### Internal

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/data/section-header/SectionHeader.stories.tsx
+++ b/src/components/ui/data/section-header/SectionHeader.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { SectionHeader } from "./SectionHeader";
+import { Button } from "@/components/ui/actions/button/Button";
+
+const meta: Meta<typeof SectionHeader> = {
+  title: "UI/Data/SectionHeader",
+  component: SectionHeader,
+  args: {
+    title: "Payment method",
+    description: "Cards used to settle invoices for this account.",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SectionHeader>;
+
+export const Playground: Story = {};
+
+export const WithAction: Story = {
+  args: {
+    action: (
+      <Button variant="outline" size="sm" onClick={() => {}}>
+        Add card
+      </Button>
+    ),
+  },
+};
+
+export const NoDescription: Story = {
+  args: { description: undefined },
+};

--- a/src/components/ui/data/section-header/SectionHeader.test.tsx
+++ b/src/components/ui/data/section-header/SectionHeader.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SectionHeader } from "./SectionHeader";
+
+afterEach(cleanup);
+
+describe("SectionHeader", () => {
+  it("renders title and description", () => {
+    render(
+      <SectionHeader
+        title="Payment method"
+        description="Cards used to settle invoices."
+      />,
+    );
+    expect(screen.getByText("Payment method")).toBeInTheDocument();
+    expect(
+      screen.getByText("Cards used to settle invoices."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the title as an h2", () => {
+    render(<SectionHeader title="Invoices" />);
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "Invoices",
+    );
+  });
+
+  it("renders the action slot", () => {
+    render(
+      <SectionHeader title="X" action={<button>my-action</button>} />,
+    );
+    expect(screen.getByText("my-action")).toBeInTheDocument();
+  });
+
+  it("omits the description when not provided", () => {
+    const { container } = render(<SectionHeader title="Title only" />);
+    expect(container.querySelectorAll("p").length).toBe(0);
+  });
+
+  it("forwards the className prop", () => {
+    const { container } = render(
+      <SectionHeader title="X" className="custom-class" />,
+    );
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+});

--- a/src/components/ui/data/section-header/SectionHeader.tsx
+++ b/src/components/ui/data/section-header/SectionHeader.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "SectionHeader",
+  description:
+    "Bare section header — title with optional description and right-aligned action slot, rendered above a content area with no card chrome.",
+};
+
+export interface SectionHeaderProps {
+  /** Primary heading for the section, rendered as an h2. */
+  title: string;
+  /** Optional supporting copy, rendered below the title. */
+  description?: string;
+  /** Right-aligned action — typically a Button or IconButton. */
+  action?: ReactNode;
+  className?: string;
+}
+
+export function SectionHeader({
+  title,
+  description,
+  action,
+  className,
+}: SectionHeaderProps) {
+  return (
+    <header
+      className={cn(
+        "flex items-center justify-between gap-4",
+        className,
+      )}
+    >
+      <div className="min-w-0">
+        <h2 className="text-base font-semibold text-on-surface">{title}</h2>
+        {description && (
+          <p className="mt-0.5 text-sm text-on-surface-variant">
+            {description}
+          </p>
+        )}
+      </div>
+      {action}
+    </header>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,10 @@ export {
   type SliderProps,
 } from "./components/ui/inputs/slider/Slider";
 export {
+  SectionHeader,
+  type SectionHeaderProps,
+} from "./components/ui/data/section-header/SectionHeader";
+export {
   SectionLabel,
   type SectionLabelProps,
 } from "./components/ui/data/section-label/SectionLabel";


### PR DESCRIPTION
Adds a new kit primitive: **`SectionHeader`** — title with optional description and optional right-aligned action, rendered above a content area with **no card chrome**.

## Why

`/me/billing/page.tsx` in web-account uses this pattern 5× already (Subscription, Usage detail, Payment method, Invoices headers). Will spread to other `/me/*` settings pages and to web-applications.

The kit already has nearby primitives but none cover this role:

| Existing                  | Role                                                       |
| ------------------------- | ---------------------------------------------------------- |
| `SectionLabel`            | uppercase chip-style `<p>` (eyebrow label)                 |
| `SettingRow`              | bordered card-row with required `control` slot             |
| `SettingsSection`         | container wrapping content in `<Surface>` + `SectionLabel` |
| **`SectionHeader` (new)** | **bare h2 header above bare content; no surface**          |

## API

```ts
interface SectionHeaderProps {
  title: string;
  description?: string;
  action?: ReactNode;
  className?: string;
}
```

## /simplify findings applied

A 3-agent review surfaced two issues before push:

- **P1 — drop `mb-4`** — was leaky vs the kit's parent-owns-gap convention; `SectionLabel`, `SettingRow`, and `SettingsSection` all let the parent own vertical rhythm via `gap`/`space-y`. Consumers add their own spacing.
- **P2 — trim `meta.description`** — was 3 sentences with cross-refs to other components; trimmed to one focused sentence per the kit pattern.

## Version

`0.3.1` → `0.3.2` (patch, per pre-1.0 patch-only versioning). `release` label applied so the release workflow fires on merge.

## Tests

5 new unit tests (title/description rendering, h2 semantics, action slot, omitted description, className forwarding). All passing. Preexisting `ThemeProvider` localStorage test failures are unrelated.

## Consumer follow-up

After merge + publish, web-account (PR mirrorstack-ai/web-account#34) will:
1. Bump `@mirrorstack-ai/web-ui-kit` to `^0.3.2`
2. Replace the local `src/app/(settings)/me/billing/_shared/SectionHeader.tsx` with the kit import
3. Add `space-y-*` to each `<section>` wrapper to compensate for the now-unbaked `mb-4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)