### PR TITLE
refactor(simplify): extract shared composer + click-outside hooks

### DIFF
--- a/src/components/ui/agent/greeting/AgentGreeting.tsx
+++ b/src/components/ui/agent/greeting/AgentGreeting.tsx
@@ -1,17 +1,13 @@
-import {
-  useState,
-  useRef,
-  useEffect,
-  useLayoutEffect,
-  type KeyboardEvent,
-  type ChangeEvent,
-} from "react";
+import { useState, useRef, useLayoutEffect } from "react";
 import { cn } from "@/utils/cn";
 import type { ComponentMeta } from "@/types/component-meta";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 import { Icon } from "@/components/ui/media/icon/Icon";
 import { Logo } from "@/components/ui/media/logo-mirrorstack/LogoMirrorStack";
 import { Notch } from "@/components/ui/surfaces/notch/Notch";
+import { useAutoGrowTextarea } from "@/hooks/useAutoGrowTextarea";
+import { useComposerSubmit } from "@/hooks/useComposerSubmit";
+import { useClickOutside } from "@/hooks/useClickOutside";
 
 export const meta: ComponentMeta = {
   name: "AgentGreeting",
@@ -83,7 +79,6 @@ export function AgentGreeting({
   className,
 }: AgentGreetingProps) {
   const [text, setText] = useState("");
-  const [isComposing, setIsComposing] = useState(false);
   const [modelMenuOpen, setModelMenuOpen] = useState(false);
   const [menuH, setMenuH] = useState(0);
   const [notchX, setNotchX] = useState(0);
@@ -101,12 +96,10 @@ export function AgentGreeting({
   const modelMenuRef = useRef<HTMLDivElement>(null);
   const modelContentRef = useRef<HTMLDivElement>(null);
 
-  useLayoutEffect(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = "auto";
-    el.style.height = `${Math.min(Math.max(el.scrollHeight, MIN_TEXTAREA_HEIGHT), MAX_TEXTAREA_HEIGHT)}px`;
-  }, [text]);
+  useAutoGrowTextarea(textareaRef, text, {
+    min: MIN_TEXTAREA_HEIGHT,
+    max: MAX_TEXTAREA_HEIGHT,
+  });
 
   // Measure the trigger pill so the notch tab sits directly under it —
   // mirrors AgentSidebarHeader's overflow-dropdown measurement pattern.
@@ -127,44 +120,16 @@ export function AgentGreeting({
     setMenuH(content.offsetHeight);
   }, [modelMenuOpen, activeModelId, models]);
 
-  useEffect(() => {
-    if (!modelMenuOpen) return;
-    const onMouseDown = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (modelTriggerRef.current?.contains(target)) return;
-      if (modelMenuRef.current?.contains(target)) return;
-      setModelMenuOpen(false);
-    };
-    const onKey = (e: globalThis.KeyboardEvent) => {
-      if (e.key === "Escape") setModelMenuOpen(false);
-    };
-    document.addEventListener("mousedown", onMouseDown);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onMouseDown);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [modelMenuOpen]);
+  useClickOutside({
+    refs: [modelTriggerRef, modelMenuRef],
+    onDismiss: () => setModelMenuOpen(false),
+    enabled: modelMenuOpen,
+  });
 
   const canSend = text.trim().length > 0;
 
-  const send = () => {
-    if (!canSend) return;
-    onSend?.(text.trim());
-    setText("");
-  };
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (isComposing || e.nativeEvent.isComposing) return;
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      send();
-    }
-  };
-
-  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    setText(e.target.value);
-  };
+  const { send, handleKeyDown, handleChange, onCompositionStart, onCompositionEnd } =
+    useComposerSubmit({ value: text, onSend }, setText);
 
   const activeModel =
     models?.find((m) => m.id === activeModelId) ?? models?.[0];
