### PR TITLE
chore(release): export NotchGrid + publish 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.3.5
+
+### Components
+
+- **NotchGrid** — now publicly exported (the v2 component landed in the
+  tarball at 0.3.4 but was not re-exported, so it was not importable). A
+  desire-driven notched layout for the dynamic-ui wire format: items
+  declare position/shape priorities, the solver packs them, and each
+  placement renders as a themed `BlockShape`. Supports the gain-1-col /
+  `1fr` auto-sizing rule (`cols="auto"` + `blockMin`), outer drag-to-place,
+  and sub-item drag + promote-to-top-level. Exports `NotchGrid` plus its
+  public types (`NotchGridProps`, `NotchGridItem`, `NotchSubItem`,
+  `NotchGridUI`, `PrimitiveRegistry`) and the desire/theme model types
+  (`Desire`, `Pos`, `Mask`, `Priority`, `NotchTheme`). Design doc:
+  [`mirrorstack-docs/architecture/notch-grid-v2/`](https://github.com/mirrorstack-ai/mirrorstack-docs/tree/main/architecture/notch-grid-v2).
+
+## 0.3.4
+
+### Components
+
+- **Dialog** — compensate for scrollbar-gutter when locking body scroll,
+  so opening a dialog no longer shifts the page content under it.
+
 ## 0.3.3
 
 ### Components

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,6 +239,27 @@ export {
   type NotchSide,
 } from "./components/ui/surfaces/notch/Notch";
 export {
+  NotchGrid,
+  type NotchGridProps,
+  type NotchGridItem,
+  type NotchSubItem,
+  type NotchGridUI,
+  type NotchGridError,
+  type PrimitiveRegistry,
+  type ItemKey,
+} from "./components/ui/surfaces/notch-grid/NotchGrid";
+export {
+  type Desire,
+  type Pos,
+  type Mask,
+  type Priority,
+} from "./components/ui/surfaces/notch-grid/layout";
+export {
+  type NotchTheme,
+  type ThemeType,
+  type ThemeVariant,
+} from "./components/ui/surfaces/notch-grid/theme";
+export {
   AgentSidebarHeader,
   type AgentSidebarHeaderProps,
   AgentSidebarInput,


### PR DESCRIPTION
## Summary

- **Export NotchGrid** from the package barrel (`src/index.ts`). notch-grid v2 source already shipped in the 0.3.4 tarball, but it was never re-exported — and `package.json` `exports` only exposes `.` (no deep imports), so `import { NotchGrid } from "@mirrorstack-ai/web-ui-kit"` failed. This is the change that actually makes notch-grid v2 consumable by `web-account` / `web-applications`.
- **Bump to 0.3.5** so the Release workflow tags `v0.3.5` and publishes to GitHub Packages on merge.
- **CHANGELOG**: add the 0.3.5 entry (NotchGrid now exported) and a retroactive 0.3.4 entry for the Dialog scrollbar-gutter fix (#233), which shipped without a changelog note.

Public surface now exported: `NotchGrid`, `NotchGridProps`, `NotchGridItem`, `NotchSubItem`, `NotchGridUI`, `PrimitiveRegistry`, `NotchGridError`, `ItemKey`, plus model types `Desire`, `Pos`, `Mask`, `Priority`, `NotchTheme`, `ThemeType`, `ThemeVariant`.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — emits `NotchGrid` into `dist/index.d.ts` + `dist/index.js`
- [x] notch-grid suite (21 tests) green
- [ ] CI green on Node 24 (local-only `ThemeProvider` failures are a Node 25 / jsdom `localStorage.clear` quirk, not present on CI's Node 24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)