### PR TITLE
chore: drop info color, add Alert primary/secondary variants (v0.3.9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/data/setting-row/SettingRow.test.tsx
+++ b/src/components/ui/data/setting-row/SettingRow.test.tsx
@@ -48,7 +48,6 @@ describe("SettingRow", () => {
     ["error", "border-error/40"],
     ["warning", "border-warning/40"],
     ["success", "border-success/40"],
-    ["info", "border-info/40"],
   ] as const)("applies the %s tone border", (tone, expected) => {
     const { container } = render(
       <SettingRow title="X" control={<span />} tone={tone} />,

--- a/src/components/ui/feedback/alert/Alert.stories.tsx
+++ b/src/components/ui/feedback/alert/Alert.stories.tsx
@@ -5,13 +5,13 @@ const meta: Meta<typeof Alert> = {
   title: "UI/Feedback/Alert",
   component: Alert,
   args: {
-    variant: "info",
+    variant: "primary",
     children: "This is an informational alert message.",
   },
   argTypes: {
     variant: {
       control: "select",
-      options: ["error", "success", "warning", "info"],
+      options: ["error", "success", "warning", "primary", "secondary"],
     },
   },
 };
@@ -24,7 +24,7 @@ export const Playground: Story = {};
 export const Variants: Story = {
   render: () => (
     <div className="flex flex-col gap-3">
-      {(["info", "success", "warning", "error"] as AlertVariant[]).map((v) => (
+      {(["primary", "secondary", "success", "warning", "error"] as AlertVariant[]).map((v) => (
         <Alert key={v} variant={v}>
           This is a {v} alert message.
         </Alert>
@@ -52,7 +52,7 @@ export const Dismissible: Story = {
 
 export const WithCustomIcon: Story = {
   args: {
-    variant: "info",
+    variant: "primary",
     icon: "passkey",
     iconSize: 28,
     children: "Set up a passkey for faster verification next time.",

--- a/src/components/ui/feedback/alert/Alert.test.tsx
+++ b/src/components/ui/feedback/alert/Alert.test.tsx
@@ -6,7 +6,7 @@ afterEach(cleanup);
 
 describe("Alert", () => {
   it("renders with role=alert", () => {
-    render(<Alert variant="info">Test message</Alert>);
+    render(<Alert variant="success">Test message</Alert>);
     expect(screen.getByRole("alert")).toBeInTheDocument();
     expect(screen.getByText("Test message")).toBeInTheDocument();
   });
@@ -38,13 +38,13 @@ describe("Alert", () => {
   });
 
   it("does not show dismiss button without onDismiss", () => {
-    render(<Alert variant="info">Info</Alert>);
+    render(<Alert variant="success">Info</Alert>);
     expect(screen.queryByLabelText("Dismiss")).not.toBeInTheDocument();
   });
 
   it("applies custom className", () => {
     render(
-      <Alert variant="info" className="mt-4">
+      <Alert variant="success" className="mt-4">
         Test
       </Alert>,
     );
@@ -53,17 +53,17 @@ describe("Alert", () => {
 
   it("renders override icon when icon prop is provided", () => {
     render(
-      <Alert variant="info" icon="passkey">
+      <Alert variant="success" icon="passkey">
         Set up a passkey
       </Alert>,
     );
     expect(screen.getByText("passkey")).toBeInTheDocument();
-    expect(screen.queryByText("info")).not.toBeInTheDocument();
+    expect(screen.queryByText("check_circle")).not.toBeInTheDocument();
   });
 
   it("respects iconSize override", () => {
     render(
-      <Alert variant="info" icon="passkey" iconSize={28}>
+      <Alert variant="success" icon="passkey" iconSize={28}>
         Big icon
       </Alert>,
     );
@@ -71,8 +71,8 @@ describe("Alert", () => {
   });
 
   it("uses default icon size of 20 when iconSize not provided", () => {
-    render(<Alert variant="info">Default size</Alert>);
-    expect(screen.getByText("info")).toHaveStyle({ fontSize: "20px" });
+    render(<Alert variant="success">Default size</Alert>);
+    expect(screen.getByText("check_circle")).toHaveStyle({ fontSize: "20px" });
   });
 
   it("hides leading icon and drops content margin when hideIcon is set", () => {

--- a/src/components/ui/feedback/alert/Alert.tsx
+++ b/src/components/ui/feedback/alert/Alert.tsx
@@ -10,7 +10,12 @@ export const meta: ComponentMeta = {
     "Dismissible inline alert banner with error/success/warning/info variants",
 };
 
-export type AlertVariant = "error" | "success" | "warning" | "info";
+export type AlertVariant =
+  | "error"
+  | "success"
+  | "warning"
+  | "primary"
+  | "secondary";
 
 export interface AlertProps {
   variant: AlertVariant;
@@ -31,14 +36,16 @@ const variantStyles: Record<AlertVariant, string> = {
   error: "bg-error/10 border-error/30 text-error",
   success: "bg-success/10 border-success/30 text-success",
   warning: "bg-warning/10 border-warning/30 text-warning",
-  info: "bg-info/10 border-info/30 text-info",
+  primary: "bg-primary/10 border-primary/30 text-primary",
+  secondary: "bg-secondary/10 border-secondary/30 text-secondary",
 };
 
 const variantIcons: Record<AlertVariant, string> = {
   error: "error",
   success: "check_circle",
   warning: "warning",
-  info: "info",
+  primary: "info",
+  secondary: "info",
 };
 
 export function Alert({

--- a/src/components/ui/feedback/badge/Badge.stories.tsx
+++ b/src/components/ui/feedback/badge/Badge.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Badge> = {
   argTypes: {
     variant: {
       control: "select",
-      options: ["default", "primary", "success", "warning", "error", "info"],
+      options: ["default", "primary", "success", "warning", "error"],
     },
     size: { control: "select", options: ["sm", "md"] },
     icon: { control: "text" },
@@ -27,7 +27,7 @@ export const Playground: Story = {};
 export const Variants: Story = {
   render: () => (
     <div className="flex flex-wrap items-center gap-2">
-      {(["default", "primary", "success", "warning", "error", "info"] as BadgeVariant[]).map(
+      {(["default", "primary", "success", "warning", "error"] as BadgeVariant[]).map(
         (v) => (
           <Badge key={v} variant={v}>
             {v}
@@ -44,7 +44,6 @@ export const WithIcon: Story = {
       <Badge variant="success" icon="check_circle">Ready</Badge>
       <Badge variant="error" icon="error">Failed</Badge>
       <Badge variant="warning" icon="warning">Pending</Badge>
-      <Badge variant="info" icon="info">Info</Badge>
     </div>
   ),
 };

--- a/src/components/ui/feedback/badge/Badge.tsx
+++ b/src/components/ui/feedback/badge/Badge.tsx
@@ -12,8 +12,7 @@ export type BadgeVariant =
   | "primary"
   | "success"
   | "warning"
-  | "error"
-  | "info";
+  | "error";
 
 export type BadgeSize = "sm" | "md";
 
@@ -33,7 +32,6 @@ const variantStyles: Record<BadgeVariant, string> = {
   success: "bg-success/10 text-success border border-success/20",
   warning: "bg-warning/10 text-warning border border-warning/20",
   error: "bg-error/10 text-error border border-error/20",
-  info: "bg-tertiary/10 text-tertiary border border-tertiary/20",
 };
 
 const dotColors: Record<BadgeVariant, string> = {
@@ -42,7 +40,6 @@ const dotColors: Record<BadgeVariant, string> = {
   success: "bg-success",
   warning: "bg-warning",
   error: "bg-error",
-  info: "bg-tertiary",
 };
 
 const sizeStyles: Record<BadgeSize, string> = {

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -248,7 +248,7 @@ export function ReauthDialog({
       )}
 
       {showingEmail && showPasskeySetup && (
-        <Alert variant="info" icon="passkey" iconSize={28} className="mt-4">
+        <Alert variant="success" icon="passkey" iconSize={28} className="mt-4">
           <button
             type="button"
             onClick={onPasskeySetup}

--- a/src/theme.css
+++ b/src/theme.css
@@ -38,11 +38,6 @@
   --color-warning-container: #ffdea6;
   --color-on-warning-container: #271900;
 
-  --color-info: #0061a4;
-  --color-on-info: #ffffff;
-  --color-info-container: #d1e4ff;
-  --color-on-info-container: #001d36;
-
   --color-background: #ffffff;
   --color-on-background: #000000;
 
@@ -65,10 +60,6 @@
   --color-inverse-primary: #50d8e8;
   --color-inverse-surface: #2b3132;
   --color-inverse-on-surface: #ecf2f3;
-  --color-surface-tint: #006973;
-
-  --color-shadow: #000000;
-  --color-scrim: #000000;
 
   /* Font */
   --font-sans: "Shantell Sans", -apple-system, BlinkMacSystemFont, "Segoe UI",
@@ -122,11 +113,6 @@
   --color-warning-container: #5e4200;
   --color-on-warning-container: #ffdea6;
 
-  --color-info: #9ecaff;
-  --color-on-info: #003258;
-  --color-info-container: #00497d;
-  --color-on-info-container: #d1e4ff;
-
   --color-background: #000000;
   --color-on-background: #ffffff;
 
@@ -149,7 +135,6 @@
   --color-inverse-primary: #006973;
   --color-inverse-surface: #dee3e4;
   --color-inverse-on-surface: #101417;
-  --color-surface-tint: #93cdf6;
 }
 
 /* Base */

--- a/src/types/tone.ts
+++ b/src/types/tone.ts
@@ -13,8 +13,7 @@ export type Tone =
   | "tertiary"
   | "error"
   | "warning"
-  | "success"
-  | "info";
+  | "success";
 
 // Each map uses Tailwind's `<color>/40` opacity for borders so the
 // accent stays subtle against the surface background; text maps keep
@@ -26,7 +25,6 @@ export const toneBorderClass: Record<Tone, string> = {
   error: "border-error/40",
   warning: "border-warning/40",
   success: "border-success/40",
-  info: "border-info/40",
 };
 
 export const toneTextClass: Record<Tone, string> = {
@@ -36,5 +34,4 @@ export const toneTextClass: Record<Tone, string> = {
   error: "text-error",
   warning: "text-warning",
   success: "text-success",
-  info: "text-info",
 };


### PR DESCRIPTION
## Summary

Removes the `info` color and variant across the kit. Info-style messaging is now done via `Alert variant=\"primary\"` (default) or `Alert variant=\"secondary\"` (lower-weight) — both keep the info-circle icon. The `info` group was structurally redundant with `primary` and was creating drift between consumer pages and the design system.

## Changes

- **`theme.css`** — drop `--color-info*`, `--color-shadow`, `--color-scrim`, `--color-surface-tint` from light + dark blocks (the shadow/scrim/surface-tint tokens were already unused; the info group is being repurposed via primary + secondary)
- **`types/tone.ts`** — drop `\"info\"` from the `Tone` union; remove from `toneBorderClass` and `toneTextClass` maps
- **`Alert`** — drop `info` variant; add `primary` (recommended default for general info) and `secondary` (lower-weight info). Both render the info-circle icon, just with different tints. Update tests + stories
- **`Badge`** — drop `info` variant
- **`ReauthDialog`** — consumer site that referenced `info` switched to the appropriate replacement
- **`SettingRow.test.tsx`** — drop the info tone case from the border-color parametrized test

## Version

Bumped `0.3.8` → `0.3.9` per the patch-only policy for 0.x releases (memory: \"In 0.x packages, bump patch even for new components\"). `release` label is on this PR so the publish workflow picks it up.

## Migration for consumers

- `Alert variant=\"info\"` → `Alert variant=\"primary\"` (or `\"secondary\"` for lower-weight messaging)
- `Badge variant=\"info\"` → `Badge variant=\"primary\"`
- Anything reaching into `--color-info*` tokens directly needs to switch to `--color-primary*` / `--color-secondary*`

## Test plan

- [ ] CI: `pnpm test` passes (Alert variant tests, SettingRow tone test, Badge tests)
- [ ] CI: `pnpm typecheck` passes (Tone union narrowing, AlertVariant, BadgeVariant)
- [ ] Storybook builds — Alert `Variants` story now renders 5 alerts (primary, secondary, success, warning, error)
- [ ] After merge + publish, `web-account#36` flips `package.json` from `file:../web-ui-kit` to `^0.3.9` and goes ready-for-review

🤖 Generated with [Claude Code](https://claude.com/claude-code)