### PR TITLE
fix(dialog): compensate scrollbar gutter when locking body scroll (0.3.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/surfaces/dialog/Dialog.test.tsx
+++ b/src/components/ui/surfaces/dialog/Dialog.test.tsx
@@ -60,4 +60,66 @@ describe("Dialog", () => {
     expect(dialog).toHaveAttribute("aria-modal", "true");
     expect(dialog).toHaveAttribute("aria-labelledby");
   });
+
+  it("compensates scrollbar gutter with paddingRight when locking scroll", () => {
+    // Simulate a vertical scrollbar: viewport is 1024px wide but
+    // the document only has 1009px of usable width (15px gutter).
+    const originalInnerWidth = window.innerWidth;
+    const originalClientWidth = document.documentElement.clientWidth;
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1024,
+    });
+    Object.defineProperty(document.documentElement, "clientWidth", {
+      configurable: true,
+      value: 1009,
+    });
+    try {
+      const { rerender } = render(<Dialog open title="Test" />);
+      expect(document.body.style.overflow).toBe("hidden");
+      expect(document.body.style.paddingRight).toBe("15px");
+      rerender(<Dialog open={false} title="Test" />);
+      expect(document.body.style.overflow).toBe("");
+      expect(document.body.style.paddingRight).toBe("");
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        value: originalInnerWidth,
+      });
+      Object.defineProperty(document.documentElement, "clientWidth", {
+        configurable: true,
+        value: originalClientWidth,
+      });
+    }
+  });
+
+  it("skips paddingRight when there's no scrollbar gutter", () => {
+    // Page already has scrollbar-gutter: stable (or no scrollbar at
+    // all), so innerWidth === clientWidth and locking scroll
+    // shouldn't add padding.
+    const originalInnerWidth = window.innerWidth;
+    const originalClientWidth = document.documentElement.clientWidth;
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1024,
+    });
+    Object.defineProperty(document.documentElement, "clientWidth", {
+      configurable: true,
+      value: 1024,
+    });
+    try {
+      render(<Dialog open title="Test" />);
+      expect(document.body.style.overflow).toBe("hidden");
+      expect(document.body.style.paddingRight).toBe("");
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        value: originalInnerWidth,
+      });
+      Object.defineProperty(document.documentElement, "clientWidth", {
+        configurable: true,
+        value: originalClientWidth,
+      });
+    }
+  });
 });

--- a/src/components/ui/surfaces/dialog/Dialog.tsx
+++ b/src/components/ui/surfaces/dialog/Dialog.tsx
@@ -33,16 +33,27 @@ export interface DialogProps {
 
 let scrollLockCount = 0;
 
+// Reserve the scrollbar gutter as right-padding while scroll is
+// locked, otherwise the page reflows by the gutter width (≈15px on
+// macOS Safari/Chrome) the moment overflow flips to hidden and the
+// scrollbar disappears. Pages that already opt into
+// `scrollbar-gutter: stable` at the html level will see gutter === 0
+// and skip the padding adjustment.
 function lockScroll() {
   if (typeof document === "undefined") return;
   scrollLockCount++;
-  if (scrollLockCount === 1) document.body.style.overflow = "hidden";
+  if (scrollLockCount !== 1) return;
+  const gutter = window.innerWidth - document.documentElement.clientWidth;
+  document.body.style.overflow = "hidden";
+  if (gutter > 0) document.body.style.paddingRight = `${gutter}px`;
 }
 
 function unlockScroll() {
   if (typeof document === "undefined") return;
   scrollLockCount = Math.max(0, scrollLockCount - 1);
-  if (scrollLockCount === 0) document.body.style.overflow = "";
+  if (scrollLockCount !== 0) return;
+  document.body.style.overflow = "";
+  document.body.style.paddingRight = "";
 }
 
 export function Dialog({


### PR DESCRIPTION
## What

Dialog now compensates for the scrollbar gutter when it locks body scroll, so opening a dialog no longer reflows the page horizontally.

- `lockScroll`/`unlockScroll` reserve the scrollbar width while the body is locked.
- Adds Dialog tests covering the gutter behavior.
- Patches `0.3.3 → 0.3.4` (pre-1.0 patch-only; paired with the `release` label).

## Note

This branch originally also extracted a `StripeSetupForm` primitive. That was reverted — a component whose entire UI is a Stripe-hosted iframe can't be rendered in Storybook, so it doesn't fit the design-system kit. It now lives in `web-account` next to its only consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)