### PR TITLE
chore(simplify): fix doc/comment rot

### DIFF
--- a/src/components/ui/data/setting-row/SettingRow.tsx
+++ b/src/components/ui/data/setting-row/SettingRow.tsx
@@ -7,7 +7,7 @@ import { toneBorderClass, type Tone } from "@/types/tone";
 export const meta: ComponentMeta = {
   name: "SettingRow",
   description:
-    "Title + optional description on the left, control slot on the right. Used to compose settings forms; supports an optional tone for warning/error/success/info accents.",
+    "Title + optional description on the left, control slot on the right. Used to compose settings forms; supports an optional Tone border accent (primary, secondary, tertiary, error, warning, or success).",
 };
 
 export interface SettingRowProps {

--- a/src/components/ui/feedback/alert/Alert.tsx
+++ b/src/components/ui/feedback/alert/Alert.tsx
@@ -7,7 +7,7 @@ import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 export const meta: ComponentMeta = {
   name: "Alert",
   description:
-    "Dismissible inline alert banner with error/success/warning/info variants",
+    "Dismissible inline alert banner with error/success/warning/primary/secondary variants",
 };
 
 export type AlertVariant =

--- a/src/components/ui/graph/graph/Graph.tsx
+++ b/src/components/ui/graph/graph/Graph.tsx
@@ -259,7 +259,7 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
     height,
     onNodeClick,
     selectedId,
-    nodeSize = 2,
+    nodeSize = 1,
     textSize = 1,
     lineSize = 1,
     showTags = false,


### PR DESCRIPTION
- Alert + SettingRow `meta.description` no longer advertise the dropped `info` variant/tone; surface the real variants
- Graph `nodeSize` default 2 → 1 (matches its JSDoc, sibling defaults, slider midpoint, and all stories)

Part of the web-ui-kit `/simplify` audit (45 verified findings → 8 file-disjoint PRs). No version bump — a rollup release (0.3.11) lands after these merge.

Tests: green except 4 pre-existing `ThemeProvider` `localStorage.clear` failures (present on `main`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)