### PR TITLE
feat(icon): add fill prop; route StarRating through Icon; tidy public API

### DIFF
--- a/src/components/ui/agent/sidebar/AgentSidebar.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebar.tsx
@@ -37,4 +37,3 @@ export {
   type AgentSidebarHistoryGroup,
   type AgentSidebarHistoryItem,
 } from "./types";
-export { mockAgentHistory, mockAgentMessages } from "./mock-data";

--- a/src/components/ui/data/star-rating/StarRating.tsx
+++ b/src/components/ui/data/star-rating/StarRating.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/utils/cn";
 import { isDev } from "@/utils/env";
+import { Icon } from "@/components/ui/media/icon/Icon";
 import type { ComponentMeta } from "@/types/component-meta";
 
 export const meta: ComponentMeta = {
@@ -24,44 +25,28 @@ function normalise(raw: number): number {
   return Math.round(clamped * 2) / 2;
 }
 
-const STAR_COLOR = "var(--color-warning)";
-
 function Stars({ value }: { value: number }) {
   return (
-    <span className="flex items-center gap-0.5">
+    <span aria-hidden className="flex items-center gap-0.5">
       {Array.from({ length: 5 }, (_, i) => {
         const threshold = i + 1;
         if (value >= threshold) {
           return (
-            <span
-              key={i}
-              className="material-symbols-rounded"
-              style={{ fontSize: 16, color: STAR_COLOR, fontVariationSettings: "'FILL' 1" }}
-            >
-              star
-            </span>
+            <Icon key={i} name="star" size={16} fill className="text-warning" />
           );
         }
         if (value >= threshold - 0.5) {
           return (
-            <span
+            <Icon
               key={i}
-              className="material-symbols-rounded"
-              style={{ fontSize: 16, color: STAR_COLOR, fontVariationSettings: "'FILL' 1" }}
-            >
-              star_half
-            </span>
+              name="star_half"
+              size={16}
+              fill
+              className="text-warning"
+            />
           );
         }
-        return (
-          <span
-            key={i}
-            className="material-symbols-rounded opacity-20"
-            style={{ fontSize: 16 }}
-          >
-            star
-          </span>
-        );
+        return <Icon key={i} name="star" size={16} className="opacity-20" />;
       })}
     </span>
   );
@@ -82,7 +67,11 @@ export function StarRating({
   const value = normalise(rawValue);
 
   return (
-    <div className={cn("flex h-full w-full flex-col justify-between p-1", className)}>
+    <div
+      className={cn("flex h-full w-full flex-col justify-between p-1", className)}
+      role="img"
+      aria-label={`${value} out of 5 stars`}
+    >
       {label != null && (
         <span className="truncate text-xs opacity-60">{label}</span>
       )}

--- a/src/components/ui/media/icon/Icon.tsx
+++ b/src/components/ui/media/icon/Icon.tsx
@@ -16,6 +16,8 @@ export interface IconProps {
    */
   size?: number | string;
   className?: string;
+  /** Render the filled variant of the icon (Material Symbols `FILL` axis). */
+  fill?: boolean;
   /** Accessible label. If omitted, icon is decorative (aria-hidden). */
   "aria-label"?: string;
 }
@@ -24,12 +26,16 @@ export function Icon({
   name,
   size = 24,
   className,
+  fill,
   "aria-label": ariaLabel,
 }: IconProps) {
   return (
     <span
       className={cn("material-symbols-rounded select-none shrink-0", className)}
-      style={{ fontSize: size }}
+      style={{
+        fontSize: size,
+        ...(fill ? { fontVariationSettings: "'FILL' 1" } : {}),
+      }}
       aria-hidden={ariaLabel ? undefined : true}
       aria-label={ariaLabel}
       role={ariaLabel ? "img" : undefined}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export {
 export {
   FloatingLabelInput,
   type FloatingLabelInputProps,
+  type FloatingLabelInputSize,
 } from "./components/ui/inputs/floating-label-input/FloatingLabelInput";
 export {
   SegmentedButton,
@@ -114,6 +115,7 @@ export {
   Combobox,
   type ComboboxProps,
   type ComboboxOption,
+  type ComboboxSize,
 } from "./components/ui/inputs/combobox/Combobox";
 export {
   ImageCarousel,
@@ -310,8 +312,6 @@ export {
   AgentSidebarMessages,
   type AgentSidebarMessage,
   type AgentSidebarMessagesProps,
-  mockAgentHistory,
-  mockAgentMessages,
   type AgentSidebarHistoryGroup,
   type AgentSidebarHistoryItem,
 } from "./components/ui/agent/sidebar/AgentSidebar";


### PR DESCRIPTION
- Icon gains optional `fill?: boolean` (Material Symbols FILL axis); StarRating drops its raw material-symbols spans + gains `role=img` accessible name
- Drop demo-only `mockAgentHistory`/`mockAgentMessages` from the public barrel (0 consumers; story uses the local path)
- Re-export `ComboboxSize` + `FloatingLabelInputSize` for symmetry with Switch/SegmentedButton

Part of the web-ui-kit `/simplify` audit (45 verified findings → 8 file-disjoint PRs). No version bump — a rollup release (0.3.11) lands after these merge.

Tests: green except 4 pre-existing `ThemeProvider` `localStorage.clear` failures (present on `main`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)