@@ -206,8 +171,8 @@ export function AgentGreeting({
           value={text}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
-          onCompositionStart={() => setIsComposing(true)}
-          onCompositionEnd={() => setIsComposing(false)}
+          onCompositionStart={onCompositionStart}
+          onCompositionEnd={onCompositionEnd}
           className="w-full resize-none rounded-lg bg-transparent px-3 py-2 text-base text-on-surface placeholder:text-on-surface-variant/60 focus:outline-none"
           placeholder={placeholder}
           aria-label="Start a conversation with the agent"

--- a/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
@@ -4,6 +4,7 @@ import { cn } from "@/utils/cn";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 import { Icon } from "@/components/ui/media/icon/Icon";
 import { Notch } from "@/components/ui/surfaces/notch/Notch";
+import { useClickOutside } from "@/hooks/useClickOutside";
 import type { AgentSidebarHistoryGroup } from "./types";
 
 interface ChatTab {
@@ -105,33 +106,17 @@ export function AgentSidebarHeader({
     overflowTabs = swapped.slice(visibleCount);
   }
 
-  useEffect(() => {
-    if (!showOverflow) return;
-    const handleKey = (e: KeyboardEvent) => { if (e.key === "Escape") setShowOverflow(false); };
-    const handleClick = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (overflowRef.current?.contains(target)) return;
-      if (dropdownRef.current?.contains(target)) return;
-      setShowOverflow(false);
-    };
-    document.addEventListener("keydown", handleKey);
-    document.addEventListener("mousedown", handleClick);
-    return () => { document.removeEventListener("keydown", handleKey); document.removeEventListener("mousedown", handleClick); };
-  }, [showOverflow]);
+  useClickOutside({
+    refs: [overflowRef, dropdownRef],
+    onDismiss: () => setShowOverflow(false),
+    enabled: showOverflow,
+  });
 
-  useEffect(() => {
-    if (!showHistory) return;
-    const handleKey = (e: KeyboardEvent) => { if (e.key === "Escape") setShowHistory(false); };
-    const handleClick = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (historyBtnRef.current?.contains(target)) return;
-      if (historyDropdownRef.current?.contains(target)) return;
-      setShowHistory(false);
-    };
-    document.addEventListener("keydown", handleKey);
-    document.addEventListener("mousedown", handleClick);
-    return () => { document.removeEventListener("keydown", handleKey); document.removeEventListener("mousedown", handleClick); };
-  }, [showHistory]);
+  useClickOutside({
+    refs: [historyBtnRef, historyDropdownRef],
+    onDismiss: () => setShowHistory(false),
+    enabled: showHistory,
+  });
 
   useLayoutEffect(() => {
     if (!showHistory || !histContentRef.current) return;

--- a/src/components/ui/agent/sidebar/AgentSidebarInput.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebarInput.tsx
@@ -1,11 +1,7 @@
-import {
-  useState,
-  useRef,
-  useLayoutEffect,
-  type KeyboardEvent,
-  type ChangeEvent,
-} from "react";
+import { useState, useRef } from "react";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+import { useAutoGrowTextarea } from "@/hooks/useAutoGrowTextarea";
+import { useComposerSubmit } from "@/hooks/useComposerSubmit";
 
 export interface AgentSidebarInputProps {
   onSend?: (message: string) => void;
@@ -21,33 +17,12 @@ export function AgentSidebarInput({
   placeholder = "Type a message...",
 }: AgentSidebarInputProps) {
   const [text, setText] = useState("");
-  const [isComposing, setIsComposing] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  useLayoutEffect(() => {
-    const el = textareaRef.current;
-    if (!el) return;
-    el.style.height = "auto";
-    el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
-  }, [text]);
+  useAutoGrowTextarea(textareaRef, text, { max: 150 });
 
-  const send = () => {
-    if (!text.trim()) return;
-    onSend?.(text);
-    setText("");
-  };
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (isComposing || e.nativeEvent.isComposing) return;
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      send();
-    }
-  };
-
-  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    setText(e.target.value);
-  };
+  const { send, handleKeyDown, handleChange, onCompositionStart, onCompositionEnd } =
+    useComposerSubmit({ value: text, onSend }, setText);
 
   const iconBtnCls = "text-inverse-on-surface/60 hover:text-inverse-on-surface";
 
@@ -64,8 +39,8 @@ export function AgentSidebarInput({
           value={text}
           onChange={handleChange}
           onKeyDown={handleKeyDown}
-          onCompositionStart={() => setIsComposing(true)}
-          onCompositionEnd={() => setIsComposing(false)}
+          onCompositionStart={onCompositionStart}
+          onCompositionEnd={onCompositionEnd}
           className="w-full text-inverse-on-surface placeholder:text-inverse-on-surface/30 rounded-lg px-2 py-1 resize-none focus:outline-none bg-transparent text-sm"
           placeholder={placeholder}
           aria-label="Message to agent"

--- a/src/components/ui/graph/graph-side/GraphSideGroup.tsx
+++ b/src/components/ui/graph/graph-side/GraphSideGroup.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/utils/cn";
+import { useClickOutside } from "@/hooks/useClickOutside";
 import { Button } from "@/components/ui/actions/button/Button";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 import { FloatingLabelInput } from "@/components/ui/inputs/floating-label-input/FloatingLabelInput";
@@ -91,17 +92,13 @@ export function GraphSideGroup({
 
   // Close on click outside the editor AND outside the portaled popover.
   // Matches the kit's existing Combobox/DropdownMenu pattern (reliable on
-  // touch devices, no setTimeout race).
-  useEffect(() => {
-    const handle = (e: MouseEvent) => {
-      const target = e.target as Node;
-      if (containerRef.current?.contains(target)) return;
-      if (popoverRef.current?.contains(target)) return;
-      setFocusedRowId(null);
-    };
-    document.addEventListener("mousedown", handle);
-    return () => document.removeEventListener("mousedown", handle);
-  }, []);
+  // touch devices, no setTimeout race). Escape is left to the input itself.
+  useClickOutside({
+    refs: [containerRef, popoverRef],
+    onDismiss: () => setFocusedRowId(null),
+    enabled: true,
+    closeOnEscape: false,
+  });
 
   const update = (id: string, patch: Partial<GraphSideGroupItem>) =>
     onChange(groups.map((g) => (g.id === id ? { ...g, ...patch } : g)));

--- a/src/hooks/useAutoGrowTextarea.ts
+++ b/src/hooks/useAutoGrowTextarea.ts
@@ -1,0 +1,30 @@
+import { useLayoutEffect, type RefObject } from "react";
+
+export interface AutoGrowTextareaBounds {
+  /** Minimum height (px). Omit to let the textarea collapse to its content. */
+  min?: number;
+  /** Maximum height (px). Beyond this the textarea scrolls internally. */
+  max?: number;
+}
+
+/**
+ * Auto-sizes a textarea to its content on every `value` change: reset to `auto`
+ * to measure the natural `scrollHeight`, then clamp into the `[min, max]` range.
+ *
+ * Runs in a layout effect so the height is committed before paint (no flicker).
+ */
+export function useAutoGrowTextarea(
+  ref: RefObject<HTMLTextAreaElement | null>,
+  value: string,
+  { min, max }: AutoGrowTextareaBounds = {},
+) {
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = "auto";
+    let next = el.scrollHeight;
+    if (min !== undefined) next = Math.max(next, min);
+    if (max !== undefined) next = Math.min(next, max);
+    el.style.height = `${next}px`;
+  }, [ref, value, min, max]);
+}

--- a/src/hooks/useClickOutside.ts
+++ b/src/hooks/useClickOutside.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef, type RefObject } from "react";
+
+export interface UseClickOutsideOptions {
+  /** Refs treated as "inside" — a mousedown within any of them is ignored. */
+  refs: RefObject<HTMLElement | null>[];
+  /** Called when a mousedown lands outside every ref (or on Escape). */
+  onDismiss: () => void;
+  /** Attach the listeners only while true (e.g. while a popover is open). */
+  enabled: boolean;
+  /** Also dismiss on the Escape key. Defaults to true. */
+  closeOnEscape?: boolean;
+}
+
+/**
+ * Dismiss-on-outside behavior shared by popovers, dropdowns, and inline
+ * editors: a document `mousedown` outside every supplied ref fires `onDismiss`,
+ * and (by default) so does Escape. Listeners attach only while `enabled`.
+ *
+ * `onDismiss` is read through a ref, so callers may pass an inline closure
+ * without re-subscribing the listeners every render.
+ */
+export function useClickOutside({
+  refs,
+  onDismiss,
+  enabled,
+  closeOnEscape = true,
+}: UseClickOutsideOptions) {
+  const onDismissRef = useRef(onDismiss);
+  onDismissRef.current = onDismiss;
+
+  useEffect(() => {
+    if (!enabled) return;
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as Node;
+      for (const ref of refs) {
+        if (ref.current?.contains(target)) return;
+      }
+      onDismissRef.current();
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    let onKey: ((e: KeyboardEvent) => void) | undefined;
+    if (closeOnEscape) {
+      onKey = (e: KeyboardEvent) => {
+        if (e.key === "Escape") onDismissRef.current();
+      };
+      document.addEventListener("keydown", onKey);
+    }
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      if (onKey) document.removeEventListener("keydown", onKey);
+    };
+    // Ref objects are stable; spreading them keeps the lint rule satisfied
+    // without re-subscribing on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, closeOnEscape, ...refs]);
+}

--- a/src/hooks/useComposerSubmit.ts
+++ b/src/hooks/useComposerSubmit.ts
@@ -1,0 +1,67 @@
+import {
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+} from "react";
+
+export interface UseComposerSubmitOptions {
+  /** Current textarea value (controlled). */
+  value: string;
+  /** Called with the TRIMMED text when the user submits a non-empty message. */
+  onSend?: (message: string) => void;
+}
+
+export interface UseComposerSubmit {
+  /** True while an IME composition session is active — Enter must not submit. */
+  isComposing: boolean;
+  /** Submit the trimmed value (guards empty), then clear via the consumer's setter. */
+  send: () => void;
+  /** Enter (without Shift) submits; respects the IME guard. */
+  handleKeyDown: (e: KeyboardEvent<HTMLTextAreaElement>) => void;
+  /** Wire to the textarea `onChange` to keep the controlled value in sync. */
+  handleChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
+  /** Wire to `onCompositionStart`. */
+  onCompositionStart: () => void;
+  /** Wire to `onCompositionEnd`. */
+  onCompositionEnd: () => void;
+}
+
+/**
+ * Shared chat-composer submit behavior: IME-safe Enter-to-send (Shift+Enter
+ * inserts a newline), trim-guard, and value clearing. Always sends the TRIMMED
+ * text. The consumer owns the value state and supplies `setValue`.
+ */
+export function useComposerSubmit(
+  { value, onSend }: UseComposerSubmitOptions,
+  setValue: (value: string) => void,
+): UseComposerSubmit {
+  const [isComposing, setIsComposing] = useState(false);
+
+  const send = () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    onSend?.(trimmed);
+    setValue("");
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (isComposing || e.nativeEvent.isComposing) return;
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      send();
+    }
+  };
+
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setValue(e.target.value);
+  };
+
+  return {
+    isComposing,
+    send,
+    handleKeyDown,
+    handleChange,
+    onCompositionStart: () => setIsComposing(true),
+    onCompositionEnd: () => setIsComposing(false),
+  };
+}


### PR DESCRIPTION
- New private `src/hooks/`: `useAutoGrowTextarea`, `useComposerSubmit` (dedup AgentSidebarInput + AgentGreeting; normalize trim), `useClickOutside`
- Migrate the conflict-free dismissal sites (AgentSidebarHeader ×2, AgentGreeting, GraphSideGroup); DropdownMenu/AppSwitcher/Combobox deferred to a follow-up to keep this PR file-disjoint

Part of the web-ui-kit `/simplify` audit (45 verified findings → 8 file-disjoint PRs). No version bump — a rollup release (0.3.11) lands after these merge.

Tests: green except 4 pre-existing `ThemeProvider` `localStorage.clear` failures (present on `main`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)