### PR TITLE
feat(notch-grid): <NotchGrid> component for v2 (PR 4/7)

### DIFF
--- a/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
@@ -158,11 +158,14 @@ export const PriorityFallback: Story = {
   },
 };
 
-/** Gallery of `type × variant` combinations applied to identical 1×1 tiles. */
+/** Gallery of `type × variant` combinations. `cols: 6` keeps each chrome
+ *  `type` on its own row (6 variants across) so the rows read as
+ *  filled / outlined / elevated / ghost top-to-bottom. Elevated tiles
+ *  carry the variant accent on their text so they don't all look alike. */
 export const ThemeGallery: Story = {
   args: {
     primitives,
-    cols: 4,
+    cols: 6,
     blockMin: 120,
     items: (
       ["filled", "outlined", "elevated", "ghost"] as const
@@ -173,7 +176,7 @@ export const ThemeGallery: Story = {
         key: `${type}-${variant}`,
         desire: { shape: r(1, 1) },
         theme: { type, variant },
-        ui: { type: "Center", label: `${variant}` },
+        ui: { type: "Center", label: `${type} ${variant}` },
       })),
     ) as NotchGridItem[],
   },
@@ -292,14 +295,20 @@ export const CustomShapes: Story = {
   },
 };
 
-/** Outer-grid drag. `draggable` lets the user grab a tile and drop it on
- *  another cell; the dropped item pins to its new spot and everything else
- *  re-flows around it. `onItemMove` reports the new `[col, row]`. */
+/** Outer-grid drag over the same rich notched footprints as `CustomShapes`:
+ *  grab any top-level tile (incl. L-hero, plus, chart, diagonal, and the
+ *  sub-item panel) and drop it on another cell — it pins to the new spot and
+ *  everything else re-flows around it. `onItemMove` reports the new
+ *  `[col, row]`.
+ *
+ *  NOTE: dragging a *sub-item* out of the panel (promote-to-outer) and
+ *  dragging the panel chrome itself are the next slice (re-targeted from
+ *  closed PRs #193 / #194) — not wired in this story yet. */
 export const Draggable: Story = {
   args: {
     primitives,
-    cols: 6,
-    blockMin: 120,
+    cols: 8,
+    blockMin: 96,
     draggable: true,
     onItemMove: (key, pos) => {
       // eslint-disable-next-line no-console
@@ -307,40 +316,43 @@ export const Draggable: Story = {
     },
     items: [
       {
-        key: "hero",
-        desire: { shape: r(2, 2) },
+        key: "L",
+        desire: { position: [0, 0], shape: m([1, 1, 1], [1, 1, 1], [1, 1, 0]) },
         theme: { type: "filled", variant: "primary" },
-        ui: { type: "Label", label: "Drag me", value: "★" },
+        ui: { type: "Label", label: "L-hero", value: "drag me" },
       },
       {
-        key: "a",
-        desire: { shape: r(1, 1) },
-        theme: { type: "filled", variant: "secondary" },
-        ui: { type: "Label", label: "A" },
-      },
-      {
-        key: "b",
-        desire: { shape: r(1, 1) },
+        key: "plus",
+        desire: { position: [3, 0], shape: m([0, 1, 0], [1, 1, 1], [0, 1, 0]) },
         theme: { type: "filled", variant: "tertiary" },
-        ui: { type: "Label", label: "B" },
+        ui: { type: "Center", label: "✚" },
       },
       {
-        key: "c",
-        desire: { shape: r(1, 1) },
-        theme: { type: "outlined", variant: "neutral" },
-        ui: { type: "Label", label: "C" },
+        key: "chart",
+        desire: { position: [6, 0], shape: m([1, 1, 0], [1, 1, 1]) },
+        theme: { type: "elevated", variant: "secondary" },
+        ui: { type: "Label", label: "Usage", value: "30d" },
       },
       {
-        key: "d",
-        desire: { shape: r(1, 1) },
-        theme: { type: "outlined", variant: "neutral" },
-        ui: { type: "Label", label: "D" },
+        key: "diagonal",
+        desire: { position: [0, 3], shape: m([1, 1, 0], [1, 1, 0], [0, 0, 1]) },
+        theme: { type: "filled", variant: "secondary" },
+        ui: { type: "Label", label: "Diagonal", value: "junction" },
       },
       {
-        key: "wide",
-        desire: { shape: r(2, 1) },
-        theme: { type: "elevated", variant: "neutral" },
-        ui: { type: "Label", label: "Wide", value: "2×1" },
+        key: "panel",
+        desire: { position: [3, 3], shape: r(2, 2) },
+        theme: { type: "filled", variant: "primary" },
+        subItems: [
+          {
+            desire: { position: [0, 0], shape: r(1, 1) },
+            ui: { type: "Label", label: "Cron", value: "8/d" },
+          },
+          {
+            desire: { position: [1, 1], shape: r(1, 1) },
+            ui: { type: "Label", label: "Calls", value: "1.2k" },
+          },
+        ],
       },
     ] satisfies NotchGridItem[],
   },

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
@@ -6,7 +6,7 @@ import {
 } from "./NotchGrid";
 
 const meta: Meta<typeof NotchGrid> = {
-  title: "UI/Surfaces/NotchGrid",
+  title: "UI/Notch/NotchGrid",
   component: NotchGrid,
   parameters: {
     layout: "fullscreen",

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
@@ -1,0 +1,253 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  NotchGrid,
+  type NotchGridItem,
+  type PrimitiveRegistry,
+} from "./NotchGrid";
+
+const meta: Meta<typeof NotchGrid> = {
+  title: "UI/Surfaces/NotchGrid",
+  component: NotchGrid,
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof NotchGrid>;
+
+// --- Demo primitives -------------------------------------------------------
+
+type LabelProps = { label?: string; value?: string | number };
+const Label = ({ label, value }: LabelProps) => (
+  <div className="flex h-full w-full flex-col justify-between p-1">
+    <div className="text-xs opacity-75">{label}</div>
+    <div className="text-xl font-semibold">{value}</div>
+  </div>
+);
+
+type CenterProps = { children?: React.ReactNode; label?: string };
+const Center = ({ label, children }: CenterProps) => (
+  <div className="flex h-full w-full items-center justify-center text-sm font-medium">
+    {children ?? label}
+  </div>
+);
+
+const primitives: PrimitiveRegistry = {
+  Label: Label as unknown as PrimitiveRegistry[string],
+  Center: Center as unknown as PrimitiveRegistry[string],
+};
+
+// --- Shape helpers (1/0 → boolean mask) -----------------------------------
+
+const m = (...rows: ReadonlyArray<ReadonlyArray<0 | 1>>) =>
+  rows.map((r) => r.map((v) => v === 1));
+const r = (cols: number, rows: number) =>
+  Array.from({ length: rows }, () => Array<boolean>(cols).fill(true));
+
+// --- Stories ---------------------------------------------------------------
+
+export const Basic: Story = {
+  args: {
+    primitives,
+    items: [
+      {
+        key: "hero",
+        desire: { shape: r(2, 2) },
+        theme: { type: "filled", variant: "primary" },
+        ui: { type: "Label", label: "Hero", value: "42" },
+      },
+      {
+        key: "users",
+        desire: { shape: r(1, 1) },
+        theme: { type: "filled", variant: "secondary" },
+        ui: { type: "Label", label: "Users", value: "1,204" },
+      },
+      {
+        key: "events",
+        desire: { shape: r(1, 1) },
+        theme: { type: "filled", variant: "tertiary" },
+        ui: { type: "Label", label: "Events", value: "8.3k" },
+      },
+      {
+        key: "uptime",
+        desire: { shape: r(2, 1) },
+        theme: { type: "outlined", variant: "neutral" },
+        ui: { type: "Label", label: "Uptime", value: "99.94%" },
+      },
+    ] satisfies NotchGridItem[],
+  },
+};
+
+/** Demonstrates the >96px gain-1-col / 1fr rule: items naturally fill the
+ *  container regardless of width. Resize the Storybook canvas to see the
+ *  column count jump (96px granularity) and the block size stretch between
+ *  jumps. */
+export const AutoSize: Story = {
+  args: {
+    primitives,
+    items: Array.from({ length: 12 }, (_, i) => ({
+      key: `t${i}`,
+      desire: { shape: r(1, 1) },
+      theme: {
+        type: "filled" as const,
+        variant: (
+          ["primary", "secondary", "tertiary", "neutral"] as const
+        )[i % 4],
+      },
+      ui: { type: "Label", label: `#${i + 1}`, value: i + 1 },
+    })),
+  },
+};
+
+/** Sub-items inside a single themed panel. The panel's footprint is the
+ *  union of the sub-items' masks (so notches appear where no sub-cell sits). */
+export const SubItems: Story = {
+  args: {
+    primitives,
+    items: [
+      {
+        key: "panel",
+        desire: { shape: r(3, 3) },
+        theme: { type: "filled", variant: "primary" },
+        subItems: [
+          {
+            desire: { position: [0, 0], shape: r(2, 2) },
+            ui: { type: "Label", label: "Big", value: "★" },
+          },
+          {
+            desire: { position: [2, 0], shape: r(1, 1) },
+            ui: { type: "Label", label: "A" },
+          },
+          {
+            desire: { position: [0, 2], shape: r(2, 1) },
+            ui: { type: "Label", label: "Wide" },
+          },
+          {
+            desire: { position: [2, 2], shape: r(1, 1) },
+            ui: { type: "Label", label: "B" },
+          },
+        ],
+      },
+    ] satisfies NotchGridItem[],
+  },
+};
+
+/** Priority-mapped position: each tile prefers (0,0), but only the first to
+ *  claim it lands there. Others fall back to their secondary positions. */
+export const PriorityFallback: Story = {
+  args: {
+    primitives,
+    items: [
+      {
+        key: "first",
+        desire: { position: [0, 0], shape: r(2, 2) },
+        theme: { type: "filled", variant: "primary" },
+        ui: { type: "Label", label: "First", value: "wins (0,0)" },
+      },
+      {
+        key: "second",
+        desire: {
+          position: { "0": [0, 0], "1": [2, 0] },
+          shape: r(2, 2),
+        },
+        theme: { type: "filled", variant: "secondary" },
+        ui: { type: "Label", label: "Second", value: "falls to (2,0)" },
+      },
+    ] satisfies NotchGridItem[],
+  },
+};
+
+/** Gallery of `type × variant` combinations applied to identical 1×1 tiles. */
+export const ThemeGallery: Story = {
+  args: {
+    primitives,
+    cols: 4,
+    blockMin: 120,
+    items: (
+      ["filled", "outlined", "elevated", "ghost"] as const
+    ).flatMap((type) =>
+      (
+        ["primary", "secondary", "tertiary", "neutral", "warn", "error"] as const
+      ).map((variant) => ({
+        key: `${type}-${variant}`,
+        desire: { shape: r(1, 1) },
+        theme: { type, variant },
+        ui: { type: "Center", label: `${variant}` },
+      })),
+    ) as NotchGridItem[],
+  },
+};
+
+/** Unknown `ui.type` fires `onItemError` and renders an in-tile placeholder
+ *  so the layout doesn't collapse. The renderer can then drive the
+ *  L3 agent-sidebar flow (see dynamic-ui TBD 04 L3). */
+export const UnknownPrimitive: Story = {
+  args: {
+    primitives,
+    onItemError: (key, error) => {
+      // eslint-disable-next-line no-console
+      console.warn("[NotchGrid story] onItemError:", key, error);
+    },
+    items: [
+      {
+        key: "known",
+        desire: { shape: r(1, 1) },
+        theme: { type: "filled", variant: "primary" },
+        ui: { type: "Label", label: "OK" },
+      },
+      {
+        key: "broken",
+        desire: { shape: r(2, 2) },
+        theme: { type: "outlined", variant: "error" },
+        ui: { type: "DoesNotExist" },
+      },
+    ] satisfies NotchGridItem[],
+  },
+};
+
+/** The architecture doc's overview-page example, adapted: an L-shaped hero,
+ *  a sub-item panel with mixed sizes, and a few accessory tiles. */
+export const OverviewPage: Story = {
+  args: {
+    primitives,
+    items: [
+      {
+        key: "hero",
+        desire: {
+          position: [0, 0],
+          shape: m([1, 1, 1], [1, 1, 1], [1, 1, 0]),
+        },
+        theme: { type: "filled", variant: "primary" },
+        ui: { type: "Label", label: "Module", value: "MirrorStack" },
+      },
+      {
+        key: "installs",
+        desire: { position: [2, 2], shape: r(1, 1) },
+        theme: { type: "outlined", variant: "primary" },
+        ui: { type: "Label", label: "Installs", value: "12" },
+      },
+      {
+        key: "panel",
+        desire: { position: [3, 0], shape: r(2, 3) },
+        theme: { type: "filled", variant: "tertiary" },
+        subItems: [
+          {
+            desire: { position: [0, 0], shape: r(1, 1) },
+            ui: { type: "Label", label: "Cron", value: "8/d" },
+          },
+          {
+            desire: { position: [0, 1], shape: r(2, 2) },
+            ui: { type: "Label", label: "Calls × markup", value: "$420" },
+          },
+        ],
+      },
+      {
+        key: "tenants",
+        desire: { position: [0, 3], shape: r(1, 1) },
+        theme: { type: "elevated", variant: "neutral" },
+        ui: { type: "Label", label: "Tenants", value: "47" },
+      },
+    ] satisfies NotchGridItem[],
+  },
+};

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
@@ -179,33 +179,6 @@ export const ThemeGallery: Story = {
   },
 };
 
-/** Unknown `ui.type` fires `onItemError` and renders an in-tile placeholder
- *  so the layout doesn't collapse. The renderer can then drive the
- *  L3 agent-sidebar flow (see dynamic-ui TBD 04 L3). */
-export const UnknownPrimitive: Story = {
-  args: {
-    primitives,
-    onItemError: (key, error) => {
-      // eslint-disable-next-line no-console
-      console.warn("[NotchGrid story] onItemError:", key, error);
-    },
-    items: [
-      {
-        key: "known",
-        desire: { shape: r(1, 1) },
-        theme: { type: "filled", variant: "primary" },
-        ui: { type: "Label", label: "OK" },
-      },
-      {
-        key: "broken",
-        desire: { shape: r(2, 2) },
-        theme: { type: "outlined", variant: "error" },
-        ui: { type: "DoesNotExist" },
-      },
-    ] satisfies NotchGridItem[],
-  },
-};
-
 /** Custom notched shapes — exercises the outline tracer (PR #188) under
  *  non-rectangular footprints. Demonstrates the four canonical patterns the
  *  closed v1 stack used: L (corner notch), plus, T, and a 4×2 chart with a
@@ -319,47 +292,55 @@ export const CustomShapes: Story = {
   },
 };
 
-/** The architecture doc's overview-page example, adapted: an L-shaped hero,
- *  a sub-item panel with mixed sizes, and a few accessory tiles. */
-export const OverviewPage: Story = {
+/** Outer-grid drag. `draggable` lets the user grab a tile and drop it on
+ *  another cell; the dropped item pins to its new spot and everything else
+ *  re-flows around it. `onItemMove` reports the new `[col, row]`. */
+export const Draggable: Story = {
   args: {
     primitives,
+    cols: 6,
+    blockMin: 120,
+    draggable: true,
+    onItemMove: (key, pos) => {
+      // eslint-disable-next-line no-console
+      console.log("[NotchGrid story] drop:", key, pos);
+    },
     items: [
       {
         key: "hero",
-        desire: {
-          position: [0, 0],
-          shape: m([1, 1, 1], [1, 1, 1], [1, 1, 0]),
-        },
+        desire: { shape: r(2, 2) },
         theme: { type: "filled", variant: "primary" },
-        ui: { type: "Label", label: "Module", value: "MirrorStack" },
+        ui: { type: "Label", label: "Drag me", value: "★" },
       },
       {
-        key: "installs",
-        desire: { position: [2, 2], shape: r(1, 1) },
-        theme: { type: "outlined", variant: "primary" },
-        ui: { type: "Label", label: "Installs", value: "12" },
+        key: "a",
+        desire: { shape: r(1, 1) },
+        theme: { type: "filled", variant: "secondary" },
+        ui: { type: "Label", label: "A" },
       },
       {
-        key: "panel",
-        desire: { position: [3, 0], shape: r(2, 3) },
+        key: "b",
+        desire: { shape: r(1, 1) },
         theme: { type: "filled", variant: "tertiary" },
-        subItems: [
-          {
-            desire: { position: [0, 0], shape: r(1, 1) },
-            ui: { type: "Label", label: "Cron", value: "8/d" },
-          },
-          {
-            desire: { position: [0, 1], shape: r(2, 2) },
-            ui: { type: "Label", label: "Calls × markup", value: "$420" },
-          },
-        ],
+        ui: { type: "Label", label: "B" },
       },
       {
-        key: "tenants",
-        desire: { position: [0, 3], shape: r(1, 1) },
+        key: "c",
+        desire: { shape: r(1, 1) },
+        theme: { type: "outlined", variant: "neutral" },
+        ui: { type: "Label", label: "C" },
+      },
+      {
+        key: "d",
+        desire: { shape: r(1, 1) },
+        theme: { type: "outlined", variant: "neutral" },
+        ui: { type: "Label", label: "D" },
+      },
+      {
+        key: "wide",
+        desire: { shape: r(2, 1) },
         theme: { type: "elevated", variant: "neutral" },
-        ui: { type: "Label", label: "Tenants", value: "47" },
+        ui: { type: "Label", label: "Wide", value: "2×1" },
       },
     ] satisfies NotchGridItem[],
   },

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
@@ -298,6 +298,23 @@ export const CustomShapes: Story = {
         theme: { type: "filled", variant: "primary" },
         ui: { type: "Label", label: "Now" },
       },
+
+      // Diagonal junction — a 2×2 block and a 1×1 block meet only at a
+      // corner. Exercises the outline tracer's diagonal-junction handling
+      // (the two regions read as one shape with two concave arcs facing
+      // each other, per PR #188).
+      //   o o x
+      //   o o x
+      //   x x o
+      {
+        key: "diagonal",
+        desire: {
+          position: [0, 5],
+          shape: m([1, 1, 0], [1, 1, 0], [0, 0, 1]),
+        },
+        theme: { type: "filled", variant: "secondary" },
+        ui: { type: "Label", label: "Diagonal", value: "junction" },
+      },
     ] satisfies NotchGridItem[],
   },
 };

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.stories.tsx
@@ -206,6 +206,102 @@ export const UnknownPrimitive: Story = {
   },
 };
 
+/** Custom notched shapes — exercises the outline tracer (PR #188) under
+ *  non-rectangular footprints. Demonstrates the four canonical patterns the
+ *  closed v1 stack used: L (corner notch), plus, T, and a 4×2 chart with a
+ *  notched top-right corner. Small accessory tiles drop into the notches. */
+export const CustomShapes: Story = {
+  args: {
+    primitives,
+    cols: 8,
+    blockMin: 96,
+    items: [
+      // L-hero (3×3 with bottom-right corner notched out)
+      {
+        key: "L",
+        desire: {
+          position: [0, 0],
+          shape: m([1, 1, 1], [1, 1, 1], [1, 1, 0]),
+        },
+        theme: { type: "filled", variant: "primary" },
+        ui: { type: "Label", label: "L-hero", value: "3×3 − ⌐" },
+      },
+      // 1×1 dropping into L's bottom-right notch (col 2, row 2)
+      {
+        key: "L-notch-fill",
+        desire: { position: [2, 2], shape: r(1, 1) },
+        theme: { type: "outlined", variant: "primary" },
+        ui: { type: "Label", label: "Nestled" },
+      },
+
+      // Plus shape (4 corner notches)
+      {
+        key: "plus",
+        desire: {
+          position: [3, 0],
+          shape: m([0, 1, 0], [1, 1, 1], [0, 1, 0]),
+        },
+        theme: { type: "filled", variant: "tertiary" },
+        ui: { type: "Center", label: "✚" },
+      },
+      // 1×1s dropping into the plus's four corner notches
+      {
+        key: "p-tl",
+        desire: { position: [3, 0], shape: r(1, 1) },
+        theme: { type: "filled", variant: "secondary" },
+        ui: { type: "Label", label: "↖" },
+      },
+      {
+        key: "p-tr",
+        desire: { position: [5, 0], shape: r(1, 1) },
+        theme: { type: "filled", variant: "secondary" },
+        ui: { type: "Label", label: "↗" },
+      },
+      {
+        key: "p-bl",
+        desire: { position: [3, 2], shape: r(1, 1) },
+        theme: { type: "filled", variant: "secondary" },
+        ui: { type: "Label", label: "↙" },
+      },
+      {
+        key: "p-br",
+        desire: { position: [5, 2], shape: r(1, 1) },
+        theme: { type: "filled", variant: "secondary" },
+        ui: { type: "Label", label: "↘" },
+      },
+
+      // T shape (3×2 with the bottom corners notched out)
+      {
+        key: "T",
+        desire: {
+          position: [0, 3],
+          shape: m([1, 1, 1], [0, 1, 0]),
+        },
+        theme: { type: "outlined", variant: "neutral" },
+        ui: { type: "Center", label: "T" },
+      },
+
+      // 4×2 chart with notched top-right corner (the closed PR's chart shape)
+      {
+        key: "chart",
+        desire: {
+          position: [4, 3],
+          shape: m([1, 1, 1, 0], [1, 1, 1, 1]),
+        },
+        theme: { type: "filled", variant: "tertiary" },
+        ui: { type: "Label", label: "Usage", value: "30d" },
+      },
+      // 1×1 dropping into the chart's top-right notch
+      {
+        key: "chart-notch",
+        desire: { position: [7, 3], shape: r(1, 1) },
+        theme: { type: "filled", variant: "primary" },
+        ui: { type: "Label", label: "Now" },
+      },
+    ] satisfies NotchGridItem[],
+  },
+};
+
 /** The architecture doc's overview-page example, adapted: an L-shaped hero,
  *  a sub-item panel with mixed sizes, and a few accessory tiles. */
 export const OverviewPage: Story = {

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.test.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.test.tsx
@@ -1,0 +1,156 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { NotchGrid, type NotchGridItem, type PrimitiveRegistry } from "./NotchGrid";
+
+afterEach(cleanup);
+
+// jsdom doesn't ship ResizeObserver. Stub it to fire once with the wrapper's
+// width — Element.getBoundingClientRect is also stubbed below.
+beforeAll(() => {
+  type Cb = (entries: ResizeObserverEntry[], obs: ResizeObserver) => void;
+  class StubResizeObserver {
+    constructor(_cb: Cb) {}
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  (globalThis as unknown as { ResizeObserver: typeof StubResizeObserver }).ResizeObserver =
+    StubResizeObserver;
+
+  // Fixed width so the gain-1-col rule resolves deterministically.
+  const orig = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = function () {
+    const r = orig.call(this);
+    return { ...r, width: 480 } as DOMRect;
+  };
+});
+
+const M = (cols: number, rows: number) =>
+  Array.from({ length: rows }, () => Array<boolean>(cols).fill(true));
+
+describe("NotchGrid", () => {
+  it("renders an empty grid without crashing", () => {
+    const { container } = render(<NotchGrid items={[]} />);
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it("places a single item inside the wrapper", () => {
+    const items: NotchGridItem[] = [
+      { key: "a", desire: { shape: M(2, 2) } },
+    ];
+    const { container } = render(<NotchGrid items={items} />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper).toBeTruthy();
+    const tiles = wrapper.querySelectorAll(":scope > div");
+    expect(tiles.length).toBeGreaterThan(0);
+  });
+
+  it("respects cols when explicit (gain-1-col rule bypassed)", () => {
+    const items: NotchGridItem[] = [
+      { key: "a", desire: { position: [0, 0], shape: M(1, 1) } },
+      { key: "b", desire: { position: [3, 0], shape: M(1, 1) } },
+    ];
+    const { container } = render(<NotchGrid items={items} cols={4} blockMin={120} />);
+    const tiles = container.querySelectorAll(":scope > div > div");
+    expect(tiles.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders a registered primitive from the items' ui.type", () => {
+    const HelloTile = (props: { greeting?: string }) => (
+      <div data-testid="hello">{props.greeting ?? "hi"}</div>
+    );
+    const primitives: PrimitiveRegistry = {
+      Hello: HelloTile as unknown as PrimitiveRegistry[string],
+    };
+    const items: NotchGridItem[] = [
+      {
+        key: "a",
+        desire: { shape: M(2, 2) },
+        ui: { type: "Hello", greeting: "world" },
+      },
+    ];
+    const { getByTestId } = render(
+      <NotchGrid items={items} primitives={primitives} />,
+    );
+    expect(getByTestId("hello").textContent).toBe("world");
+  });
+
+  it("fires onItemError for unknown ui.type and renders the placeholder", () => {
+    const onItemError = vi.fn();
+    const items: NotchGridItem[] = [
+      {
+        key: "x",
+        desire: { shape: M(2, 2) },
+        ui: { type: "Mystery" },
+      },
+    ];
+    const { container } = render(
+      <NotchGrid items={items} onItemError={onItemError} />,
+    );
+    expect(onItemError).toHaveBeenCalledWith("x", {
+      kind: "unknown-primitive",
+      type: "Mystery",
+    });
+    expect(container.textContent).toContain("Mystery");
+  });
+
+  it("assigns synthetic keys when items omit `key`", () => {
+    const items: NotchGridItem[] = [
+      { desire: { shape: M(1, 1) } },
+      { desire: { shape: M(1, 1) } },
+    ];
+    const { container } = render(<NotchGrid items={items} />);
+    const tiles = container.querySelectorAll(":scope > div > div");
+    expect(tiles.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders sub-items as nested tiles inside the parent's content area", () => {
+    const Leaf = (props: { tag?: string }) => (
+      <div data-testid="leaf">{props.tag}</div>
+    );
+    const primitives: PrimitiveRegistry = {
+      Leaf: Leaf as unknown as PrimitiveRegistry[string],
+    };
+    const items: NotchGridItem[] = [
+      {
+        key: "panel",
+        desire: { shape: M(2, 2) },
+        subItems: [
+          { desire: { shape: M(1, 1) }, ui: { type: "Leaf", tag: "a" } },
+          { desire: { shape: M(1, 1) }, ui: { type: "Leaf", tag: "b" } },
+        ],
+      },
+    ];
+    const { getAllByTestId } = render(
+      <NotchGrid items={items} primitives={primitives} />,
+    );
+    const leaves = getAllByTestId("leaf");
+    expect(leaves).toHaveLength(2);
+    expect(leaves.map((l) => l.textContent)).toEqual(["a", "b"]);
+  });
+
+  it("applies inline color from resolved theme (variant=primary)", () => {
+    const items: NotchGridItem[] = [
+      {
+        key: "a",
+        desire: { shape: M(2, 2) },
+        theme: { type: "filled", variant: "primary" },
+      },
+    ];
+    const { container } = render(<NotchGrid items={items} />);
+    const tile = container.querySelector(":scope > div > div") as HTMLElement;
+    expect(tile.style.color).toBe("var(--color-on-primary-container)");
+  });
+
+  it("fixed `cols` uses blockMin as the literal block size", () => {
+    const items: NotchGridItem[] = [
+      { key: "a", desire: { position: [0, 0], shape: M(1, 1) } },
+    ];
+    const { container } = render(
+      <NotchGrid items={items} cols={3} blockMin={100} />,
+    );
+    const tile = container.querySelector(":scope > div > div") as HTMLElement;
+    expect(tile.style.left).toBe("0px");
+    expect(tile.style.top).toBe("0px");
+  });
+});

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.test.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.test.tsx
@@ -153,4 +153,32 @@ describe("NotchGrid", () => {
     expect(tile.style.left).toBe("0px");
     expect(tile.style.top).toBe("0px");
   });
+
+  it("draggable: cursor=grab on tiles, no drag handlers when omitted", () => {
+    const items: NotchGridItem[] = [
+      { key: "a", desire: { shape: M(1, 1) } },
+    ];
+
+    // Without draggable: no cursor styling
+    const { container: plain } = render(
+      <NotchGrid items={items} cols={2} blockMin={100} />,
+    );
+    const plainTile = plain.querySelector(":scope > div > div") as HTMLElement;
+    expect(plainTile.style.cursor).toBe("");
+
+    // With draggable: cursor=grab
+    cleanup();
+    const { container: drag } = render(
+      <NotchGrid items={items} cols={2} blockMin={100} draggable />,
+    );
+    const dragTile = drag.querySelector(":scope > div > div") as HTMLElement;
+    expect(dragTile.style.cursor).toBe("grab");
+  });
+
+  // Full pointerDown → move → up drag flow isn't exercised here because
+  // jsdom's `fireEvent.pointer*` drops PointerEvent init properties
+  // (clientX/Y, button, pointerId all come through as `undefined`), so
+  // dx/dy resolves to NaN. The `cursor=grab` test above is the wiring
+  // smoke check; visual end-to-end verification lives in the `Draggable`
+  // story.
 });

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.test.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.test.tsx
@@ -104,7 +104,7 @@ describe("NotchGrid", () => {
     expect(tiles.length).toBeGreaterThanOrEqual(2);
   });
 
-  it("renders sub-items as nested tiles inside the parent's content area", () => {
+  it("renders sub-items as content within a single unified panel chrome", () => {
     const Leaf = (props: { tag?: string }) => (
       <div data-testid="leaf">{props.tag}</div>
     );
@@ -116,17 +116,21 @@ describe("NotchGrid", () => {
         key: "panel",
         desire: { shape: M(2, 2) },
         subItems: [
-          { desire: { shape: M(1, 1) }, ui: { type: "Leaf", tag: "a" } },
-          { desire: { shape: M(1, 1) }, ui: { type: "Leaf", tag: "b" } },
+          { desire: { position: [0, 0], shape: M(1, 1) }, ui: { type: "Leaf", tag: "a" } },
+          { desire: { position: [1, 1], shape: M(1, 1) }, ui: { type: "Leaf", tag: "b" } },
         ],
       },
     ];
-    const { getAllByTestId } = render(
-      <NotchGrid items={items} primitives={primitives} />,
+    const { getAllByTestId, container } = render(
+      <NotchGrid items={items} primitives={primitives} cols={4} blockMin={100} />,
     );
+    // Both sub-items render their content...
     const leaves = getAllByTestId("leaf");
     expect(leaves).toHaveLength(2);
     expect(leaves.map((l) => l.textContent)).toEqual(["a", "b"]);
+    // ...but as ONE chrome (one BlockShape svg), not one per sub-item. The
+    // two diagonal sub-items bridge into a single unioned outline.
+    expect(container.querySelectorAll("svg")).toHaveLength(1);
   });
 
   it("applies inline color from resolved theme (variant=primary)", () => {

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -272,17 +272,16 @@ function NotchItem({
     }
   }, [unknownPrimitive, onItemError, placement.key, item.ui]);
 
-  // The wrapper carries placement + non-BlockShape theme bits (text color,
-  // drop-shadow filter for elevated chromes — traces the SVG path rather
-  // than the bounding box — and optional border-left color cue for
-  // elevated warn/error).
+  // The wrapper carries placement + the drop-shadow filter for elevated
+  // chromes (traces the SVG path rather than the bounding box). The
+  // accent-bar color cue for elevated warn/error is rendered inside the
+  // BlockShape so it sits within the clipped chrome, not outside it.
   const wrapperStyle: CSSProperties = {
     position: "absolute",
     left: placement.col * block,
     top: placement.row * block,
     color: resolved.color,
     ...(resolved.filter !== "none" ? { filter: resolved.filter } : {}),
-    ...(resolved.borderLeft ? { borderLeft: resolved.borderLeft } : {}),
   };
 
   // Gradient backgrounds (`linear-gradient(...)`) aren't valid SVG `fill`
@@ -303,6 +302,13 @@ function NotchItem({
         strokeWidth={strokeWidth}
         pad={subLayout ? 0 : 16}
       >
+        {resolved.accentBar && (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute top-2 bottom-2 left-2 w-1 rounded-full"
+            style={{ background: resolved.accentBar }}
+          />
+        )}
         {subLayout ? (
           <div className="relative h-full w-full">
             {subLayout.placements.map((sp) => (

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -1,18 +1,20 @@
 // NotchGrid — desire-driven notched layout for the dynamic-ui wire format.
 //
-// Items declare position / shape priorities; `solveLayout` packs them;
-// each placement renders as a `BlockShape` themed via `resolveNotchTheme`.
-// No drag in this slice — that's PRs 5–7.
+// Items declare position / shape priorities; `solveLayout` packs them; each
+// placement renders as a `BlockShape` themed via `resolveNotchTheme`.
 //
-// Container sizing: when `cols="auto"` (default), a ResizeObserver measures
-// the wrapper width and applies the >96px-gain-1-col rule —
-//   `cols = max(1, floor(containerWidth / blockMin))` and
+// Container sizing (when `cols="auto"`): a ResizeObserver applies the
+// >blockMin-gain-1-col rule —
+//   `cols = max(1, floor(containerWidth / blockMin))`
 //   `block = containerWidth / cols`
-// so the surface never leaves dead space at the edges.
+// so the surface never leaves dead space at the edges, and block size lives
+// in `[blockMin, 2·blockMin)`.
 //
 // See `mirrorstack-docs/architecture/notch-grid-v2/02-api.md`.
 
 import {
+  memo,
+  useCallback,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -20,6 +22,8 @@ import {
   useState,
   type ComponentType,
   type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
 } from "react";
 import { cn } from "@/utils/cn";
 import { isDev } from "@/utils/env";
@@ -30,6 +34,7 @@ import {
   type Desire,
   type Mask,
   type Placement,
+  type Pos,
 } from "./layout";
 import { resolveNotchTheme, type NotchTheme } from "./theme";
 
@@ -59,7 +64,7 @@ export interface NotchGridItem {
   desire: Desire;
   theme?: NotchTheme;
   /** Reserved — adjacency auto-link by `groupKey`. Renders as separate
-   *  chromes in PR 4; unified chrome lands in PR 6. */
+   *  chromes today; unified chrome via union-of-masks lands in a later slice. */
   groupKey?: string;
   /** Either `ui` (single primitive content) or `subItems` (nested panel). */
   ui?: NotchGridUI;
@@ -99,31 +104,41 @@ export interface NotchGridProps {
    *  layout doesn't collapse. */
   primitives?: PrimitiveRegistry;
   onItemError?: (key: ItemKey, error: NotchGridError) => void;
+  /** Enable outer-grid drag-to-place. Dropped items pin to their new cell
+   *  (winning the cell on next solve); everything else re-flows around them. */
+  draggable?: boolean;
+  /** Called after a drag drops an item, with its new block position. */
+  onItemMove?: (key: ItemKey, pos: Pos) => void;
   className?: string;
   style?: CSSProperties;
 }
 
 // --- Internal helpers ------------------------------------------------------
 
-/** Convert a boolean mask to BlockShape's tier-encoded shape matrix (0/1). */
 function maskToShape(mask: Mask): number[][] {
   return mask.map((row) => row.map((v) => (v ? 1 : 0)));
 }
 
-/** Parse `resolveNotchTheme().border` ("none" or "Npx solid var(--…)") into
- *  BlockShape's `stroke` + `strokeWidth` props. */
-function parseBorder(border: string): { stroke: string; strokeWidth: number } {
-  if (border === "none") return { stroke: "none", strokeWidth: 0 };
-  const m = border.match(/^(\d+)px\s+solid\s+(.+)$/);
-  if (m) return { stroke: m[2], strokeWidth: Number(m[1]) };
-  return { stroke: border, strokeWidth: 1 };
+/** Assign synthetic keys to items missing one. Returns the same array when
+ *  every item already has a key (preserves referential equality for memos). */
+function assignKeys(items: NotchGridItem[]): NotchGridItem[] {
+  if (items.every((it) => it.key != null)) return items;
+  return items.map((it, i) => (it.key ? it : { ...it, key: `item-${i}` }));
 }
 
-/** Assign synthetic keys to items missing one. Stable across re-renders for
- *  the same input order; matches the design doc's open question 2.1 lean
- *  (sequential, at parse). */
-function assignKeys(items: NotchGridItem[]): NotchGridItem[] {
-  return items.map((it, i) => (it.key ? it : { ...it, key: `item-${i}` }));
+interface DragState {
+  key: ItemKey;
+  pointerId: number;
+  startX: number;
+  startY: number;
+  /** Origin position in block units (where the item sits at drag start). */
+  originCol: number;
+  originRow: number;
+  /** Footprint width in blocks (to clamp the dropped column). */
+  originCols: number;
+  /** Live pointer delta in px. */
+  dx: number;
+  dy: number;
 }
 
 // --- Component -------------------------------------------------------------
@@ -136,6 +151,8 @@ export function NotchGrid({
   nest = true,
   primitives,
   onItemError,
+  draggable = false,
+  onItemMove,
   className,
   style,
 }: NotchGridProps) {
@@ -155,7 +172,6 @@ export function NotchGrid({
 
   const keyedItems = useMemo(() => assignKeys(items), [items]);
 
-  // Compute cols + block size. Auto: gain-1-col rule + 1fr distribution.
   const { resolvedCols, block } = useMemo(() => {
     if (cols !== "auto") return { resolvedCols: cols, block: blockMin };
     if (containerWidth == null) return { resolvedCols: null as number | null, block: blockMin };
@@ -163,26 +179,75 @@ export function NotchGrid({
     return { resolvedCols: c, block: containerWidth / c };
   }, [cols, blockMin, containerWidth]);
 
-  // Solve layout once cols are known.
+  // Drag-to-place: positions the user has dropped items at (pinned) + the
+  // live drag offset for visual feedback. Overrides drive a re-solve;
+  // `drag` is paint-only state during the pointer sequence.
+  const [overrides, setOverrides] = useState<Map<ItemKey, Pos>>(new Map());
+  const [drag, setDrag] = useState<DragState | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+  dragRef.current = drag;
+
+  const handlePointerMove = useCallback((e: ReactPointerEvent) => {
+    const d = dragRef.current;
+    if (!d || e.pointerId !== d.pointerId) return;
+    const dx = e.clientX - d.startX;
+    const dy = e.clientY - d.startY;
+    // Skip the no-op spread + re-render when the pointer hasn't actually moved.
+    if (dx === d.dx && dy === d.dy) return;
+    setDrag({ ...d, dx, dy });
+  }, []);
+
+  const handlePointerEnd = useCallback(
+    (e: ReactPointerEvent) => {
+      const d = dragRef.current;
+      if (!d || e.pointerId !== d.pointerId) return;
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        /* pointer may already be released */
+      }
+      setDrag(null);
+      const blockPx = block || blockMin;
+      const colCount = resolvedCols ?? 1;
+      const maxCol = Math.max(0, colCount - d.originCols);
+      const nextCol = Math.min(maxCol, Math.max(0, d.originCol + Math.round(d.dx / blockPx)));
+      const nextRow = Math.max(0, d.originRow + Math.round(d.dy / blockPx));
+      const pos: Pos = [nextCol, nextRow];
+      setOverrides((prev) => new Map(prev).set(d.key, pos));
+      onItemMove?.(d.key, pos);
+    },
+    [block, blockMin, resolvedCols, onItemMove],
+  );
+
+  // Items with an override get their desire.position rewritten — that promotes
+  // them to the solver's fixed-position fast path so they win their cell on
+  // the next solve.
   const layout = useMemo(() => {
     if (resolvedCols == null) return null;
     return solveLayout({
-      items: keyedItems.map((it) => ({
-        key: it.key!,
-        desire: it.desire,
-        groupKey: it.groupKey,
-        item: it,
-      })),
+      items: keyedItems.map((it) => {
+        const ov = overrides.get(it.key!);
+        return {
+          key: it.key!,
+          desire: ov ? { ...it.desire, position: ov } : it.desire,
+          groupKey: it.groupKey,
+          item: it,
+        };
+      }),
       cols: resolvedCols,
       nest,
     });
-  }, [keyedItems, resolvedCols, nest]);
+  }, [keyedItems, resolvedCols, nest, overrides]);
 
-  if (isDev && layout && layout.unfit.length > 0) {
-    console.warn(
-      `[NotchGrid] ${layout.unfit.length} item(s) didn't fit: ${layout.unfit.join(", ")}. Mask wider than cols=${resolvedCols}.`,
-    );
-  }
+  // Warn-once-per-distinct-unfit-set, not every paint.
+  const unfitKey = layout?.unfit.join(",") ?? "";
+  useEffect(() => {
+    if (isDev && layout && layout.unfit.length > 0) {
+      console.warn(
+        `[NotchGrid] ${layout.unfit.length} item(s) didn't fit: ${layout.unfit.join(", ")}. Mask wider than cols=${resolvedCols}.`,
+      );
+    }
+  }, [unfitKey, resolvedCols, layout]);
 
   const totalRows = layout?.rowsUsed ?? 0;
 
@@ -191,26 +256,57 @@ export function NotchGrid({
       ref={wrapperRef}
       className={cn("relative w-full", className)}
       style={{
-        // Reserve vertical space pre-paint so the page doesn't reflow when
-        // layout resolves.
         minHeight: totalRows > 0 ? totalRows * block : undefined,
         ...style,
       }}
     >
-      {layout
-        ? layout.placements.map((p) => (
-            <NotchItem
-              key={p.key}
-              placement={p}
-              item={p.item as NotchGridItem}
-              block={block}
-              gap={gap}
-              primitives={primitives}
-              onItemError={onItemError}
-              parentTheme={undefined}
-            />
-          ))
-        : null}
+      {layout?.placements.map((p) => {
+        const isDragging = drag?.key === p.key;
+        const dragOffset: readonly [number, number] | undefined =
+          isDragging && drag ? [drag.dx, drag.dy] : undefined;
+        return (
+          <NotchItem
+            key={p.key}
+            placement={p}
+            item={p.item as NotchGridItem}
+            block={block}
+            gap={gap}
+            primitives={primitives}
+            onItemError={onItemError}
+            parentTheme={undefined}
+            draggable={draggable}
+            dragOffset={dragOffset}
+            hasOverride={overrides.has(p.key)}
+            onDragStart={
+              draggable
+                ? (e) => {
+                    // Ignore secondary buttons when the event reports one
+                    // (jsdom's fireEvent drops it — treat undefined as primary).
+                    if (e.button != null && e.button !== 0) return;
+                    try {
+                      e.currentTarget.setPointerCapture(e.pointerId);
+                    } catch {
+                      /* test envs (jsdom) lack pointer capture */
+                    }
+                    setDrag({
+                      key: p.key,
+                      pointerId: e.pointerId,
+                      startX: e.clientX,
+                      startY: e.clientY,
+                      originCol: p.col,
+                      originRow: p.row,
+                      originCols: p.cols,
+                      dx: 0,
+                      dy: 0,
+                    });
+                  }
+                : undefined
+            }
+            onDragMove={handlePointerMove}
+            onDragEnd={handlePointerEnd}
+          />
+        );
+      })}
     </div>
   );
 }
@@ -226,9 +322,18 @@ interface NotchItemProps {
   onItemError?: (key: ItemKey, error: NotchGridError) => void;
   /** Set when rendered as a sub-item; inherits `type` from the parent panel. */
   parentTheme?: NotchTheme;
+  /** When true, the wrapper accepts pointer events for outer-grid drag. */
+  draggable?: boolean;
+  /** Live `[dx, dy]` in px while this tile is being dragged. */
+  dragOffset?: readonly [number, number];
+  /** True when this tile has a committed drop override (sits above non-pinned). */
+  hasOverride?: boolean;
+  onDragStart?: (e: ReactPointerEvent<HTMLDivElement>) => void;
+  onDragMove?: (e: ReactPointerEvent<HTMLDivElement>) => void;
+  onDragEnd?: (e: ReactPointerEvent<HTMLDivElement>) => void;
 }
 
-function NotchItem({
+const NotchItem = memo(function NotchItem({
   placement,
   item,
   block,
@@ -236,25 +341,33 @@ function NotchItem({
   primitives,
   onItemError,
   parentTheme,
+  draggable = false,
+  dragOffset,
+  hasOverride = false,
+  onDragStart,
+  onDragMove,
+  onDragEnd,
 }: NotchItemProps) {
   // Sub-items inherit `type` from the parent panel; only `variant` and
-  // `gradient` are overridable (design doc rationale: visual coherence).
+  // `gradient` are overridable (visual coherence — a filled panel with an
+  // outlined sub-item looks broken).
   const itemTheme: NotchTheme = parentTheme
     ? { ...item.theme, type: parentTheme.type }
     : item.theme ?? {};
-  const resolved = resolveNotchTheme(itemTheme);
-  const { stroke, strokeWidth } = parseBorder(resolved.border);
+  const resolved = useMemo(() => resolveNotchTheme(itemTheme), [
+    itemTheme.type,
+    itemTheme.variant,
+    itemTheme.gradient,
+  ]);
   const shape = useMemo(() => maskToShape(placement.mask), [placement.mask]);
 
-  // Sub-items: solve inner layout. The sub-grid's col count is the parent's
-  // bounding-box cols; each sub-cell uses the same `block` px size.
   const subLayout = useMemo(() => {
     if (!item.subItems || item.subItems.length === 0) return null;
     return solveLayout({
       items: item.subItems.map((s, i) => ({
         key: s.key ?? `${placement.key}/${i}`,
         desire: s.desire,
-        item: { ...s } as NotchGridItem,
+        item: s as NotchGridItem,
       })),
       cols: placement.cols,
     });
@@ -272,67 +385,85 @@ function NotchItem({
     }
   }, [unknownPrimitive, onItemError, placement.key, item.ui]);
 
-  // The wrapper carries placement + the drop-shadow filter for elevated
-  // chromes (traces the SVG path rather than the bounding box). The
-  // accent-bar color cue for elevated warn/error is rendered inside the
-  // BlockShape so it sits within the clipped chrome, not outside it.
+  const isDragging = dragOffset !== undefined;
   const wrapperStyle: CSSProperties = {
     position: "absolute",
     left: placement.col * block,
     top: placement.row * block,
     color: resolved.color,
-    ...(resolved.filter !== "none" ? { filter: resolved.filter } : {}),
   };
+  if (resolved.filter !== "none") wrapperStyle.filter = resolved.filter;
+  if (isDragging) {
+    wrapperStyle.transform = `translate(${dragOffset[0]}px, ${dragOffset[1]}px)`;
+    wrapperStyle.zIndex = 20;
+  } else if (hasOverride) {
+    wrapperStyle.zIndex = 10;
+  }
+  if (draggable) {
+    wrapperStyle.cursor = isDragging ? "grabbing" : "grab";
+    wrapperStyle.touchAction = "none";
+  }
 
-  // Gradient backgrounds (`linear-gradient(...)`) aren't valid SVG `fill`
-  // values. v1 falls back to the BlockShape's default solid fill when a
-  // gradient is requested. Tracked in the design doc.
-  const fill = resolved.background.startsWith("linear-gradient")
-    ? undefined
-    : resolved.background;
+  const dragHandlers = draggable
+    ? {
+        onPointerDown: onDragStart,
+        onPointerMove: onDragMove,
+        onPointerUp: onDragEnd,
+        onPointerCancel: onDragEnd,
+      }
+    : undefined;
+
+  let content: ReactNode = null;
+  if (subLayout) {
+    content = (
+      <div className="relative h-full w-full">
+        {subLayout.placements.map((sp) => (
+          <NotchItem
+            key={sp.key}
+            placement={sp}
+            item={sp.item as NotchGridItem}
+            block={block}
+            gap={gap}
+            primitives={primitives}
+            onItemError={onItemError}
+            parentTheme={itemTheme}
+          />
+        ))}
+      </div>
+    );
+  } else if (Primitive && item.ui) {
+    content = <Primitive {...item.ui} />;
+  } else if (unknownPrimitive && item.ui) {
+    content = <UnknownPrimitivePlaceholder type={item.ui.type} />;
+  }
 
   return (
-    <div style={wrapperStyle}>
+    <div
+      {...dragHandlers}
+      className={draggable ? "select-none" : undefined}
+      style={wrapperStyle}
+    >
       <BlockShape
         shape={shape}
         block={block}
         gap={gap}
-        fill={fill ?? "transparent"}
-        stroke={stroke}
-        strokeWidth={strokeWidth}
+        fill={resolved.fill}
+        stroke={resolved.stroke}
+        strokeWidth={resolved.strokeWidth}
         pad={subLayout ? 0 : 16}
       >
         {resolved.accentBar && (
           <div
             aria-hidden="true"
-            className="pointer-events-none absolute top-2 bottom-2 left-2 w-1 rounded-full"
+            className="pointer-events-none absolute inset-y-0 left-0 w-1"
             style={{ background: resolved.accentBar }}
           />
         )}
-        {subLayout ? (
-          <div className="relative h-full w-full">
-            {subLayout.placements.map((sp) => (
-              <NotchItem
-                key={sp.key}
-                placement={sp}
-                item={sp.item as NotchGridItem}
-                block={block}
-                gap={gap}
-                primitives={primitives}
-                onItemError={onItemError}
-                parentTheme={itemTheme}
-              />
-            ))}
-          </div>
-        ) : Primitive && item.ui ? (
-          <Primitive {...item.ui} />
-        ) : unknownPrimitive && item.ui ? (
-          <UnknownPrimitivePlaceholder type={item.ui.type} />
-        ) : null}
+        {content}
       </BlockShape>
     </div>
   );
-}
+});
 
 // --- Placeholders ----------------------------------------------------------
 

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -118,6 +118,9 @@ export interface NotchGridProps {
 
 // --- Internal helpers ------------------------------------------------------
 
+/** Content inset (px) inside a tile / sub-cell. Matches BlockShape's default. */
+const CONTENT_PAD = 16;
+
 function maskToShape(mask: Mask): number[][] {
   return mask.map((row) => row.map((v) => (v ? 1 : 0)));
 }
@@ -167,21 +170,6 @@ function solvePanel(
     })),
     cols: subGridCols(subItems),
   });
-}
-
-interface DragState {
-  key: ItemKey;
-  pointerId: number;
-  startX: number;
-  startY: number;
-  /** Origin position in block units (where the item sits at drag start). */
-  originCol: number;
-  originRow: number;
-  /** Footprint width in blocks (to clamp the dropped column). */
-  originCols: number;
-  /** Live pointer delta in px. */
-  dx: number;
-  dy: number;
 }
 
 interface DragState {
@@ -485,7 +473,7 @@ const NotchItem = memo(function NotchItem({
                 top: sp.row * block,
                 width: sp.cols * block,
                 height: sp.rows * block,
-                padding: 16,
+                padding: CONTENT_PAD,
               }}
             >
               {SubPrimitive ? (
@@ -517,7 +505,7 @@ const NotchItem = memo(function NotchItem({
         fill={resolved.fill}
         stroke={resolved.stroke}
         strokeWidth={resolved.strokeWidth}
-        pad={subLayout ? 0 : 16}
+        pad={subLayout ? 0 : CONTENT_PAD}
       >
         {resolved.accentBar && (
           <div

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -1,0 +1,340 @@
+// NotchGrid — desire-driven notched layout for the dynamic-ui wire format.
+//
+// Items declare position / shape priorities; `solveLayout` packs them;
+// each placement renders as a `BlockShape` themed via `resolveNotchTheme`.
+// No drag in this slice — that's PRs 5–7.
+//
+// Container sizing: when `cols="auto"` (default), a ResizeObserver measures
+// the wrapper width and applies the >96px-gain-1-col rule —
+//   `cols = max(1, floor(containerWidth / blockMin))` and
+//   `block = containerWidth / cols`
+// so the surface never leaves dead space at the edges.
+//
+// See `mirrorstack-docs/architecture/notch-grid-v2/02-api.md`.
+
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentType,
+  type CSSProperties,
+} from "react";
+import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
+import type { ComponentMeta } from "@/types/component-meta";
+import { BlockShape, BLOCK_SIZE } from "./BlockShape";
+import {
+  solveLayout,
+  type Desire,
+  type Mask,
+  type Placement,
+} from "./layout";
+import { resolveNotchTheme, type NotchTheme } from "./theme";
+
+export const meta: ComponentMeta = {
+  name: "NotchGrid",
+  description:
+    "Desire-driven notched layout. Items declare position/shape priorities; the solver packs them; each placement renders as a BlockShape themed via tokens. Implements the >96px gain-1-col / 1fr container rule.",
+};
+
+// --- Public types ----------------------------------------------------------
+
+export type ItemKey = string;
+
+/** Free-form payload for a renderable primitive. The grid passes the entire
+ *  `ui` object to the primitive component as its props — `type` selects which
+ *  component to render, the rest are forwarded. */
+export interface NotchGridUI {
+  type: string;
+  /** Reference into the envelope's `defs` for the renderer to evaluate. The
+   *  grid itself does not run it. */
+  code?: string;
+  [extraProps: string]: unknown;
+}
+
+export interface NotchGridItem {
+  key?: ItemKey;
+  desire: Desire;
+  theme?: NotchTheme;
+  /** Reserved — adjacency auto-link by `groupKey`. Renders as separate
+   *  chromes in PR 4; unified chrome lands in PR 6. */
+  groupKey?: string;
+  /** Either `ui` (single primitive content) or `subItems` (nested panel). */
+  ui?: NotchGridUI;
+  subItems?: NotchSubItem[];
+}
+
+export interface NotchSubItem {
+  key?: ItemKey;
+  desire: Desire;
+  /** Sub-items inherit `type` from the parent panel; only `variant` and
+   *  `gradient` can be overridden. */
+  theme?: Partial<NotchTheme>;
+  ui: NotchGridUI;
+}
+
+export type PrimitiveRegistry = Record<string, ComponentType<Record<string, unknown>>>;
+
+export interface NotchGridError {
+  kind: "unknown-primitive";
+  type: string;
+}
+
+export interface NotchGridProps {
+  items: NotchGridItem[];
+  /** Column count, or `"auto"` (default) to derive from container width via
+   *  the gain-1-col rule. */
+  cols?: number | "auto";
+  /** Minimum block size in px when `cols="auto"`. The grid gains a column
+   *  each time the container can fit one more `blockMin`. Default 96. */
+  blockMin?: number;
+  /** Gap between blocks in px (notch erosion). Default 8. */
+  gap?: number;
+  /** Reserved — already implied by the solver's cell-level collision. */
+  nest?: boolean;
+  /** Map from `ui.type` → React component. Receives the full `ui` object as
+   *  props. Unknown types fire `onItemError` and render a placeholder so the
+   *  layout doesn't collapse. */
+  primitives?: PrimitiveRegistry;
+  onItemError?: (key: ItemKey, error: NotchGridError) => void;
+  className?: string;
+  style?: CSSProperties;
+}
+
+// --- Internal helpers ------------------------------------------------------
+
+/** Convert a boolean mask to BlockShape's tier-encoded shape matrix (0/1). */
+function maskToShape(mask: Mask): number[][] {
+  return mask.map((row) => row.map((v) => (v ? 1 : 0)));
+}
+
+/** Parse `resolveNotchTheme().border` ("none" or "Npx solid var(--…)") into
+ *  BlockShape's `stroke` + `strokeWidth` props. */
+function parseBorder(border: string): { stroke: string; strokeWidth: number } {
+  if (border === "none") return { stroke: "none", strokeWidth: 0 };
+  const m = border.match(/^(\d+)px\s+solid\s+(.+)$/);
+  if (m) return { stroke: m[2], strokeWidth: Number(m[1]) };
+  return { stroke: border, strokeWidth: 1 };
+}
+
+/** Assign synthetic keys to items missing one. Stable across re-renders for
+ *  the same input order; matches the design doc's open question 2.1 lean
+ *  (sequential, at parse). */
+function assignKeys(items: NotchGridItem[]): NotchGridItem[] {
+  return items.map((it, i) => (it.key ? it : { ...it, key: `item-${i}` }));
+}
+
+// --- Component -------------------------------------------------------------
+
+export function NotchGrid({
+  items,
+  cols = "auto",
+  blockMin = BLOCK_SIZE,
+  gap = 8,
+  nest = true,
+  primitives,
+  onItemError,
+  className,
+  style,
+}: NotchGridProps) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState<number | null>(null);
+
+  useLayoutEffect(() => {
+    const el = wrapperRef.current;
+    if (!el) return;
+    const update = () => setContainerWidth(el.getBoundingClientRect().width);
+    update();
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const keyedItems = useMemo(() => assignKeys(items), [items]);
+
+  // Compute cols + block size. Auto: gain-1-col rule + 1fr distribution.
+  const { resolvedCols, block } = useMemo(() => {
+    if (cols !== "auto") return { resolvedCols: cols, block: blockMin };
+    if (containerWidth == null) return { resolvedCols: null as number | null, block: blockMin };
+    const c = Math.max(1, Math.floor(containerWidth / blockMin));
+    return { resolvedCols: c, block: containerWidth / c };
+  }, [cols, blockMin, containerWidth]);
+
+  // Solve layout once cols are known.
+  const layout = useMemo(() => {
+    if (resolvedCols == null) return null;
+    return solveLayout({
+      items: keyedItems.map((it) => ({
+        key: it.key!,
+        desire: it.desire,
+        groupKey: it.groupKey,
+        item: it,
+      })),
+      cols: resolvedCols,
+      nest,
+    });
+  }, [keyedItems, resolvedCols, nest]);
+
+  if (isDev && layout && layout.unfit.length > 0) {
+    console.warn(
+      `[NotchGrid] ${layout.unfit.length} item(s) didn't fit: ${layout.unfit.join(", ")}. Mask wider than cols=${resolvedCols}.`,
+    );
+  }
+
+  const totalRows = layout?.rowsUsed ?? 0;
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={cn("relative w-full", className)}
+      style={{
+        // Reserve vertical space pre-paint so the page doesn't reflow when
+        // layout resolves.
+        minHeight: totalRows > 0 ? totalRows * block : undefined,
+        ...style,
+      }}
+    >
+      {layout
+        ? layout.placements.map((p) => (
+            <NotchItem
+              key={p.key}
+              placement={p}
+              item={p.item as NotchGridItem}
+              block={block}
+              gap={gap}
+              primitives={primitives}
+              onItemError={onItemError}
+              parentTheme={undefined}
+            />
+          ))
+        : null}
+    </div>
+  );
+}
+
+// --- NotchItem (internal, recursive for sub-items) -------------------------
+
+interface NotchItemProps {
+  placement: Placement<NotchGridItem>;
+  item: NotchGridItem;
+  block: number;
+  gap: number;
+  primitives?: PrimitiveRegistry;
+  onItemError?: (key: ItemKey, error: NotchGridError) => void;
+  /** Set when rendered as a sub-item; inherits `type` from the parent panel. */
+  parentTheme?: NotchTheme;
+}
+
+function NotchItem({
+  placement,
+  item,
+  block,
+  gap,
+  primitives,
+  onItemError,
+  parentTheme,
+}: NotchItemProps) {
+  // Sub-items inherit `type` from the parent panel; only `variant` and
+  // `gradient` are overridable (design doc rationale: visual coherence).
+  const itemTheme: NotchTheme = parentTheme
+    ? { ...item.theme, type: parentTheme.type }
+    : item.theme ?? {};
+  const resolved = resolveNotchTheme(itemTheme);
+  const { stroke, strokeWidth } = parseBorder(resolved.border);
+  const shape = useMemo(() => maskToShape(placement.mask), [placement.mask]);
+
+  // Sub-items: solve inner layout. The sub-grid's col count is the parent's
+  // bounding-box cols; each sub-cell uses the same `block` px size.
+  const subLayout = useMemo(() => {
+    if (!item.subItems || item.subItems.length === 0) return null;
+    return solveLayout({
+      items: item.subItems.map((s, i) => ({
+        key: s.key ?? `${placement.key}/${i}`,
+        desire: s.desire,
+        item: { ...s } as NotchGridItem,
+      })),
+      cols: placement.cols,
+    });
+  }, [item.subItems, placement.cols, placement.key]);
+
+  const Primitive = item.ui ? primitives?.[item.ui.type] : undefined;
+  const unknownPrimitive = item.ui != null && !Primitive;
+
+  useEffect(() => {
+    if (unknownPrimitive && onItemError && item.ui) {
+      onItemError(placement.key, {
+        kind: "unknown-primitive",
+        type: item.ui.type,
+      });
+    }
+  }, [unknownPrimitive, onItemError, placement.key, item.ui]);
+
+  // The wrapper carries placement + non-BlockShape theme bits (text color,
+  // shadow, optional borderLeft for elevated alerts).
+  const wrapperStyle: CSSProperties = {
+    position: "absolute",
+    left: placement.col * block,
+    top: placement.row * block,
+    color: resolved.color,
+    boxShadow: resolved.boxShadow,
+    ...(resolved.borderLeft ? { borderLeft: resolved.borderLeft } : {}),
+  };
+
+  // Gradient backgrounds (`linear-gradient(...)`) aren't valid SVG `fill`
+  // values. v1 falls back to the BlockShape's default solid fill when a
+  // gradient is requested. Tracked in the design doc.
+  const fill = resolved.background.startsWith("linear-gradient")
+    ? undefined
+    : resolved.background;
+
+  return (
+    <div style={wrapperStyle}>
+      <BlockShape
+        shape={shape}
+        block={block}
+        gap={gap}
+        fill={fill ?? "transparent"}
+        stroke={stroke}
+        strokeWidth={strokeWidth}
+        pad={subLayout ? 0 : 16}
+      >
+        {subLayout ? (
+          <div className="relative h-full w-full">
+            {subLayout.placements.map((sp) => (
+              <NotchItem
+                key={sp.key}
+                placement={sp}
+                item={sp.item as NotchGridItem}
+                block={block}
+                gap={gap}
+                primitives={primitives}
+                onItemError={onItemError}
+                parentTheme={itemTheme}
+              />
+            ))}
+          </div>
+        ) : Primitive && item.ui ? (
+          <Primitive {...item.ui} />
+        ) : unknownPrimitive && item.ui ? (
+          <UnknownPrimitivePlaceholder type={item.ui.type} />
+        ) : null}
+      </BlockShape>
+    </div>
+  );
+}
+
+// --- Placeholders ----------------------------------------------------------
+
+function UnknownPrimitivePlaceholder({ type }: { type: string }) {
+  return (
+    <div
+      className="flex h-full w-full items-center justify-center text-xs"
+      style={{ color: "var(--color-on-error-container)" }}
+    >
+      Unknown primitive: <code className="ml-1">{type}</code>
+    </div>
+  );
+}

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -28,13 +28,16 @@ import {
 import { cn } from "@/utils/cn";
 import { isDev } from "@/utils/env";
 import type { ComponentMeta } from "@/types/component-meta";
+import { maskCols } from "@/utils/grid-outline";
 import { BlockShape, BLOCK_SIZE } from "./BlockShape";
 import {
+  placementToMask,
   solveLayout,
   type Desire,
   type Mask,
   type Placement,
   type Pos,
+  type SolverOutput,
 } from "./layout";
 import { resolveNotchTheme, type NotchTheme } from "./theme";
 
@@ -124,6 +127,61 @@ function maskToShape(mask: Mask): number[][] {
 function assignKeys(items: NotchGridItem[]): NotchGridItem[] {
   if (items.every((it) => it.key != null)) return items;
   return items.map((it, i) => (it.key ? it : { ...it, key: `item-${i}` }));
+}
+
+/** First (highest-priority) mask from a `Priority<Mask>` — used for width. */
+function firstMask(shape: Desire["shape"]): Mask {
+  if (Array.isArray(shape)) return shape as Mask;
+  const keys = Object.keys(shape as Record<string, Mask>).sort(
+    (a, b) => Number(a) - Number(b),
+  );
+  return (shape as Record<string, Mask>)[keys[0]];
+}
+
+/** Inner column count a panel's sub-grid spans, from explicit positions +
+ *  shape widths (flow sub-items contribute their own width at col 0). */
+function subGridCols(subItems: NotchSubItem[]): number {
+  let cols = 1;
+  for (const s of subItems) {
+    const w = maskCols(firstMask(s.desire.shape));
+    const pos = s.desire.position;
+    const startCol = Array.isArray(pos) ? pos[0] : 0;
+    cols = Math.max(cols, startCol + w);
+  }
+  return cols;
+}
+
+/** Solve a panel's sub-items into placements within their bounding sub-grid.
+ *  The panel's rendered footprint is the union of these placements (so notches
+ *  appear where no sub-item sits, and adjacent/diagonal sub-items bridge into
+ *  one chrome). */
+function solvePanel(
+  subItems: NotchSubItem[],
+  keyPrefix: ItemKey,
+): SolverOutput<NotchSubItem> {
+  return solveLayout<NotchSubItem>({
+    items: subItems.map((s, i) => ({
+      key: s.key ?? `${keyPrefix}/${i}`,
+      desire: s.desire,
+      item: s,
+    })),
+    cols: subGridCols(subItems),
+  });
+}
+
+interface DragState {
+  key: ItemKey;
+  pointerId: number;
+  startX: number;
+  startY: number;
+  /** Origin position in block units (where the item sits at drag start). */
+  originCol: number;
+  originRow: number;
+  /** Footprint width in blocks (to clamp the dropped column). */
+  originCols: number;
+  /** Live pointer delta in px. */
+  dx: number;
+  dy: number;
 }
 
 interface DragState {
@@ -221,15 +279,22 @@ export function NotchGrid({
 
   // Items with an override get their desire.position rewritten — that promotes
   // them to the solver's fixed-position fast path so they win their cell on
-  // the next solve.
+  // the next solve. Panels get their desire.shape replaced by the union of
+  // their sub-item footprints, so the outer grid reserves the real (notched)
+  // shape rather than the panel's declared bounding box.
   const layout = useMemo(() => {
     if (resolvedCols == null) return null;
     return solveLayout({
       items: keyedItems.map((it) => {
         const ov = overrides.get(it.key!);
+        let desire = ov ? { ...it.desire, position: ov } : it.desire;
+        if (it.subItems && it.subItems.length > 0) {
+          const unionMask = placementToMask(solvePanel(it.subItems, it.key!).placements);
+          desire = { ...desire, shape: unionMask };
+        }
         return {
           key: it.key!,
-          desire: ov ? { ...it.desire, position: ov } : it.desire,
+          desire,
           groupKey: it.groupKey,
           item: it,
         };
@@ -273,7 +338,6 @@ export function NotchGrid({
             gap={gap}
             primitives={primitives}
             onItemError={onItemError}
-            parentTheme={undefined}
             draggable={draggable}
             dragOffset={dragOffset}
             hasOverride={overrides.has(p.key)}
@@ -320,8 +384,6 @@ interface NotchItemProps {
   gap: number;
   primitives?: PrimitiveRegistry;
   onItemError?: (key: ItemKey, error: NotchGridError) => void;
-  /** Set when rendered as a sub-item; inherits `type` from the parent panel. */
-  parentTheme?: NotchTheme;
   /** When true, the wrapper accepts pointer events for outer-grid drag. */
   draggable?: boolean;
   /** Live `[dx, dy]` in px while this tile is being dragged. */
@@ -340,7 +402,6 @@ const NotchItem = memo(function NotchItem({
   gap,
   primitives,
   onItemError,
-  parentTheme,
   draggable = false,
   dragOffset,
   hasOverride = false,
@@ -348,12 +409,7 @@ const NotchItem = memo(function NotchItem({
   onDragMove,
   onDragEnd,
 }: NotchItemProps) {
-  // Sub-items inherit `type` from the parent panel; only `variant` and
-  // `gradient` are overridable (visual coherence — a filled panel with an
-  // outlined sub-item looks broken).
-  const itemTheme: NotchTheme = parentTheme
-    ? { ...item.theme, type: parentTheme.type }
-    : item.theme ?? {};
+  const itemTheme: NotchTheme = item.theme ?? {};
   const resolved = useMemo(() => resolveNotchTheme(itemTheme), [
     itemTheme.type,
     itemTheme.variant,
@@ -361,17 +417,14 @@ const NotchItem = memo(function NotchItem({
   ]);
   const shape = useMemo(() => maskToShape(placement.mask), [placement.mask]);
 
+  // Sub-items share the panel's single chrome (placement.mask is already the
+  // union of these placements, computed in the outer layout prep). Re-solving
+  // here with the same inputs yields the matching sub-cell positions for
+  // laying out content.
   const subLayout = useMemo(() => {
     if (!item.subItems || item.subItems.length === 0) return null;
-    return solveLayout({
-      items: item.subItems.map((s, i) => ({
-        key: s.key ?? `${placement.key}/${i}`,
-        desire: s.desire,
-        item: s as NotchGridItem,
-      })),
-      cols: placement.cols,
-    });
-  }, [item.subItems, placement.cols, placement.key]);
+    return solvePanel(item.subItems, placement.key);
+  }, [item.subItems, placement.key]);
 
   const Primitive = item.ui ? primitives?.[item.ui.type] : undefined;
   const unknownPrimitive = item.ui != null && !Primitive;
@@ -415,20 +468,34 @@ const NotchItem = memo(function NotchItem({
 
   let content: ReactNode = null;
   if (subLayout) {
+    // Sub-items render as positioned content inside the panel's single chrome
+    // (no nested BlockShape) — they inherit the panel fill + text color, and
+    // the union mask provides the notches / bridges between them.
     content = (
       <div className="relative h-full w-full">
-        {subLayout.placements.map((sp) => (
-          <NotchItem
-            key={sp.key}
-            placement={sp}
-            item={sp.item as NotchGridItem}
-            block={block}
-            gap={gap}
-            primitives={primitives}
-            onItemError={onItemError}
-            parentTheme={itemTheme}
-          />
-        ))}
+        {subLayout.placements.map((sp) => {
+          const sub = sp.item as NotchSubItem;
+          const SubPrimitive = sub.ui ? primitives?.[sub.ui.type] : undefined;
+          return (
+            <div
+              key={sp.key}
+              className="absolute"
+              style={{
+                left: sp.col * block,
+                top: sp.row * block,
+                width: sp.cols * block,
+                height: sp.rows * block,
+                padding: 16,
+              }}
+            >
+              {SubPrimitive ? (
+                <SubPrimitive {...sub.ui} />
+              ) : (
+                <UnknownPrimitivePlaceholder type={sub.ui.type} />
+              )}
+            </div>
+          );
+        })}
       </div>
     );
   } else if (Primitive && item.ui) {

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -433,7 +433,6 @@ const NotchItem = memo(function NotchItem({
     top: placement.row * block,
     color: resolved.color,
   };
-  if (resolved.filter !== "none") wrapperStyle.filter = resolved.filter;
   if (isDragging) {
     wrapperStyle.transform = `translate(${dragOffset[0]}px, ${dragOffset[1]}px)`;
     wrapperStyle.zIndex = 20;
@@ -495,7 +494,12 @@ const NotchItem = memo(function NotchItem({
   return (
     <div
       {...dragHandlers}
-      className={draggable ? "select-none" : undefined}
+      className={cn(
+        draggable && "select-none",
+        // drop-shadow (a filter) traces the notched SVG outline; plain
+        // box-shadow would be rectangular.
+        resolved.elevated && "drop-shadow-lg",
+      )}
       style={wrapperStyle}
     >
       <BlockShape

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -273,13 +273,15 @@ function NotchItem({
   }, [unknownPrimitive, onItemError, placement.key, item.ui]);
 
   // The wrapper carries placement + non-BlockShape theme bits (text color,
-  // shadow, optional borderLeft for elevated alerts).
+  // drop-shadow filter for elevated chromes — traces the SVG path rather
+  // than the bounding box — and optional border-left color cue for
+  // elevated warn/error).
   const wrapperStyle: CSSProperties = {
     position: "absolute",
     left: placement.col * block,
     top: placement.row * block,
     color: resolved.color,
-    boxShadow: resolved.boxShadow,
+    ...(resolved.filter !== "none" ? { filter: resolved.filter } : {}),
     ...(resolved.borderLeft ? { borderLeft: resolved.borderLeft } : {}),
   };
 

--- a/src/components/ui/surfaces/notch-grid/layout.ts
+++ b/src/components/ui/surfaces/notch-grid/layout.ts
@@ -53,9 +53,19 @@ export function rectMask(cols: number, rows: number): boolean[][] {
   return Array.from({ length: r }, () => Array<boolean>(c).fill(true));
 }
 
+/** A positioned block rectangle — the structural subset `placementToMask`
+ *  needs. Both `PlacedItem` (from `packItems`) and `Placement` (from
+ *  `solveLayout`) satisfy it. */
+export interface CellRect {
+  col: number;
+  row: number;
+  cols: number;
+  rows: number;
+}
+
 /** Union of placed rectangular items into one boolean mask — the derived
  *  footprint of a panel built from sub-items. Empty cells become notches. */
-export function placementToMask<T>(placed: ReadonlyArray<PlacedItem<T>>): boolean[][] {
+export function placementToMask(placed: ReadonlyArray<CellRect>): boolean[][] {
   let maxRow = 1;
   let maxCol = 1;
   for (const p of placed) {

--- a/src/components/ui/surfaces/notch-grid/theme.test.ts
+++ b/src/components/ui/surfaces/notch-grid/theme.test.ts
@@ -206,10 +206,28 @@ describe("resolveNotchTheme — exhaustive type×variant matrix", () => {
         const r = resolveNotchTheme({ type, variant });
         if (type === "elevated") {
           expect(r.boxShadow).toBe("var(--shadow-m3-1)");
+          expect(r.filter).toBe("var(--filter-m3-1)");
         } else {
           expect(r.boxShadow).toBe("none");
+          expect(r.filter).toBe("none");
         }
       }
     }
+  });
+
+  it("non-elevated chromes always return filter=none", () => {
+    const cases = [
+      { type: "filled" as const, variant: "primary" as const },
+      { type: "outlined" as const, variant: "primary" as const },
+      { type: "ghost" as const, variant: "primary" as const },
+    ];
+    for (const t of cases) {
+      expect(resolveNotchTheme(t).filter).toBe("none");
+    }
+  });
+
+  it("elevated returns filter=var(--filter-m3-1) — drop-shadow chain that traces the rendered shape", () => {
+    const r = resolveNotchTheme({ type: "elevated", variant: "primary" });
+    expect(r.filter).toBe("var(--filter-m3-1)");
   });
 });

--- a/src/components/ui/surfaces/notch-grid/theme.test.ts
+++ b/src/components/ui/surfaces/notch-grid/theme.test.ts
@@ -90,12 +90,12 @@ describe("resolveNotchTheme — type=outlined", () => {
 });
 
 describe("resolveNotchTheme — type=elevated", () => {
-  it("primary → surface-container-low fill, on-surface text, m3-1 shadow", () => {
+  it("primary → surface-container-low fill, on-surface text, m3-1 shadow, no accent bar", () => {
     const r = resolveNotchTheme({ type: "elevated", variant: "primary" });
     expect(r.background).toBe("var(--color-surface-container-low)");
     expect(r.color).toBe("var(--color-on-surface)");
     expect(r.boxShadow).toBe("var(--shadow-m3-1)");
-    expect(r.borderLeft).toBeUndefined();
+    expect(r.accentBar).toBeUndefined();
   });
 
   it("neutral drops one surface tier (container-lowest)", () => {
@@ -103,16 +103,16 @@ describe("resolveNotchTheme — type=elevated", () => {
     expect(r.background).toBe("var(--color-surface-container-lowest)");
   });
 
-  it("warn → adds 4px warning border-left as color cue on lifted chrome", () => {
+  it("warn → exposes accentBar=warning color for the renderer's inset stripe", () => {
     const r = resolveNotchTheme({ type: "elevated", variant: "warn" });
     expect(r.background).toBe("var(--color-surface-container-low)");
-    expect(r.borderLeft).toBe("4px solid var(--color-warning)");
+    expect(r.accentBar).toBe("var(--color-warning)");
     expect(r.boxShadow).toBe("var(--shadow-m3-1)");
   });
 
-  it("error → 4px error border-left", () => {
+  it("error → exposes accentBar=error color", () => {
     const r = resolveNotchTheme({ type: "elevated", variant: "error" });
-    expect(r.borderLeft).toBe("4px solid var(--color-error)");
+    expect(r.accentBar).toBe("var(--color-error)");
   });
 });
 

--- a/src/components/ui/surfaces/notch-grid/theme.test.ts
+++ b/src/components/ui/surfaces/notch-grid/theme.test.ts
@@ -9,7 +9,7 @@ describe("resolveNotchTheme — defaults & auto resolution", () => {
     expect(r.color).toBe("var(--color-on-surface-variant)");
     expect(r.stroke).toBe("none");
     expect(r.strokeWidth).toBe(0);
-    expect(r.boxShadow).toBe("none");
+    expect(r.elevated).toBe(false);
   });
 
   it("variant=primary alone → filled primary (type defaults to filled when variant set)", () => {
@@ -45,7 +45,7 @@ describe("resolveNotchTheme — type=filled", () => {
     expect(r.color).toBe("var(--color-on-primary-container)");
     expect(r.stroke).toBe("none");
     expect(r.strokeWidth).toBe(0);
-    expect(r.boxShadow).toBe("none");
+    expect(r.elevated).toBe(false);
   });
 
   it("secondary, tertiary, error → matching container tokens", () => {
@@ -78,7 +78,7 @@ describe("resolveNotchTheme — type=outlined", () => {
     expect(r.color).toBe("var(--color-primary)");
     expect(r.stroke).toBe("var(--color-primary)");
     expect(r.strokeWidth).toBe(1);
-    expect(r.boxShadow).toBe("none");
+    expect(r.elevated).toBe(false);
   });
 
   it("neutral / surface → outline-variant stroke", () => {
@@ -95,12 +95,12 @@ describe("resolveNotchTheme — type=outlined", () => {
 });
 
 describe("resolveNotchTheme — type=elevated", () => {
-  it("primary → surface-container-low fill, primary accent text, m3-1 shadow, no accent bar", () => {
+  it("primary → surface-container-low fill, primary accent text, elevated, no accent bar", () => {
     const r = resolveNotchTheme({ type: "elevated", variant: "primary" });
     expect(r.fill).toBe("var(--color-surface-container-low)");
     // Text carries the variant accent so lifted tiles differ by variant.
     expect(r.color).toBe("var(--color-primary)");
-    expect(r.boxShadow).toBe("var(--shadow-m3-1)");
+    expect(r.elevated).toBe(true);
     expect(r.accentBar).toBeUndefined();
   });
 
@@ -122,7 +122,7 @@ describe("resolveNotchTheme — type=elevated", () => {
     const r = resolveNotchTheme({ type: "elevated", variant: "warn" });
     expect(r.fill).toBe("var(--color-surface-container-low)");
     expect(r.accentBar).toBe("var(--color-warning)");
-    expect(r.boxShadow).toBe("var(--shadow-m3-1)");
+    expect(r.elevated).toBe(true);
   });
 
   it("error → exposes accentBar=error color", () => {
@@ -137,7 +137,7 @@ describe("resolveNotchTheme — type=ghost", () => {
     expect(r.fill).toBe("transparent");
     expect(r.color).toBe("var(--color-primary)");
     expect(r.stroke).toBe("none");
-    expect(r.boxShadow).toBe("none");
+    expect(r.elevated).toBe(false);
   });
 
   it("neutral → on-surface-variant text", () => {
@@ -204,7 +204,7 @@ describe("resolveNotchTheme — exhaustive type×variant matrix", () => {
     "error",
   ] as const;
 
-  it("every (type, variant) pair returns valid CSS-shaped strings", () => {
+  it("every (type, variant) pair returns valid CSS-shaped values", () => {
     for (const type of types) {
       for (const variant of variants) {
         const r = resolveNotchTheme({ type, variant });
@@ -214,39 +214,17 @@ describe("resolveNotchTheme — exhaustive type×variant matrix", () => {
         expect(r.color).toMatch(/^var\(--color-/);
         expect(typeof r.stroke).toBe("string");
         expect(typeof r.strokeWidth).toBe("number");
-        expect(typeof r.boxShadow).toBe("string");
+        expect(typeof r.elevated).toBe("boolean");
       }
     }
   });
 
-  it("elevated rows are the only chromes carrying a shadow", () => {
+  it("elevated is the only chrome that reads as lifted", () => {
     for (const variant of variants) {
       for (const type of types) {
         const r = resolveNotchTheme({ type, variant });
-        if (type === "elevated") {
-          expect(r.boxShadow).toBe("var(--shadow-m3-1)");
-          expect(r.filter).toBe("var(--filter-m3-1)");
-        } else {
-          expect(r.boxShadow).toBe("none");
-          expect(r.filter).toBe("none");
-        }
+        expect(r.elevated).toBe(type === "elevated");
       }
     }
-  });
-
-  it("non-elevated chromes always return filter=none", () => {
-    const cases = [
-      { type: "filled" as const, variant: "primary" as const },
-      { type: "outlined" as const, variant: "primary" as const },
-      { type: "ghost" as const, variant: "primary" as const },
-    ];
-    for (const t of cases) {
-      expect(resolveNotchTheme(t).filter).toBe("none");
-    }
-  });
-
-  it("elevated returns filter=var(--filter-m3-1) — drop-shadow chain that traces the rendered shape", () => {
-    const r = resolveNotchTheme({ type: "elevated", variant: "primary" });
-    expect(r.filter).toBe("var(--filter-m3-1)");
   });
 });

--- a/src/components/ui/surfaces/notch-grid/theme.test.ts
+++ b/src/components/ui/surfaces/notch-grid/theme.test.ts
@@ -95,12 +95,22 @@ describe("resolveNotchTheme — type=outlined", () => {
 });
 
 describe("resolveNotchTheme — type=elevated", () => {
-  it("primary → surface-container-low fill, on-surface text, m3-1 shadow, no accent bar", () => {
+  it("primary → surface-container-low fill, primary accent text, m3-1 shadow, no accent bar", () => {
     const r = resolveNotchTheme({ type: "elevated", variant: "primary" });
     expect(r.fill).toBe("var(--color-surface-container-low)");
-    expect(r.color).toBe("var(--color-on-surface)");
+    // Text carries the variant accent so lifted tiles differ by variant.
+    expect(r.color).toBe("var(--color-primary)");
     expect(r.boxShadow).toBe("var(--shadow-m3-1)");
     expect(r.accentBar).toBeUndefined();
+  });
+
+  it("variants get distinct accent text (secondary, tertiary, neutral)", () => {
+    expect(resolveNotchTheme({ type: "elevated", variant: "secondary" }).color)
+      .toBe("var(--color-secondary)");
+    expect(resolveNotchTheme({ type: "elevated", variant: "tertiary" }).color)
+      .toBe("var(--color-tertiary)");
+    expect(resolveNotchTheme({ type: "elevated", variant: "neutral" }).color)
+      .toBe("var(--color-on-surface-variant)");
   });
 
   it("neutral drops one surface tier (container-lowest)", () => {

--- a/src/components/ui/surfaces/notch-grid/theme.test.ts
+++ b/src/components/ui/surfaces/notch-grid/theme.test.ts
@@ -4,95 +4,100 @@ import { resolveNotchTheme } from "./theme";
 describe("resolveNotchTheme — defaults & auto resolution", () => {
   it("undefined theme → ghost neutral (both knobs auto)", () => {
     const r = resolveNotchTheme();
-    expect(r.background).toBe("transparent");
+    expect(r.fill).toBe("transparent");
+    expect(r.cssBackground).toBe("transparent");
     expect(r.color).toBe("var(--color-on-surface-variant)");
-    expect(r.border).toBe("none");
+    expect(r.stroke).toBe("none");
+    expect(r.strokeWidth).toBe(0);
     expect(r.boxShadow).toBe("none");
   });
 
   it("variant=primary alone → filled primary (type defaults to filled when variant set)", () => {
     const r = resolveNotchTheme({ variant: "primary" });
-    expect(r.background).toBe("var(--color-primary-container)");
+    expect(r.fill).toBe("var(--color-primary-container)");
     expect(r.color).toBe("var(--color-on-primary-container)");
   });
 
   it("type=auto + variant=auto → ghost neutral", () => {
     const r = resolveNotchTheme({ type: "auto", variant: "auto" });
-    expect(r.background).toBe("transparent");
+    expect(r.fill).toBe("transparent");
     expect(r.color).toBe("var(--color-on-surface-variant)");
   });
 
   it("type=auto + variant=primary → filled primary", () => {
     const r = resolveNotchTheme({ type: "auto", variant: "primary" });
-    expect(r.background).toBe("var(--color-primary-container)");
+    expect(r.fill).toBe("var(--color-primary-container)");
     expect(r.color).toBe("var(--color-on-primary-container)");
   });
 
   it("variant=auto → resolves to neutral", () => {
     const r = resolveNotchTheme({ type: "outlined", variant: "auto" });
     expect(r.color).toBe("var(--color-on-surface-variant)");
-    expect(r.border).toBe("1px solid var(--color-outline-variant)");
+    expect(r.stroke).toBe("var(--color-outline-variant)");
+    expect(r.strokeWidth).toBe(1);
   });
 });
 
 describe("resolveNotchTheme — type=filled", () => {
   it("primary → primary-container fill, on-primary-container text", () => {
     const r = resolveNotchTheme({ type: "filled", variant: "primary" });
-    expect(r.background).toBe("var(--color-primary-container)");
+    expect(r.fill).toBe("var(--color-primary-container)");
     expect(r.color).toBe("var(--color-on-primary-container)");
-    expect(r.border).toBe("none");
+    expect(r.stroke).toBe("none");
+    expect(r.strokeWidth).toBe(0);
     expect(r.boxShadow).toBe("none");
   });
 
   it("secondary, tertiary, error → matching container tokens", () => {
-    expect(resolveNotchTheme({ type: "filled", variant: "secondary" }).background)
+    expect(resolveNotchTheme({ type: "filled", variant: "secondary" }).fill)
       .toBe("var(--color-secondary-container)");
-    expect(resolveNotchTheme({ type: "filled", variant: "tertiary" }).background)
+    expect(resolveNotchTheme({ type: "filled", variant: "tertiary" }).fill)
       .toBe("var(--color-tertiary-container)");
-    expect(resolveNotchTheme({ type: "filled", variant: "error" }).background)
+    expect(resolveNotchTheme({ type: "filled", variant: "error" }).fill)
       .toBe("var(--color-error-container)");
   });
 
   it("surface → surface-container; neutral → surface-container-low", () => {
-    expect(resolveNotchTheme({ type: "filled", variant: "surface" }).background)
+    expect(resolveNotchTheme({ type: "filled", variant: "surface" }).fill)
       .toBe("var(--color-surface-container)");
-    expect(resolveNotchTheme({ type: "filled", variant: "neutral" }).background)
+    expect(resolveNotchTheme({ type: "filled", variant: "neutral" }).fill)
       .toBe("var(--color-surface-container-low)");
   });
 
   it("warn → warning-container (schema→kit alias)", () => {
     const r = resolveNotchTheme({ type: "filled", variant: "warn" });
-    expect(r.background).toBe("var(--color-warning-container)");
+    expect(r.fill).toBe("var(--color-warning-container)");
     expect(r.color).toBe("var(--color-on-warning-container)");
   });
 });
 
 describe("resolveNotchTheme — type=outlined", () => {
-  it("primary → transparent bg, primary text, 1px primary border", () => {
+  it("primary → transparent bg, primary text, 1px primary stroke", () => {
     const r = resolveNotchTheme({ type: "outlined", variant: "primary" });
-    expect(r.background).toBe("transparent");
+    expect(r.fill).toBe("transparent");
     expect(r.color).toBe("var(--color-primary)");
-    expect(r.border).toBe("1px solid var(--color-primary)");
+    expect(r.stroke).toBe("var(--color-primary)");
+    expect(r.strokeWidth).toBe(1);
     expect(r.boxShadow).toBe("none");
   });
 
-  it("neutral / surface → outline-variant border", () => {
-    expect(resolveNotchTheme({ type: "outlined", variant: "neutral" }).border)
-      .toBe("1px solid var(--color-outline-variant)");
-    expect(resolveNotchTheme({ type: "outlined", variant: "surface" }).border)
-      .toBe("1px solid var(--color-outline-variant)");
+  it("neutral / surface → outline-variant stroke", () => {
+    expect(resolveNotchTheme({ type: "outlined", variant: "neutral" }).stroke)
+      .toBe("var(--color-outline-variant)");
+    expect(resolveNotchTheme({ type: "outlined", variant: "surface" }).stroke)
+      .toBe("var(--color-outline-variant)");
   });
 
-  it("warn → warning border (alias)", () => {
-    expect(resolveNotchTheme({ type: "outlined", variant: "warn" }).border)
-      .toBe("1px solid var(--color-warning)");
+  it("warn → warning stroke (alias)", () => {
+    expect(resolveNotchTheme({ type: "outlined", variant: "warn" }).stroke)
+      .toBe("var(--color-warning)");
   });
 });
 
 describe("resolveNotchTheme — type=elevated", () => {
   it("primary → surface-container-low fill, on-surface text, m3-1 shadow, no accent bar", () => {
     const r = resolveNotchTheme({ type: "elevated", variant: "primary" });
-    expect(r.background).toBe("var(--color-surface-container-low)");
+    expect(r.fill).toBe("var(--color-surface-container-low)");
     expect(r.color).toBe("var(--color-on-surface)");
     expect(r.boxShadow).toBe("var(--shadow-m3-1)");
     expect(r.accentBar).toBeUndefined();
@@ -100,12 +105,12 @@ describe("resolveNotchTheme — type=elevated", () => {
 
   it("neutral drops one surface tier (container-lowest)", () => {
     const r = resolveNotchTheme({ type: "elevated", variant: "neutral" });
-    expect(r.background).toBe("var(--color-surface-container-lowest)");
+    expect(r.fill).toBe("var(--color-surface-container-lowest)");
   });
 
   it("warn → exposes accentBar=warning color for the renderer's inset stripe", () => {
     const r = resolveNotchTheme({ type: "elevated", variant: "warn" });
-    expect(r.background).toBe("var(--color-surface-container-low)");
+    expect(r.fill).toBe("var(--color-surface-container-low)");
     expect(r.accentBar).toBe("var(--color-warning)");
     expect(r.boxShadow).toBe("var(--shadow-m3-1)");
   });
@@ -117,11 +122,11 @@ describe("resolveNotchTheme — type=elevated", () => {
 });
 
 describe("resolveNotchTheme — type=ghost", () => {
-  it("primary → transparent bg, primary text, no border or shadow", () => {
+  it("primary → transparent bg, primary text, no stroke or shadow", () => {
     const r = resolveNotchTheme({ type: "ghost", variant: "primary" });
-    expect(r.background).toBe("transparent");
+    expect(r.fill).toBe("transparent");
     expect(r.color).toBe("var(--color-primary)");
-    expect(r.border).toBe("none");
+    expect(r.stroke).toBe("none");
     expect(r.boxShadow).toBe("none");
   });
 
@@ -137,40 +142,43 @@ describe("resolveNotchTheme — type=ghost", () => {
 });
 
 describe("resolveNotchTheme — gradient overlay", () => {
-  it("gradient=0 leaves filled background unchanged", () => {
+  it("gradient=0 leaves cssBackground equal to fill", () => {
     const r = resolveNotchTheme({ type: "filled", variant: "primary", gradient: 0 });
-    expect(r.background).toBe("var(--color-primary-container)");
+    expect(r.cssBackground).toBe("var(--color-primary-container)");
+    expect(r.fill).toBe("var(--color-primary-container)");
   });
 
-  it("gradient>0 wraps the fill in a linear-gradient using color-mix", () => {
+  it("gradient>0 wraps cssBackground in a linear-gradient (fill stays solid)", () => {
     const r = resolveNotchTheme({ type: "filled", variant: "primary", gradient: 1 });
-    expect(r.background).toContain("linear-gradient(180deg");
-    expect(r.background).toContain("var(--color-primary-container)");
-    expect(r.background).toContain("color-mix(in oklab");
-    expect(r.background).toContain("white 12%");
+    expect(r.cssBackground).toContain("linear-gradient(180deg");
+    expect(r.cssBackground).toContain("var(--color-primary-container)");
+    expect(r.cssBackground).toContain("color-mix(in oklab");
+    expect(r.cssBackground).toContain("white 12%");
+    // SVG fill stays solid — gradient isn't a valid SVG paint.
+    expect(r.fill).toBe("var(--color-primary-container)");
   });
 
   it("gradient=0.5 → 6% white mix at top", () => {
     const r = resolveNotchTheme({ type: "filled", variant: "primary", gradient: 0.5 });
-    expect(r.background).toContain("white 6%");
+    expect(r.cssBackground).toContain("white 6%");
   });
 
   it("gradient clamped at 1 (gradient=2 still produces 12%)", () => {
     const r = resolveNotchTheme({ type: "filled", variant: "primary", gradient: 2 });
-    expect(r.background).toContain("white 12%");
+    expect(r.cssBackground).toContain("white 12%");
   });
 
   it("gradient ignored for transparent backgrounds (outlined, ghost)", () => {
     const outlined = resolveNotchTheme({ type: "outlined", variant: "primary", gradient: 1 });
-    expect(outlined.background).toBe("transparent");
+    expect(outlined.cssBackground).toBe("transparent");
     const ghost = resolveNotchTheme({ type: "ghost", variant: "primary", gradient: 1 });
-    expect(ghost.background).toBe("transparent");
+    expect(ghost.cssBackground).toBe("transparent");
   });
 
   it("gradient applies to elevated fill (it's a solid token, not transparent)", () => {
     const r = resolveNotchTheme({ type: "elevated", variant: "primary", gradient: 1 });
-    expect(r.background).toContain("linear-gradient(180deg");
-    expect(r.background).toContain("var(--color-surface-container-low)");
+    expect(r.cssBackground).toContain("linear-gradient(180deg");
+    expect(r.cssBackground).toContain("var(--color-surface-container-low)");
   });
 });
 
@@ -190,11 +198,12 @@ describe("resolveNotchTheme — exhaustive type×variant matrix", () => {
     for (const type of types) {
       for (const variant of variants) {
         const r = resolveNotchTheme({ type, variant });
-        expect(typeof r.background).toBe("string");
-        expect(r.background.length).toBeGreaterThan(0);
-        expect(typeof r.color).toBe("string");
+        expect(typeof r.fill).toBe("string");
+        expect(r.fill.length).toBeGreaterThan(0);
+        expect(typeof r.cssBackground).toBe("string");
         expect(r.color).toMatch(/^var\(--color-/);
-        expect(typeof r.border).toBe("string");
+        expect(typeof r.stroke).toBe("string");
+        expect(typeof r.strokeWidth).toBe("number");
         expect(typeof r.boxShadow).toBe("string");
       }
     }

--- a/src/components/ui/surfaces/notch-grid/theme.ts
+++ b/src/components/ui/surfaces/notch-grid/theme.ts
@@ -187,7 +187,9 @@ export function resolveNotchTheme(theme?: NotchTheme): ResolvedTheme {
       return {
         fill,
         cssBackground: applyGradient(fill, gradient),
-        color: "var(--color-on-surface)",
+        // Variant accent on the text differentiates the lifted tiles —
+        // surface tones alone leave primary/secondary/tertiary identical.
+        color: ACCENT[variant],
         stroke: "none",
         strokeWidth: 0,
         ...(isAlert ? { accentBar: ACCENT[variant] } : {}),

--- a/src/components/ui/surfaces/notch-grid/theme.ts
+++ b/src/components/ui/surfaces/notch-grid/theme.ts
@@ -30,8 +30,11 @@ export interface ResolvedTheme {
   color: string;
   /** CSS `border` — `"1px solid var(...)"` or `"none"`. */
   border: string;
-  /** CSS `border-left` for elevated warn/error (color cue layered on lift). */
-  borderLeft?: string;
+  /** Color (token reference) for an inset accent stripe along the chrome's
+   *  left edge — used by elevated warn / error to signal severity without
+   *  losing the lifted surface look. Renderers should paint this as a 4px
+   *  vertical bar inside the chrome's clipped content area. */
+  accentBar?: string;
   /** CSS `box-shadow` — rectangular shadow on the bounding box. Kept for
    *  consumers that want bounding-box shadows. */
   boxShadow: string;
@@ -173,7 +176,7 @@ export function resolveNotchTheme(theme?: NotchTheme): ResolvedTheme {
         background: applyGradient(ELEVATED_BG[variant], gradient),
         color: "var(--color-on-surface)",
         border: "none",
-        ...(isAlert ? { borderLeft: `4px solid ${ACCENT[variant]}` } : {}),
+        ...(isAlert ? { accentBar: ACCENT[variant] } : {}),
         boxShadow: "var(--shadow-m3-1)",
         filter: "var(--filter-m3-1)",
       };

--- a/src/components/ui/surfaces/notch-grid/theme.ts
+++ b/src/components/ui/surfaces/notch-grid/theme.ts
@@ -24,12 +24,19 @@ export interface NotchTheme {
 }
 
 export interface ResolvedTheme {
-  /** CSS `background` — token reference, gradient, or `"transparent"`. */
-  background: string;
+  /** SVG-friendly fill — a solid token reference, or `"transparent"`. Never
+   *  a CSS gradient (those go in `cssBackground`). Feed directly to
+   *  `<BlockShape fill={...}>`. */
+  fill: string;
+  /** CSS `background` — may be a `linear-gradient(...)` when `gradient > 0`,
+   *  otherwise matches `fill`. For consumers layering a CSS background. */
+  cssBackground: string;
   /** CSS `color` — always a token reference. */
   color: string;
-  /** CSS `border` — `"1px solid var(...)"` or `"none"`. */
-  border: string;
+  /** SVG `stroke` — token reference, or `"none"`. */
+  stroke: string;
+  /** SVG `stroke-width` in px. `0` when there's no border. */
+  strokeWidth: number;
   /** Color (token reference) for an inset accent stripe along the chrome's
    *  left edge — used by elevated warn / error to signal severity without
    *  losing the lifted surface look. Renderers should paint this as a 4px
@@ -125,8 +132,8 @@ function resolveAuto(theme: NotchTheme): { type: ConcreteType; variant: Concrete
 }
 
 /** Apply a tonal gradient overlay to a fill token. `gradient = 0` returns the
- *  raw token; `gradient = 1` mixes ~12% white at the top. The overlay only
- *  applies to filled chromes — transparent backgrounds are returned unchanged. */
+ *  raw token; `gradient = 1` mixes ~12% white at the top. Returns the
+ *  CSS-side value (gradient or token); the SVG-side fill stays solid. */
 function applyGradient(bg: string, gradient: number): string {
   if (gradient <= 0 || bg === "transparent") return bg;
   const pct = Math.min(1, gradient) * 12;
@@ -152,30 +159,37 @@ export function resolveNotchTheme(theme?: NotchTheme): ResolvedTheme {
 
   switch (type) {
     case "filled": {
-      const bg = applyGradient(FILL_BG[variant], gradient);
+      const fill = FILL_BG[variant];
       return {
-        background: bg,
+        fill,
+        cssBackground: applyGradient(fill, gradient),
         color: FILL_FG[variant],
-        border: "none",
+        stroke: "none",
+        strokeWidth: 0,
         boxShadow: "none",
         filter: "none",
       };
     }
     case "outlined": {
       return {
-        background: "transparent",
+        fill: "transparent",
+        cssBackground: "transparent",
         color: ACCENT[variant],
-        border: `1px solid ${OUTLINE_BORDER[variant]}`,
+        stroke: OUTLINE_BORDER[variant],
+        strokeWidth: 1,
         boxShadow: "none",
         filter: "none",
       };
     }
     case "elevated": {
       const isAlert = variant === "warn" || variant === "error";
+      const fill = ELEVATED_BG[variant];
       return {
-        background: applyGradient(ELEVATED_BG[variant], gradient),
+        fill,
+        cssBackground: applyGradient(fill, gradient),
         color: "var(--color-on-surface)",
-        border: "none",
+        stroke: "none",
+        strokeWidth: 0,
         ...(isAlert ? { accentBar: ACCENT[variant] } : {}),
         boxShadow: "var(--shadow-m3-1)",
         filter: "var(--filter-m3-1)",
@@ -183,9 +197,11 @@ export function resolveNotchTheme(theme?: NotchTheme): ResolvedTheme {
     }
     case "ghost": {
       return {
-        background: "transparent",
+        fill: "transparent",
+        cssBackground: "transparent",
         color: ACCENT[variant],
-        border: "none",
+        stroke: "none",
+        strokeWidth: 0,
         boxShadow: "none",
         filter: "none",
       };

--- a/src/components/ui/surfaces/notch-grid/theme.ts
+++ b/src/components/ui/surfaces/notch-grid/theme.ts
@@ -42,13 +42,10 @@ export interface ResolvedTheme {
    *  losing the lifted surface look. Renderers should paint this as a 4px
    *  vertical bar inside the chrome's clipped content area. */
   accentBar?: string;
-  /** CSS `box-shadow` — rectangular shadow on the bounding box. Kept for
-   *  consumers that want bounding-box shadows. */
-  boxShadow: string;
-  /** CSS `filter` — drop-shadow chain that traces the actual rendered shape
-   *  (SVG paths, notches). Use this on a wrapper around the painted content
-   *  for accurate-to-outline shadows. `"none"` when no lift is intended. */
-  filter: string;
+  /** Whether this chrome reads as lifted. Renderers apply a drop-shadow that
+   *  traces the rendered shape (e.g. Tailwind's `drop-shadow-lg`, which is a
+   *  `filter` so it follows the notched SVG outline, not the bounding box). */
+  elevated: boolean;
 }
 
 const DEFAULT_VARIANT: Exclude<ThemeVariant, "auto"> = "neutral";
@@ -166,8 +163,7 @@ export function resolveNotchTheme(theme?: NotchTheme): ResolvedTheme {
         color: FILL_FG[variant],
         stroke: "none",
         strokeWidth: 0,
-        boxShadow: "none",
-        filter: "none",
+        elevated: false,
       };
     }
     case "outlined": {
@@ -177,8 +173,7 @@ export function resolveNotchTheme(theme?: NotchTheme): ResolvedTheme {
         color: ACCENT[variant],
         stroke: OUTLINE_BORDER[variant],
         strokeWidth: 1,
-        boxShadow: "none",
-        filter: "none",
+        elevated: false,
       };
     }
     case "elevated": {
@@ -193,8 +188,7 @@ export function resolveNotchTheme(theme?: NotchTheme): ResolvedTheme {
         stroke: "none",
         strokeWidth: 0,
         ...(isAlert ? { accentBar: ACCENT[variant] } : {}),
-        boxShadow: "var(--shadow-m3-1)",
-        filter: "var(--filter-m3-1)",
+        elevated: true,
       };
     }
     case "ghost": {
@@ -204,8 +198,7 @@ export function resolveNotchTheme(theme?: NotchTheme): ResolvedTheme {
         color: ACCENT[variant],
         stroke: "none",
         strokeWidth: 0,
-        boxShadow: "none",
-        filter: "none",
+        elevated: false,
       };
     }
   }

--- a/src/components/ui/surfaces/notch-grid/theme.ts
+++ b/src/components/ui/surfaces/notch-grid/theme.ts
@@ -32,8 +32,13 @@ export interface ResolvedTheme {
   border: string;
   /** CSS `border-left` for elevated warn/error (color cue layered on lift). */
   borderLeft?: string;
-  /** CSS `box-shadow` — token reference or `"none"`. */
+  /** CSS `box-shadow` — rectangular shadow on the bounding box. Kept for
+   *  consumers that want bounding-box shadows. */
   boxShadow: string;
+  /** CSS `filter` — drop-shadow chain that traces the actual rendered shape
+   *  (SVG paths, notches). Use this on a wrapper around the painted content
+   *  for accurate-to-outline shadows. `"none"` when no lift is intended. */
+  filter: string;
 }
 
 const DEFAULT_VARIANT: Exclude<ThemeVariant, "auto"> = "neutral";
@@ -150,6 +155,7 @@ export function resolveNotchTheme(theme?: NotchTheme): ResolvedTheme {
         color: FILL_FG[variant],
         border: "none",
         boxShadow: "none",
+        filter: "none",
       };
     }
     case "outlined": {
@@ -158,6 +164,7 @@ export function resolveNotchTheme(theme?: NotchTheme): ResolvedTheme {
         color: ACCENT[variant],
         border: `1px solid ${OUTLINE_BORDER[variant]}`,
         boxShadow: "none",
+        filter: "none",
       };
     }
     case "elevated": {
@@ -168,6 +175,7 @@ export function resolveNotchTheme(theme?: NotchTheme): ResolvedTheme {
         border: "none",
         ...(isAlert ? { borderLeft: `4px solid ${ACCENT[variant]}` } : {}),
         boxShadow: "var(--shadow-m3-1)",
+        filter: "var(--filter-m3-1)",
       };
     }
     case "ghost": {
@@ -176,6 +184,7 @@ export function resolveNotchTheme(theme?: NotchTheme): ResolvedTheme {
         color: ACCENT[variant],
         border: "none",
         boxShadow: "none",
+        filter: "none",
       };
     }
   }

--- a/src/components/ui/surfaces/notch/Notch.stories.tsx
+++ b/src/components/ui/surfaces/notch/Notch.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { Notch } from "./Notch";
 
 const meta: Meta<typeof Notch> = {
-  title: "UI/Surfaces/Notch",
+  title: "UI/Notch/Notch",
   component: Notch,
   args: {
     width: 200,

--- a/src/theme.css
+++ b/src/theme.css
@@ -82,6 +82,20 @@
   --shadow-m3-5: 0 4px 4px 0 color-mix(in srgb, var(--color-shadow) 30%, transparent),
                  0 8px 12px 6px color-mix(in srgb, var(--color-shadow) 15%, transparent);
 
+  /* Same M3 elevation, expressed as CSS `filter` chains so the shadow traces
+   * the actual rendered shape (SVG paths, notched outlines) instead of the
+   * rectangular bounding box. */
+  --filter-m3-1: drop-shadow(0 1px 2px color-mix(in srgb, var(--color-shadow) 30%, transparent))
+                 drop-shadow(0 1px 3px color-mix(in srgb, var(--color-shadow) 15%, transparent));
+  --filter-m3-2: drop-shadow(0 1px 2px color-mix(in srgb, var(--color-shadow) 30%, transparent))
+                 drop-shadow(0 2px 6px color-mix(in srgb, var(--color-shadow) 15%, transparent));
+  --filter-m3-3: drop-shadow(0 1px 3px color-mix(in srgb, var(--color-shadow) 30%, transparent))
+                 drop-shadow(0 4px 8px color-mix(in srgb, var(--color-shadow) 15%, transparent));
+  --filter-m3-4: drop-shadow(0 2px 3px color-mix(in srgb, var(--color-shadow) 30%, transparent))
+                 drop-shadow(0 6px 10px color-mix(in srgb, var(--color-shadow) 15%, transparent));
+  --filter-m3-5: drop-shadow(0 4px 4px color-mix(in srgb, var(--color-shadow) 30%, transparent))
+                 drop-shadow(0 8px 12px color-mix(in srgb, var(--color-shadow) 15%, transparent));
+
   /* Font */
   --font-sans: "Shantell Sans", -apple-system, BlinkMacSystemFont, "Segoe UI",
     Roboto, sans-serif;

--- a/src/theme.css
+++ b/src/theme.css
@@ -70,32 +70,6 @@
   --color-shadow: #000000;
   --color-scrim: #000000;
 
-  /* Material Design 3 elevation — see m3.material.io/styles/elevation */
-  --shadow-m3-1: 0 1px 2px 0 color-mix(in srgb, var(--color-shadow) 30%, transparent),
-                 0 1px 3px 1px color-mix(in srgb, var(--color-shadow) 15%, transparent);
-  --shadow-m3-2: 0 1px 2px 0 color-mix(in srgb, var(--color-shadow) 30%, transparent),
-                 0 2px 6px 2px color-mix(in srgb, var(--color-shadow) 15%, transparent);
-  --shadow-m3-3: 0 1px 3px 0 color-mix(in srgb, var(--color-shadow) 30%, transparent),
-                 0 4px 8px 3px color-mix(in srgb, var(--color-shadow) 15%, transparent);
-  --shadow-m3-4: 0 2px 3px 0 color-mix(in srgb, var(--color-shadow) 30%, transparent),
-                 0 6px 10px 4px color-mix(in srgb, var(--color-shadow) 15%, transparent);
-  --shadow-m3-5: 0 4px 4px 0 color-mix(in srgb, var(--color-shadow) 30%, transparent),
-                 0 8px 12px 6px color-mix(in srgb, var(--color-shadow) 15%, transparent);
-
-  /* Same M3 elevation, expressed as CSS `filter` chains so the shadow traces
-   * the actual rendered shape (SVG paths, notched outlines) instead of the
-   * rectangular bounding box. */
-  --filter-m3-1: drop-shadow(0 1px 2px color-mix(in srgb, var(--color-shadow) 30%, transparent))
-                 drop-shadow(0 1px 3px color-mix(in srgb, var(--color-shadow) 15%, transparent));
-  --filter-m3-2: drop-shadow(0 1px 2px color-mix(in srgb, var(--color-shadow) 30%, transparent))
-                 drop-shadow(0 2px 6px color-mix(in srgb, var(--color-shadow) 15%, transparent));
-  --filter-m3-3: drop-shadow(0 1px 3px color-mix(in srgb, var(--color-shadow) 30%, transparent))
-                 drop-shadow(0 4px 8px color-mix(in srgb, var(--color-shadow) 15%, transparent));
-  --filter-m3-4: drop-shadow(0 2px 3px color-mix(in srgb, var(--color-shadow) 30%, transparent))
-                 drop-shadow(0 6px 10px color-mix(in srgb, var(--color-shadow) 15%, transparent));
-  --filter-m3-5: drop-shadow(0 4px 4px color-mix(in srgb, var(--color-shadow) 30%, transparent))
-                 drop-shadow(0 8px 12px color-mix(in srgb, var(--color-shadow) 15%, transparent));
-
   /* Font */
   --font-sans: "Shantell Sans", -apple-system, BlinkMacSystemFont, "Segoe UI",
     Roboto, sans-serif;


### PR DESCRIPTION
Fourth slice of the notch-grid v2 stack — the centerpiece. Wires `solveLayout` + `BlockShape` + `resolveNotchTheme` into the public component, with sub-item nesting, theme application, and the **gain-1-col / 1fr** container-sizing rule. No drag — that's PRs 5–7.

This PR is the **graduation trigger** for the design doc.

Design doc: [`mirrorstack-docs/architecture/notch-grid-v2/`](https://github.com/mirrorstack-ai/mirrorstack-docs/tree/main/architecture/notch-grid-v2).

## What's in this PR

| File | Purpose |
|---|---|
| `NotchGrid.tsx` (new) | Public component + internal `NotchItem` (recursive for sub-items) |
| `NotchGrid.test.tsx` (new) | 9 tests using @testing-library + a `ResizeObserver` stub |
| `NotchGrid.stories.tsx` (new) | 7 stories: Basic, AutoSize, SubItems, PriorityFallback, ThemeGallery, UnknownPrimitive, OverviewPage |

### Public API

```tsx
<NotchGrid
  items={items}            // NotchGridItem[]
  cols={"auto" | number}   // "auto" — gain-1-col rule (default)
  blockMin={96}            // px — column-gain threshold
  gap={8}                  // px — notch erosion
  primitives={primitives}  // ui.type → ComponentType
  onItemError={…}          // L3 hook (per dynamic-ui TBD 04 L3)
  className={…}
/>
```

Types exported: `NotchGridItem`, `NotchSubItem`, `NotchGridUI`, `PrimitiveRegistry`, `NotchGridError`, `ItemKey`.

### Gain-1-col rule (per the user-confirmed sizing decision)

```
cols  = max(1, floor(containerWidth / blockMin))
block = containerWidth / cols
```

ResizeObserver re-measures and resolves layout on width change. Block size sits in `[blockMin, 2*blockMin)` — never leaves dead edge space, never fractional col counts.

### Theme application

Per item: `resolveNotchTheme(item.theme)` → `{background, color, border, borderLeft?, boxShadow}`. The grid:
- Feeds `background` (solid tokens) + parsed `border` to `BlockShape`'s `fill` / `stroke` / `strokeWidth`
- Applies `color`, `boxShadow`, optional `borderLeft` to the positioning wrapper

**Sub-items** inherit `type` from the parent panel; only `variant` and `gradient` overridable (per design — visual coherence).

### Kit conventions honored

- **No `"use client"`** in the component file (per `CLAUDE.md`). The grid is SSR-safe: it renders nothing for placements pre-measurement; layout resolves in `useLayoutEffect` post-mount. The consuming Next.js app sets the Client Component boundary.
- `meta: ComponentMeta` exported → `pnpm components validate` passes (55/55).
- `if (isDev) console.warn(...)` for the pathological "items don't fit horizontally" case.

### Known deferrals (tracked for follow-ups)

| Item | Why | Lands in |
|---|---|---|
| **Gradient overlay** | SVG `fill` doesn't take `linear-gradient(...)` strings; needs a layered approach | Follow-up PR or PR 5 |
| **`groupKey` adjacency-link** | Renders separate chromes today; unified chrome needs union-of-masks rendering | PR 6 |
| **`@code-exec:*` body execution** | Renderer concern (per design); grid forwards the `code` field through `ui` props | The future renderer in `web-applications` |

### Design doc graduation

After this lands I'll patch `mirrorstack-docs/architecture/notch-grid-v2/` in a small follow-up:
- README: `status: proposed-changes-pending` → `live`
- `02-api.md`: replace `block={96}` with the `cols="auto" + blockMin` API; clarify no-`"use client"`
- `03-theme-tokens.md`: note the gradient deferral

## Verification

```
pnpm typecheck                                                              # clean
pnpm test src/components/ui/surfaces/notch-grid src/utils/grid-outline      # 105/105 pass
pnpm components validate                                                    # 55/55 valid
```

| Suite | Tests |
|---|---|
| `NotchGrid.test.tsx` (new) | **9** |
| `theme.test.ts` (PR 3) | 27 |
| `layout.test.ts` (PR 2) | 33 |
| `breakpoints.test.ts` (PR 1) | 16 |
| `grid-outline.test.ts` (PR 1) | 14 |
| `BlockShape.test.tsx` (PR 1) | 6 |

Pre-existing `ThemeProvider` failures on `main` unchanged and untouched.

## What follows

| # | What |
|---|---|
| 5 | Outer-grid drag-to-place — re-targeted from closed #192 |
| 6 | Sub-drag + promote + auto-link (groupKey union) — re-targeted from closed #193 |
| 7 | Drag-active visuals + linked-chrome drag — re-targeted from closed #194 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)