### PR TITLE
feat(graph-side-content): prependClassName escape hatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/graph/graph-side/GraphSide.tsx
+++ b/src/components/ui/graph/graph-side/GraphSide.tsx
@@ -66,6 +66,11 @@ export interface GraphSideProps<T extends GraphSideNode = GraphSideNode> {
   /** Panel width — number for pixels, string for any CSS value. Default 260. */
   width?: number | string;
   className?: string;
+  /** Class passed straight to the auto-rendered GraphSideHeader.
+      Useful for theming the header per node — e.g. swapping the
+      surface to a success / warning / error tint while the details
+      body keeps its default styling. */
+  headerClassName?: string;
 }
 
 export function GraphSide<T extends GraphSideNode = GraphSideNode>({
@@ -75,6 +80,7 @@ export function GraphSide<T extends GraphSideNode = GraphSideNode>({
   renderDetails,
   width = 260,
   className,
+  headerClassName,
 }: GraphSideProps<T>) {
   // Remember the last non-null node so the close animation keeps showing
   // its label/tags while sliding out, instead of snapping to an empty header.
@@ -93,7 +99,7 @@ export function GraphSide<T extends GraphSideNode = GraphSideNode>({
       style={{ width }}
       aria-hidden={!isOpen}
     >
-      <GraphSideHeader node={display} onClose={onClose} />
+      <GraphSideHeader node={display} onClose={onClose} className={headerClassName} />
       <div className="flex-1 min-h-0 overflow-hidden">
         {isOpen && display ? renderDetails(display) : null}
       </div>

--- a/src/components/ui/graph/graph-side/GraphSideContent.tsx
+++ b/src/components/ui/graph/graph-side/GraphSideContent.tsx
@@ -24,10 +24,20 @@ export interface GraphSideContentProps {
       chevron, not toggleable). Use for a search input or other always-on
       controls. */
   prepend?: ReactNode;
+  /** Class for the wrapper around `prepend`. Defaults to
+      `"px-1 pt-1.5 pb-1"` (a tight inset that matches the items'
+      header padding). Pass an empty string when the consumer wants
+      the prepend to bleed edge-to-edge (e.g. a primary action button
+      that should share the same width as the divider below it), or
+      pass any other class to override entirely. The prepend slot
+      itself is omitted when `prepend` is nullish, regardless. */
+  prependClassName?: string;
   className?: string;
 }
 
-export function GraphSideContent({ items, prepend, className }: GraphSideContentProps) {
+const DEFAULT_PREPEND_CLS = "px-1 pt-1.5 pb-1";
+
+export function GraphSideContent({ items, prepend, prependClassName, className }: GraphSideContentProps) {
   const [openIds, setOpenIds] = useState<Set<string>>(
     () => new Set(items.map((i) => i.id)),
   );
@@ -49,7 +59,9 @@ export function GraphSideContent({ items, prepend, className }: GraphSideContent
         className,
       )}
     >
-      {prepend && <div className="px-1 pt-1.5 pb-1">{prepend}</div>}
+      {prepend && (
+        <div className={prependClassName ?? DEFAULT_PREPEND_CLS}>{prepend}</div>
+      )}
       {items.map((item) => {
         const isOpen = openIds.has(item.id);
         return (

--- a/src/components/ui/graph/graph-side/GraphSideContent.tsx
+++ b/src/components/ui/graph/graph-side/GraphSideContent.tsx
@@ -60,7 +60,9 @@ export function GraphSideContent({ items, prepend, prependClassName, className }
       )}
     >
       {prepend && (
-        <div className={prependClassName ?? DEFAULT_PREPEND_CLS}>{prepend}</div>
+        <div className={cn(prependClassName ?? DEFAULT_PREPEND_CLS)}>
+          {prepend}
+        </div>
       )}
       {items.map((item) => {
         const isOpen = openIds.has(item.id);


### PR DESCRIPTION
## Summary

The prepend slot on `GraphSideContent` was hard-wired to `"px-1 pt-1.5 pb-1"` — fine for text-only prepends, but fights anything that wants to flush against the panel edges (e.g. a full-width primary action button that should share width with the divider between prepend and items).

Add an optional `prependClassName?: string` prop that defaults to the existing class. Consumers can pass `""` to opt out of all padding, or any custom class to override.

## Why

Discovered while wiring an "Open settings" button into the side panel of a module-graph view (web-applications). The button needed to flush full-width but the prepend wrapper added a 4px inset, causing the button to be visually narrower than the divider below it.

## Behavior

| Caller | Result |
|---|---|
| omitted | `px-1 pt-1.5 pb-1` (current behavior) |
| `""` | no padding — content sits flush |
| any class | overrides entirely |

`label` field omitted → wrapper still renders with the chosen class. The `prepend` slot itself is omitted when `prepend` is nullish, regardless.

## Versioning

Patch bump 0.3.6 → 0.3.7 (pre-1.0 patch-only convention).

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm build` — green
- [ ] Reviewer: confirm existing stories that pass `prepend` still render correctly (no `prependClassName` provided = default class applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)