### PR TITLE
feat(avatar): forward `style` to root for per-instance theming (v0.3.10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/media/avatar/Avatar.tsx
+++ b/src/components/ui/media/avatar/Avatar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { cn } from "@/utils/cn";
 import type { ComponentMeta } from "@/types/component-meta";
 import { Icon } from "@/components/ui/media/icon/Icon";
@@ -66,6 +66,10 @@ export interface AvatarProps {
   square?: boolean;
   overlay?: ReactNode;
   className?: string;
+  /** Inline styles for the root element. Handy for setting CSS variables
+   *  (e.g. `--color-primary`) to theme the border/initials fallback per
+   *  instance, since those resolve through `var(--color-primary)`. */
+  style?: CSSProperties;
 }
 
 export function Avatar({
@@ -78,6 +82,7 @@ export function Avatar({
   square = false,
   overlay,
   className,
+  style,
 }: AvatarProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [imgFailed, setImgFailed] = useState(false);
@@ -140,7 +145,7 @@ export function Avatar({
   ) : null;
 
   return (
-    <div className={cn("relative inline-flex shrink-0", className)}>
+    <div className={cn("relative inline-flex shrink-0", className)} style={style}>
       {editable ? (
         <button
           type="button"


### PR DESCRIPTION
## What
Adds an optional `style` prop to `Avatar`, forwarded to its root element alongside the existing `className`.

## Why
`Avatar`'s initials fallback uses `border-primary` / `bg-primary/20` / `text-primary`, all of which resolve through `var(--color-primary)`. Forwarding `style` lets a consumer re-theme a single avatar instance by overriding that variable inline — e.g. per-org brand colors across a list of org cards — without a wrapper element. `className` already lands on the root, but a *dynamic* (runtime) color can't be a Tailwind class, so inline `style` is the missing piece.

## Usage
```tsx
<Avatar fallback="N" square style={{ "--color-primary": "#7a4a97" } as CSSProperties} />
```

## Notes
- Additive / non-breaking — existing `className`-on-root behavior unchanged.
- Patch bump `0.3.9 → 0.3.10` + `release` label.
- Typecheck clean; Avatar tests pass (16/16). The 4 local `ThemeProvider` test failures are a pre-existing env quirk (Node's experimental `localStorage` lacks `.clear()`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)