### PR TITLE
refactor(simplify): shared status-color helper + status-dot a11y

### DIFF
--- a/src/components/ui/chart/gauge/Gauge.tsx
+++ b/src/components/ui/chart/gauge/Gauge.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/utils/cn";
 import { isDev } from "@/utils/env";
 import type { ComponentMeta } from "@/types/component-meta";
+import { dataStatusVarColor } from "@/types/tone";
 
 export const meta: ComponentMeta = {
   name: "Gauge",
@@ -27,9 +28,9 @@ const CIRCUMFERENCE = 2 * Math.PI * 40; // ~251.33
 
 function arcColor(value: number, thresholds?: GaugeProps["thresholds"]): string | undefined {
   if (!thresholds) return undefined;
-  if (value < thresholds.error) return "var(--color-error)";
-  if (value < thresholds.warn) return "var(--color-warning)";
-  return "var(--color-success)";
+  if (value < thresholds.error) return dataStatusVarColor.error;
+  if (value < thresholds.warn) return dataStatusVarColor.warning;
+  return dataStatusVarColor.success;
 }
 
 export function Gauge({ value, label, format, thresholds, className }: GaugeProps) {

--- a/src/components/ui/data/data-list/DataList.tsx
+++ b/src/components/ui/data/data-list/DataList.tsx
@@ -2,6 +2,11 @@ import { cn } from "@/utils/cn";
 import { isDev } from "@/utils/env";
 import { Icon } from "@/components/ui/media/icon/Icon";
 import type { ComponentMeta } from "@/types/component-meta";
+import {
+  type DataStatus,
+  dataStatusVarColor,
+  dataStatusLabel,
+} from "@/types/tone";
 
 export const meta: ComponentMeta = {
   name: "DataList",
@@ -18,7 +23,7 @@ export interface DataListItem {
   description?: string;
   /** Trailing text such as "2d ago" or "#42" */
   trailing?: string;
-  status?: "default" | "success" | "warning" | "error";
+  status?: DataStatus;
 }
 
 export interface DataListProps {
@@ -27,12 +32,6 @@ export interface DataListProps {
   emptyLabel?: string;
   className?: string;
 }
-
-const STATUS_COLORS: Record<string, string> = {
-  success: "var(--color-success)",
-  warning: "var(--color-warning)",
-  error: "var(--color-error)",
-};
 
 export function DataList({
   items,
@@ -92,8 +91,12 @@ export function DataList({
               {item.status && item.status !== "default" && (
                 <span
                   className="shrink-0 inline-block w-1.5 h-1.5 rounded-full"
-                  style={{ backgroundColor: STATUS_COLORS[item.status] }}
-                />
+                  style={{ backgroundColor: dataStatusVarColor[item.status] }}
+                >
+                  <span className="sr-only">
+                    {dataStatusLabel[item.status]}
+                  </span>
+                </span>
               )}
               <span className="text-xs font-medium truncate">{item.title}</span>
             </div>

--- a/src/components/ui/data/timeline/Timeline.tsx
+++ b/src/components/ui/data/timeline/Timeline.tsx
@@ -2,6 +2,11 @@ import { cn } from "@/utils/cn";
 import { isDev } from "@/utils/env";
 import { Icon } from "@/components/ui/media/icon/Icon";
 import type { ComponentMeta } from "@/types/component-meta";
+import {
+  type DataStatus,
+  dataStatusVarColor,
+  dataStatusLabel,
+} from "@/types/tone";
 
 export const meta: ComponentMeta = {
   name: "Timeline",
@@ -13,19 +18,13 @@ export interface TimelineEntry {
   icon?: string;
   text: string;
   time: string;
-  status?: "default" | "success" | "warning" | "error";
+  status?: DataStatus;
 }
 
 export interface TimelineProps {
   entries: TimelineEntry[];
   className?: string;
 }
-
-const statusColor: Record<string, string> = {
-  success: "var(--color-success)",
-  warning: "var(--color-warning)",
-  error: "var(--color-error)",
-};
 
 export function Timeline({ entries, className }: TimelineProps) {
   if (entries.length === 0) return null;
@@ -44,9 +43,9 @@ export function Timeline({ entries, className }: TimelineProps) {
       )}
     >
       {entries.map((entry, index) => {
-        const color = entry.status && entry.status !== "default"
-          ? statusColor[entry.status]
-          : undefined;
+        const status =
+          entry.status && entry.status !== "default" ? entry.status : undefined;
+        const color = status ? dataStatusVarColor[status] : undefined;
 
         const isLast = index === entries.length - 1;
 
@@ -72,7 +71,11 @@ export function Timeline({ entries, className }: TimelineProps) {
                       ? { backgroundColor: color }
                       : { backgroundColor: "currentColor", opacity: 0.4 }
                   }
-                />
+                >
+                  {status && (
+                    <span className="sr-only">{dataStatusLabel[status]}</span>
+                  )}
+                </span>
               )}
               {!isLast && <div className="mb-1 w-px flex-1 bg-current/15" />}
             </div>

--- a/src/types/tone.ts
+++ b/src/types/tone.ts
@@ -35,3 +35,32 @@ export const toneTextClass: Record<Tone, string> = {
   warning: "text-warning",
   success: "text-success",
 };
+
+// DataStatus is the severity vocabulary for data-display components
+// (DataList, Timeline, Gauge) that render a status DOT / arc whose color
+// is applied via inline style or SVG stroke. Unlike `toneTextClass`
+// above — which only emits Tailwind class names — these maps carry the
+// raw `var(--color-*)` value so they can feed `style={{ ... }}` and SVG
+// `stroke`. `default` carries no color (rendered subtly via opacity).
+export type DataStatus = "default" | "success" | "warning" | "error";
+
+export const dataStatusVarColor: Record<
+  Exclude<DataStatus, "default">,
+  string
+> = {
+  success: "var(--color-success)",
+  warning: "var(--color-warning)",
+  error: "var(--color-error)",
+};
+
+// Human-readable status words for screen readers, used alongside
+// color-only status dots that would otherwise convey no information to
+// assistive technology.
+export const dataStatusLabel: Record<
+  Exclude<DataStatus, "default">,
+  string
+> = {
+  success: "Success",
+  warning: "Warning",
+  error: "Error",
+};


### PR DESCRIPTION
- Add `dataStatusVarColor` + `DataStatus` + `dataStatusLabel` to `types/tone.ts` (value-level CSS vars; tone.ts only had Tailwind classes)
- DataList + Timeline drop their byte-identical status→color maps and unions; Gauge `arcColor` reuses the helper
- StarRating intentionally excluded (its warning-colored star is a brand fill, not a status)
- a11y: status DOTs in DataList/Timeline get a visually-hidden status word

Part of the web-ui-kit `/simplify` audit (45 verified findings → 8 file-disjoint PRs). No version bump — a rollup release (0.3.11) lands after these merge.

Tests: green except 4 pre-existing `ThemeProvider` `localStorage.clear` failures (present on `main`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)