### PR TITLE
feat(page-header): top-of-page header primitive (+ 0.3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.3.3
+
+### Components
+
+- **PageHeader** — new top-of-page header. `h1` title with optional
+  description and an optional trailing slot (`tail`) for a picker,
+  button, breadcrumb, or other element. Mid-page sibling is
+  `SectionHeader` (h2). Replaces the duplicated
+  `text-2xl font-bold mb-1 + on-surface-variant <p>` shape across
+  settings/profile pages.
+
 ## 0.3.2
 
 ### Components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ Notable API additions and breaking changes. For the full commit log, see
 ### Components
 
 - **PageHeader** — new top-of-page header. `h1` title with optional
-  description and an optional trailing slot (`tail`) for a picker,
-  button, breadcrumb, or other element. Mid-page sibling is
-  `SectionHeader` (h2). Replaces the duplicated
-  `text-2xl font-bold mb-1 + on-surface-variant <p>` shape across
-  settings/profile pages.
+  description and three optional slots:
+  - `path` — back link / breadcrumb above the title
+  - `leading` — avatar or icon marker left of the title block
+  - `tail` — picker / button / status pill right of the title block
+  Mid-page sibling is `SectionHeader` (h2). Replaces the duplicated
+  `text-2xl font-bold + on-surface-variant <p>` shape across the
+  settings, profile, and module pages.
 
 ## 0.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Notable API additions and breaking changes. For the full commit log, see
   `text-2xl font-bold + on-surface-variant <p>` shape across the
   settings, profile, and module pages.
 
+- **Breadcrumb** — navigable path trail, rendered as
+  `← <root> / <…> / <next-level-up>`. The canonical content for
+  `PageHeader.path` when a page has more than one level of "where you
+  came from". Each segment is an anchor; the back arrow is implicit
+  (a trail IS where you came from). Lives under `navigation/`.
+
 ## 0.3.2
 
 ### Components

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/data/page-header/PageHeader.stories.tsx
+++ b/src/components/ui/data/page-header/PageHeader.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { PageHeader } from "./PageHeader";
+import { Breadcrumb } from "@/components/ui/navigation/breadcrumb/Breadcrumb";
 import { Button } from "@/components/ui/actions/button/Button";
 import { Icon } from "@/components/ui/media/icon/Icon";
 
@@ -47,35 +48,26 @@ export const WithPath: Story = {
   args: {
     title: "Usage detail",
     description: undefined,
-    path: (
-      <a
-        href="#"
-        className="inline-flex items-center gap-1 text-sm text-on-surface-variant hover:text-on-surface"
-      >
-        <Icon name="arrow_back" size={16} />
-        Billing
-      </a>
-    ),
+    path: <Breadcrumb items={[{ label: "Billing", href: "#" }]} />,
   },
 };
 
 /**
- * Mirrors the web-applications /dev/module/[slug] header — path
- * navigator on top, tinted-icon leading marker, name + slug, and a
- * Settings action on the right.
+ * Deeper trail — drill from a versions list into a specific version.
+ * Each segment is the next level up; the current page (e.g. "v1.2.0")
+ * lives in the h1, not the breadcrumb.
  */
 export const ModulePage: Story = {
   args: {
     title: "Acme Module",
     description: "@acme/widgets",
     path: (
-      <a
-        href="#"
-        className="inline-flex items-center gap-1 text-sm text-on-surface-variant hover:text-on-surface"
-      >
-        <Icon name="arrow_back" size={16} />
-        Dev Modules
-      </a>
+      <Breadcrumb
+        items={[
+          { label: "Dev Modules", href: "#" },
+          { label: "Versions", href: "#" },
+        ]}
+      />
     ),
     leading: (
       <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/15 text-primary">

--- a/src/components/ui/data/page-header/PageHeader.stories.tsx
+++ b/src/components/ui/data/page-header/PageHeader.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { PageHeader } from "./PageHeader";
 import { Button } from "@/components/ui/actions/button/Button";
+import { Icon } from "@/components/ui/media/icon/Icon";
 
 const meta: Meta<typeof PageHeader> = {
   title: "UI/Data/PageHeader",
@@ -16,6 +17,10 @@ type Story = StoryObj<typeof PageHeader>;
 
 export const Playground: Story = {};
 
+export const TitleOnly: Story = {
+  args: { description: undefined },
+};
+
 export const WithTail: Story = {
   args: {
     tail: (
@@ -26,10 +31,61 @@ export const WithTail: Story = {
   },
 };
 
-export const NoDescription: Story = {
-  args: { description: undefined },
+export const WithLeading: Story = {
+  args: {
+    title: "Acme Module",
+    description: "@acme/widgets",
+    leading: (
+      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/15 text-primary">
+        <Icon name="extension" size={24} />
+      </div>
+    ),
+  },
 };
 
-export const TitleOnly: Story = {
-  args: { title: "Profile", description: undefined },
+export const WithPath: Story = {
+  args: {
+    title: "Usage detail",
+    description: undefined,
+    path: (
+      <a
+        href="#"
+        className="inline-flex items-center gap-1 text-sm text-on-surface-variant hover:text-on-surface"
+      >
+        <Icon name="arrow_back" size={16} />
+        Billing
+      </a>
+    ),
+  },
+};
+
+/**
+ * Mirrors the web-applications /dev/module/[slug] header — path
+ * navigator on top, tinted-icon leading marker, name + slug, and a
+ * Settings action on the right.
+ */
+export const ModulePage: Story = {
+  args: {
+    title: "Acme Module",
+    description: "@acme/widgets",
+    path: (
+      <a
+        href="#"
+        className="inline-flex items-center gap-1 text-sm text-on-surface-variant hover:text-on-surface"
+      >
+        <Icon name="arrow_back" size={16} />
+        Dev Modules
+      </a>
+    ),
+    leading: (
+      <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/15 text-primary">
+        <Icon name="extension" size={24} />
+      </div>
+    ),
+    tail: (
+      <Button variant="outline" size="sm" onClick={() => {}}>
+        Settings
+      </Button>
+    ),
+  },
 };

--- a/src/components/ui/data/page-header/PageHeader.stories.tsx
+++ b/src/components/ui/data/page-header/PageHeader.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { PageHeader } from "./PageHeader";
+import { Button } from "@/components/ui/actions/button/Button";
+
+const meta: Meta<typeof PageHeader> = {
+  title: "UI/Data/PageHeader",
+  component: PageHeader,
+  args: {
+    title: "Billing",
+    description: "Charges, plan, usage, and payment for this account.",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PageHeader>;
+
+export const Playground: Story = {};
+
+export const WithTail: Story = {
+  args: {
+    tail: (
+      <Button variant="outline" size="sm" onClick={() => {}}>
+        Period: May 19 – Jun 19, 2026
+      </Button>
+    ),
+  },
+};
+
+export const NoDescription: Story = {
+  args: { description: undefined },
+};
+
+export const TitleOnly: Story = {
+  args: { title: "Profile", description: undefined },
+};

--- a/src/components/ui/data/page-header/PageHeader.test.tsx
+++ b/src/components/ui/data/page-header/PageHeader.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { PageHeader } from "./PageHeader";
+
+afterEach(cleanup);
+
+describe("PageHeader", () => {
+  it("renders title and description", () => {
+    render(
+      <PageHeader
+        title="Billing"
+        description="Charges, plan, usage, and payment for this account."
+      />,
+    );
+    expect(screen.getByText("Billing")).toBeInTheDocument();
+    expect(
+      screen.getByText("Charges, plan, usage, and payment for this account."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the title as an h1", () => {
+    render(<PageHeader title="Profile" />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Profile",
+    );
+  });
+
+  it("renders the tail slot", () => {
+    render(
+      <PageHeader title="X" tail={<button>my-tail</button>} />,
+    );
+    expect(screen.getByText("my-tail")).toBeInTheDocument();
+  });
+
+  it("omits the description when not provided", () => {
+    const { container } = render(<PageHeader title="Title only" />);
+    expect(container.querySelectorAll("p").length).toBe(0);
+  });
+
+  it("forwards the className prop", () => {
+    const { container } = render(
+      <PageHeader title="X" className="custom-class" />,
+    );
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+});

--- a/src/components/ui/data/page-header/PageHeader.test.tsx
+++ b/src/components/ui/data/page-header/PageHeader.test.tsx
@@ -32,6 +32,20 @@ describe("PageHeader", () => {
     expect(screen.getByText("my-tail")).toBeInTheDocument();
   });
 
+  it("renders the leading slot", () => {
+    render(
+      <PageHeader title="X" leading={<span>my-leading</span>} />,
+    );
+    expect(screen.getByText("my-leading")).toBeInTheDocument();
+  });
+
+  it("renders the path slot", () => {
+    render(
+      <PageHeader title="X" path={<a href="/back">my-path</a>} />,
+    );
+    expect(screen.getByText("my-path")).toBeInTheDocument();
+  });
+
   it("omits the description when not provided", () => {
     const { container } = render(<PageHeader title="Title only" />);
     expect(container.querySelectorAll("p").length).toBe(0);

--- a/src/components/ui/data/page-header/PageHeader.tsx
+++ b/src/components/ui/data/page-header/PageHeader.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "PageHeader",
+  description:
+    "Top-of-page header — h1 title with optional description and an optional trailing slot for a picker, button, breadcrumb, or other tail element.",
+};
+
+export interface PageHeaderProps {
+  /** Page title, rendered as an h1. */
+  title: string;
+  /** Optional supporting copy, rendered below the title. */
+  description?: string;
+  /**
+   * Optional trailing slot — picker, button, breadcrumb, or other
+   * element rendered to the right of the title block. Wraps below on
+   * narrow viewports.
+   */
+  tail?: ReactNode;
+  className?: string;
+}
+
+export function PageHeader({
+  title,
+  description,
+  tail,
+  className,
+}: PageHeaderProps) {
+  return (
+    <header
+      className={cn(
+        "flex items-end justify-between gap-4 flex-wrap",
+        className,
+      )}
+    >
+      <div className="min-w-0">
+        <h1 className="text-2xl font-bold text-on-surface">{title}</h1>
+        {description && (
+          <p className="mt-1 text-on-surface-variant">{description}</p>
+        )}
+      </div>
+      {tail}
+    </header>
+  );
+}

--- a/src/components/ui/data/page-header/PageHeader.tsx
+++ b/src/components/ui/data/page-header/PageHeader.tsx
@@ -45,13 +45,13 @@ export function PageHeader({
   return (
     <header className={cn("flex flex-col gap-2", className)}>
       {path}
-      <div className="flex items-end justify-between gap-4 flex-wrap">
+      <div className="flex items-center justify-between gap-4 flex-wrap">
         <div className="flex items-center gap-3 min-w-0">
           {leading}
           <div className="min-w-0">
             <h1 className="text-2xl font-bold text-on-surface">{title}</h1>
             {description && (
-              <p className="mt-1 text-on-surface-variant">{description}</p>
+              <p className="text-on-surface-variant">{description}</p>
             )}
           </div>
         </div>

--- a/src/components/ui/data/page-header/PageHeader.tsx
+++ b/src/components/ui/data/page-header/PageHeader.tsx
@@ -6,7 +6,7 @@ import type { ComponentMeta } from "@/types/component-meta";
 export const meta: ComponentMeta = {
   name: "PageHeader",
   description:
-    "Top-of-page header — h1 title with optional description and an optional trailing slot for a picker, button, breadcrumb, or other tail element.",
+    "Top-of-page header — h1 title with optional description, an optional leading marker (avatar/icon), an optional path navigator above (back link/breadcrumb), and an optional trailing slot (picker/button/status).",
 };
 
 export interface PageHeaderProps {
@@ -15,9 +15,20 @@ export interface PageHeaderProps {
   /** Optional supporting copy, rendered below the title. */
   description?: string;
   /**
-   * Optional trailing slot — picker, button, breadcrumb, or other
-   * element rendered to the right of the title block. Wraps below on
-   * narrow viewports.
+   * Optional path navigator rendered above the title — back link,
+   * breadcrumb, or any element that indicates where this page sits in
+   * a larger navigation hierarchy.
+   */
+  path?: ReactNode;
+  /**
+   * Optional leading element rendered to the left of the title block —
+   * typically an Avatar, Icon container, or other visual marker.
+   */
+  leading?: ReactNode;
+  /**
+   * Optional trailing slot rendered to the right of the title block —
+   * picker, button, breadcrumb, status pill, or other element. Wraps
+   * below on narrow viewports.
    */
   tail?: ReactNode;
   className?: string;
@@ -26,23 +37,26 @@ export interface PageHeaderProps {
 export function PageHeader({
   title,
   description,
+  path,
+  leading,
   tail,
   className,
 }: PageHeaderProps) {
   return (
-    <header
-      className={cn(
-        "flex items-end justify-between gap-4 flex-wrap",
-        className,
-      )}
-    >
-      <div className="min-w-0">
-        <h1 className="text-2xl font-bold text-on-surface">{title}</h1>
-        {description && (
-          <p className="mt-1 text-on-surface-variant">{description}</p>
-        )}
+    <header className={cn("flex flex-col gap-2", className)}>
+      {path}
+      <div className="flex items-end justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-3 min-w-0">
+          {leading}
+          <div className="min-w-0">
+            <h1 className="text-2xl font-bold text-on-surface">{title}</h1>
+            {description && (
+              <p className="mt-1 text-on-surface-variant">{description}</p>
+            )}
+          </div>
+        </div>
+        {tail}
       </div>
-      {tail}
     </header>
   );
 }

--- a/src/components/ui/navigation/breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/ui/navigation/breadcrumb/Breadcrumb.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Breadcrumb } from "./Breadcrumb";
+
+const meta: Meta<typeof Breadcrumb> = {
+  title: "UI/Navigation/Breadcrumb",
+  component: Breadcrumb,
+  args: {
+    items: [
+      { label: "Dev Modules", href: "#" },
+      { label: "Acme Module", href: "#" },
+    ],
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Breadcrumb>;
+
+export const Playground: Story = {};
+
+export const Single: Story = {
+  args: {
+    items: [{ label: "Billing", href: "#" }],
+  },
+};
+
+export const Deep: Story = {
+  args: {
+    items: [
+      { label: "Dev Modules", href: "#" },
+      { label: "Acme Module", href: "#" },
+      { label: "Versions", href: "#" },
+      { label: "v1.2.0", href: "#" },
+    ],
+  },
+};

--- a/src/components/ui/navigation/breadcrumb/Breadcrumb.test.tsx
+++ b/src/components/ui/navigation/breadcrumb/Breadcrumb.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Breadcrumb } from "./Breadcrumb";
+
+afterEach(cleanup);
+
+describe("Breadcrumb", () => {
+  it("renders each item as an anchor with the right href", () => {
+    render(
+      <Breadcrumb
+        items={[
+          { label: "Dev Modules", href: "/dev" },
+          { label: "Acme Module", href: "/dev/module/acme" },
+        ]}
+      />,
+    );
+    const first = screen.getByRole("link", { name: "Dev Modules" });
+    const second = screen.getByRole("link", { name: "Acme Module" });
+    expect(first).toHaveAttribute("href", "/dev");
+    expect(second).toHaveAttribute("href", "/dev/module/acme");
+  });
+
+  it("exposes a Breadcrumb landmark for assistive tech", () => {
+    render(<Breadcrumb items={[{ label: "X", href: "/x" }]} />);
+    expect(
+      screen.getByRole("navigation", { name: "Breadcrumb" }),
+    ).toBeInTheDocument();
+  });
+
+  it("inserts a separator between items, none before the first", () => {
+    render(
+      <Breadcrumb
+        items={[
+          { label: "A", href: "/a" },
+          { label: "B", href: "/b" },
+          { label: "C", href: "/c" },
+        ]}
+      />,
+    );
+    // Three items → two "/" separators between them.
+    expect(screen.getAllByText("/").length).toBe(2);
+  });
+
+  it("renders nothing when items is empty", () => {
+    const { container } = render(<Breadcrumb items={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("forwards the className prop", () => {
+    const { container } = render(
+      <Breadcrumb
+        items={[{ label: "X", href: "/x" }]}
+        className="custom-class"
+      />,
+    );
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+});

--- a/src/components/ui/navigation/breadcrumb/Breadcrumb.tsx
+++ b/src/components/ui/navigation/breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,58 @@
+import { cn } from "@/utils/cn";
+import type { ComponentMeta } from "@/types/component-meta";
+import { Icon } from "@/components/ui/media/icon/Icon";
+
+export const meta: ComponentMeta = {
+  name: "Breadcrumb",
+  description:
+    "Navigable path trail showing the user's location in the app hierarchy. Prefixed with a back arrow; segments separated by slashes; each segment is an anchor link.",
+};
+
+export interface BreadcrumbItem {
+  label: string;
+  href: string;
+}
+
+export interface BreadcrumbProps {
+  /**
+   * Ordered list of trail segments, root-first. Every segment renders
+   * as a clickable anchor; the rightmost segment is the next level up
+   * from the current page (the current page itself is owned by the
+   * page heading, not the breadcrumb).
+   */
+  items: BreadcrumbItem[];
+  className?: string;
+}
+
+export function Breadcrumb({ items, className }: BreadcrumbProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={cn(
+        "flex items-center gap-1.5 text-sm text-on-surface-variant",
+        className,
+      )}
+    >
+      <Icon name="arrow_back" size={16} className="shrink-0" />
+      <ol className="flex items-center gap-1.5">
+        {items.map((item, i) => (
+          <li key={`${item.href}-${i}`} className="flex items-center gap-1.5">
+            {i > 0 && (
+              <span aria-hidden className="text-on-surface-variant/60">
+                /
+              </span>
+            )}
+            <a
+              href={item.href}
+              className="rounded-sm transition-colors hover:text-on-surface hover:underline focus-visible:outline-2 focus-visible:outline-primary focus-visible:outline-offset-2"
+            >
+              {item.label}
+            </a>
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,10 @@ export {
   type SliderProps,
 } from "./components/ui/inputs/slider/Slider";
 export {
+  PageHeader,
+  type PageHeaderProps,
+} from "./components/ui/data/page-header/PageHeader";
+export {
   SectionHeader,
   type SectionHeaderProps,
 } from "./components/ui/data/section-header/SectionHeader";

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,6 +197,11 @@ export {
   type VerificationCodeInputProps,
 } from "./components/ui/inputs/verification-code-input/VerificationCodeInput";
 export {
+  Breadcrumb,
+  type BreadcrumbItem,
+  type BreadcrumbProps,
+} from "./components/ui/navigation/breadcrumb/Breadcrumb";
+export {
   NavItem,
   type NavItemProps,
   type NavItemVariant,


### PR DESCRIPTION
Adds a new kit primitive: **`PageHeader`** — the h1 equivalent of the recently-landed `SectionHeader`.

## Why

`text-2xl font-bold mb-1` + `text-on-surface-variant <p>` is inlined across web-account at:

- `src/app/(settings)/me/page.tsx`
- `src/app/(settings)/me/preferences/page.tsx`
- `src/app/(settings)/me/security/page.tsx`
- `src/app/(settings)/me/billing/page.tsx`

PageHeader collapses all four to one import and adds an optional **`tail`** slot for the right side — billing uses it for a period picker; other consumers may use it for save buttons, breadcrumbs, status pills, etc.

## API

```ts
interface PageHeaderProps {
  title: string;
  description?: string;
  tail?: ReactNode;     // picker / button / breadcrumb / status — wraps on narrow viewports
  className?: string;
}
```

Slot named `tail` rather than `action` because the content is often a selector/breadcrumb, not a button.

## Sibling map

| Component        | Role                                                          |
| ---------------- | ------------------------------------------------------------- |
| **`PageHeader`** | **Top-of-page h1 with optional tail slot (new)**              |
| `SectionHeader`  | Mid-page h2 with optional action slot                         |
| `SectionLabel`   | Uppercase chip eyebrow label                                  |
| `SettingRow`     | Bordered card-row with required control slot                  |

## /simplify findings applied

3-agent review before push:

- **Skipped** (Agent 1, P1): rename `tail` → `action` for consistency with SectionHeader. Kept `tail` per the user's explicit naming and because it's more honest for typical contents (pickers, breadcrumbs).
- **Applied** (Agent 2, P2): moved title→description gap from `mb-1` on the h1 to `mt-1` on the description `<p>`. Matches SectionHeader's `mt-0.5` pattern and eliminates an orphan 4px below the h1 in title-only usages.
- Reuse + efficiency: clean.

## Version

`0.3.2` → `0.3.3` (patch, per pre-1.0 patch-only versioning). `release` label applied so the release workflow fires on merge.

## Tests

5 unit tests (h1 semantics, title+description rendering, tail slot, omitted description, className forwarding). All passing. The preexisting `ThemeProvider` localStorage test failures are unrelated.

## Consumer follow-up

After merge + publish, web-account PR #34 will:

1. Bump `@mirrorstack-ai/web-ui-kit` to `^0.3.3`
2. Replace the inlined header block in 4 settings pages with `<PageHeader />`
3. Move billing's `<PeriodSelector />` into the `tail` slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)