### PR TITLE
fix(nav): a11y + consistency + danger→error alias

### DIFF
--- a/src/components/ui/actions/button/Button.tsx
+++ b/src/components/ui/actions/button/Button.tsx
@@ -10,6 +10,7 @@ import {
   type ButtonSize,
   variantMap,
   iconSizes,
+  buttonBaseClass,
 } from "@/components/ui/actions/shared/button-styles";
 
 export const meta: ComponentMeta = {
@@ -76,7 +77,8 @@ export function Button({
   return (
     <button
       className={cn(
-        "relative inline-flex items-center justify-center font-medium rounded-lg transition-all cursor-pointer active:scale-95 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed",
+        buttonBaseClass,
+        "font-medium",
         variantMap[variant][color],
         sizeStyles[size],
         fullWidth && "w-full",

--- a/src/components/ui/actions/icon-button/IconButton.tsx
+++ b/src/components/ui/actions/icon-button/IconButton.tsx
@@ -10,6 +10,7 @@ import {
   type ButtonSize,
   variantMap,
   iconSizes,
+  buttonBaseClass,
 } from "@/components/ui/actions/shared/button-styles";
 
 export const meta: ComponentMeta = {
@@ -56,7 +57,7 @@ export function IconButton({
   return (
     <button
       className={cn(
-        "relative inline-flex items-center justify-center rounded-lg transition-all cursor-pointer active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:opacity-50 disabled:cursor-not-allowed",
+        buttonBaseClass,
         variantMap[variant][color],
         sizeStyles[size],
         className,

--- a/src/components/ui/actions/shared/button-styles.ts
+++ b/src/components/ui/actions/shared/button-styles.ts
@@ -58,3 +58,15 @@ export const iconSizes: Record<ButtonSize, number> = {
   md: 24,
   lg: 28,
 };
+
+/**
+ * Shared base class string for Button and IconButton.
+ *
+ * Includes the WCAG 2.4.7 keyboard focus indicator
+ * (`focus-visible:ring-2 focus-visible:ring-primary`) so every action button
+ * shows a visible focus ring. `focus:outline-none` only removes the default UA
+ * outline — it is always paired with the focus-visible ring as a replacement,
+ * never on its own.
+ */
+export const buttonBaseClass =
+  "relative inline-flex items-center justify-center rounded-lg transition-all cursor-pointer active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:opacity-50 disabled:cursor-not-allowed";

--- a/src/components/ui/actions/social-button/SocialButton.tsx
+++ b/src/components/ui/actions/social-button/SocialButton.tsx
@@ -1,5 +1,6 @@
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
 import type { ComponentMeta } from "@/types/component-meta";
 import { GoogleIcon, DiscordIcon, OpenIdIcon, LineIcon } from "./social-icons";
 
@@ -42,6 +43,12 @@ export function SocialButton({
   className,
   ...props
 }: SocialButtonProps) {
+  if (isDev && !provider && !props["aria-label"]) {
+    console.warn(
+      "[SocialButton] provide a provider or aria-label for accessibility.",
+    );
+  }
+
   return (
     <button
       type="button"
@@ -50,6 +57,7 @@ export function SocialButton({
         "flex-1 min-h-12 min-w-12 px-4 py-3 gap-2 flex items-center justify-center rounded-lg",
         "border border-outline-variant bg-surface-container-low",
         "hover:bg-surface-container transition-colors cursor-pointer",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
         "disabled:opacity-50 disabled:cursor-not-allowed",
         className,
       )}

--- a/src/components/ui/navigation/app-switcher/AppSwitcher.test.tsx
+++ b/src/components/ui/navigation/app-switcher/AppSwitcher.test.tsx
@@ -15,24 +15,24 @@ describe("AppSwitcher", () => {
     expect(screen.getByText("Account")).toBeInTheDocument();
   });
 
-  it("opens menu on click", () => {
+  it("opens the switcher panel on click", () => {
     render(<AppSwitcher currentApp="Account" logo={<span>L</span>} apps={apps} activeAppId="account" />);
-    fireEvent.click(screen.getByRole("button"));
-    expect(screen.getByRole("menu")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Current app/ }));
+    expect(screen.getByRole("navigation", { name: "Switch application" })).toBeInTheDocument();
   });
 
-  it("filters out active app from menu", () => {
+  it("filters out the active app from the panel", () => {
     render(<AppSwitcher currentApp="Account" logo={<span>L</span>} apps={apps} activeAppId="account" />);
-    fireEvent.click(screen.getByRole("button"));
-    expect(screen.queryByRole("menuitem", { name: /Account/ })).not.toBeInTheDocument();
-    expect(screen.getByRole("menuitem", { name: /Apps/ })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Current app/ }));
+    expect(screen.queryByRole("link", { name: /Account/ })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Apps/ })).toBeInTheDocument();
   });
 
   it("closes on Escape", () => {
     render(<AppSwitcher currentApp="Account" logo={<span>L</span>} apps={apps} activeAppId="account" />);
-    fireEvent.click(screen.getByRole("button"));
-    expect(screen.getByRole("menu")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Current app/ }));
+    expect(screen.getByRole("navigation", { name: "Switch application" })).toBeInTheDocument();
     fireEvent.keyDown(document, { key: "Escape" });
-    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(screen.queryByRole("navigation", { name: "Switch application" })).not.toBeInTheDocument();
   });
 });

--- a/src/components/ui/navigation/app-switcher/AppSwitcher.tsx
+++ b/src/components/ui/navigation/app-switcher/AppSwitcher.tsx
@@ -117,11 +117,11 @@ export function AppSwitcher({
         ref={triggerRef}
         type="button"
         onClick={() => setOpen(!open)}
-        aria-haspopup="menu"
+        aria-label={`Current app: ${currentApp}`}
         aria-expanded={open}
         aria-controls={open ? menuId : undefined}
         className={cn(
-          "relative z-10 flex items-center gap-2 cursor-pointer pl-4 pr-6 py-3",
+          "relative z-10 flex items-center gap-2 cursor-pointer pl-4 pr-6 py-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
           open
             ? "w-fit pr-6 rounded-t-2xl"
             : "rounded-2xl hover:bg-surface-container transition-colors",
@@ -143,27 +143,29 @@ export function AppSwitcher({
 
       {open && filteredApps.length > 0 && (
         <div className="relative z-10 rounded-b-2xl rounded-tr-2xl shadow-lg">
-          <div id={menuId} role="menu" aria-label="Switch application" className="px-2 pb-2">
-            {filteredApps.map((app) => (
-              <a
-                key={app.id}
-                href={app.href}
-                role="menuitem"
-                onClick={() => setOpen(false)}
-                className="flex items-center gap-2.5 px-3 py-2.5 rounded-xl transition-colors hover:bg-surface-container"
-              >
-                <Icon name={app.icon} size={20} className="shrink-0 text-on-surface-variant" />
-                <div className="min-w-0 flex-1">
-                  <p className="text-sm font-medium truncate text-on-surface">{app.label}</p>
-                  {app.description && (
-                    <p className="text-xs text-on-surface-variant mt-0.5 line-clamp-1">
-                      {app.description}
-                    </p>
-                  )}
-                </div>
-              </a>
-            ))}
-          </div>
+          <nav id={menuId} aria-label="Switch application" className="px-2 pb-2">
+            <ul>
+              {filteredApps.map((app) => (
+                <li key={app.id}>
+                  <a
+                    href={app.href}
+                    onClick={() => setOpen(false)}
+                    className="flex items-center gap-2.5 px-3 py-2.5 rounded-xl transition-colors hover:bg-surface-container focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                  >
+                    <Icon name={app.icon} size={20} className="shrink-0 text-on-surface-variant" />
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-medium truncate text-on-surface">{app.label}</p>
+                      {app.description && (
+                        <p className="text-xs text-on-surface-variant mt-0.5 line-clamp-1">
+                          {app.description}
+                        </p>
+                      )}
+                    </div>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
         </div>
       )}
 

--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
 import type { ComponentMeta } from "@/types/component-meta";
 import { Icon } from "@/components/ui/media/icon/Icon";
 import { Notch } from "@/components/ui/surfaces/notch/Notch";
@@ -20,14 +21,15 @@ const DD_IR = 10;
 export const meta: ComponentMeta = {
   name: "DropdownMenu",
   description:
-    "Action dropdown menu with keyboard navigation, icon support, and danger variant.",
+    "Action dropdown menu with keyboard navigation, icon support, and error variant.",
 };
 
 export interface DropdownMenuItem {
   id: string;
   label: string;
   icon?: string;
-  variant?: "default" | "danger";
+  /** `"danger"` is a deprecated alias for `"error"`. */
+  variant?: "default" | "error" | "danger";
   disabled?: boolean;
 }
 
@@ -265,7 +267,13 @@ export function DropdownMenu({
 
               const item = entry;
               const isActive = index === activeIndex;
-              const isDanger = item.variant === "danger";
+              if (isDev && item.variant === "danger") {
+                console.warn(
+                  '[DropdownMenu] variant="danger" is deprecated; use "error".',
+                );
+              }
+              const isError =
+                item.variant === "error" || item.variant === "danger";
 
               return (
                 <div
@@ -273,11 +281,11 @@ export function DropdownMenu({
                   role="menuitem"
                   aria-disabled={item.disabled || undefined}
                   className={cn(
-                    "flex cursor-pointer items-baseline gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors",
-                    item.disabled && "pointer-events-none opacity-38",
-                    isDanger ? "text-error" : "text-on-surface",
+                    "flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors",
+                    item.disabled && "pointer-events-none opacity-50",
+                    isError ? "text-error" : "text-on-surface",
                     isActive &&
-                      (isDanger
+                      (isError
                         ? "bg-error/8"
                         : "bg-on-surface/8"),
                   )}
@@ -295,8 +303,8 @@ export function DropdownMenu({
                       name={item.icon}
                       size={16}
                       className={cn(
-                        "shrink-0 translate-y-0.5",
-                        isDanger ? "text-error" : "text-on-surface-variant",
+                        "shrink-0",
+                        isError ? "text-error" : "text-on-surface-variant",
                       )}
                     />
                   )}

--- a/src/components/ui/navigation/nav-drawer/NavDrawer.tsx
+++ b/src/components/ui/navigation/nav-drawer/NavDrawer.tsx
@@ -1,7 +1,11 @@
 import type { ReactNode } from "react";
 import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
 import type { ComponentMeta } from "@/types/component-meta";
-import { NavItem } from "@/components/ui/navigation/nav-item/NavItem";
+import {
+  NavItem,
+  type NavItemVariant,
+} from "@/components/ui/navigation/nav-item/NavItem";
 import { Surface } from "@/components/ui/surfaces/surface/Surface";
 import { SectionLabel } from "@/components/ui/data/section-label/SectionLabel";
 
@@ -15,7 +19,8 @@ export interface NavDrawerItem {
   id: string;
   label: string;
   icon: string;
-  variant?: "default" | "danger";
+  /** `"danger"` is a deprecated alias for `"error"`. */
+  variant?: NavItemVariant;
 }
 
 export interface NavDrawerSection {
@@ -65,17 +70,24 @@ export function NavDrawer({
               </SectionLabel>
             )}
             <ul className="space-y-1">
-              {section.items.map((item) => (
-                <li key={item.id}>
-                  <NavItem
-                    icon={item.icon}
-                    label={item.label}
-                    active={item.id === activeItemId}
-                    variant={item.variant}
-                    onClick={() => onItemClick?.(item)}
-                  />
-                </li>
-              ))}
+              {section.items.map((item) => {
+                if (isDev && item.variant === "danger") {
+                  console.warn(
+                    '[NavDrawer] variant="danger" is deprecated; use "error".',
+                  );
+                }
+                return (
+                  <li key={item.id}>
+                    <NavItem
+                      icon={item.icon}
+                      label={item.label}
+                      active={item.id === activeItemId}
+                      variant={item.variant}
+                      onClick={() => onItemClick?.(item)}
+                    />
+                  </li>
+                );
+              })}
             </ul>
           </Surface>
         ))}

--- a/src/components/ui/navigation/nav-item/NavItem.tsx
+++ b/src/components/ui/navigation/nav-item/NavItem.tsx
@@ -1,14 +1,18 @@
 import type { ButtonHTMLAttributes } from "react";
 import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
 import type { ComponentMeta } from "@/types/component-meta";
 import { Icon } from "@/components/ui/media/icon/Icon";
 
 export const meta: ComponentMeta = {
   name: "NavItem",
-  description: "Navigation item button with icon, label, active state, and danger variant",
+  description: "Navigation item button with icon, label, active state, and error variant",
 };
 
-export type NavItemVariant = "default" | "danger";
+/** `"danger"` is a deprecated alias for `"error"`. */
+export type NavItemVariant = "default" | "error" | "danger";
+
+type ResolvedNavItemVariant = "default" | "error";
 
 export interface NavItemProps
   extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children"> {
@@ -18,16 +22,16 @@ export interface NavItemProps
   variant?: NavItemVariant;
 }
 
-const variantStyles: Record<NavItemVariant, string> = {
+const variantStyles: Record<ResolvedNavItemVariant, string> = {
   default: "text-on-surface-variant hover:bg-surface-container hover:text-on-surface",
-  danger: "text-error hover:bg-error-container/30",
+  error: "text-error hover:bg-error-container/30",
 };
 
 const activeStyle = "bg-primary/10 text-primary font-medium";
 
-const iconVariantStyles: Record<NavItemVariant, string> = {
+const iconVariantStyles: Record<ResolvedNavItemVariant, string> = {
   default: "text-on-surface-variant",
-  danger: "text-error",
+  error: "text-error",
 };
 
 export function NavItem({
@@ -39,11 +43,20 @@ export function NavItem({
   disabled,
   ...props
 }: NavItemProps) {
+  if (isDev && variant === "danger") {
+    console.warn('[NavItem] variant="danger" is deprecated; use "error".');
+  }
+  const resolvedVariant: ResolvedNavItemVariant =
+    variant === "danger" ? "error" : variant;
+
   return (
     <button
+      aria-current={active ? "page" : undefined}
       className={cn(
-        "w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-left transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed",
-        active && variant === "default" ? activeStyle : variantStyles[variant],
+        "w-full flex items-center gap-3 px-4 py-2.5 rounded-xl text-left transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed",
+        active && resolvedVariant === "default"
+          ? activeStyle
+          : variantStyles[resolvedVariant],
         className,
       )}
       disabled={disabled}
@@ -52,7 +65,11 @@ export function NavItem({
       <Icon
         name={icon}
         size={20}
-        className={active && variant === "default" ? "text-primary" : iconVariantStyles[variant]}
+        className={
+          active && resolvedVariant === "default"
+            ? "text-primary"
+            : iconVariantStyles[resolvedVariant]
+        }
       />
       <span>{label}</span>
     </button>

--- a/src/components/ui/navigation/navigation-button/NavigationButton.tsx
+++ b/src/components/ui/navigation/navigation-button/NavigationButton.tsx
@@ -150,8 +150,9 @@ export function NavigationButton({
 
       <button
         aria-label={label}
+        aria-current={selected ? "page" : undefined}
         className={cn(
-          "flex items-center justify-center transition-all duration-200 ease-in-out box-border relative z-10 w-10 h-10 disabled:opacity-50 disabled:cursor-not-allowed",
+          "flex items-center justify-center transition-all duration-200 ease-in-out box-border relative z-10 w-10 h-10 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed",
           customIcon ? "p-0 overflow-hidden" : "p-2.5",
           isHovered ? shapeStyles[variant][selKey].hover : shapeStyles[variant][selKey].rest,
           !isHovered && bgStyles[variant][selKey],


### PR DESCRIPTION
- focus-visible rings (shared `buttonBaseClass` for Button/IconButton; inline for NavItem/NavigationButton/SocialButton/AppSwitcher) — WCAG 2.4.7
- `aria-current` on active nav items; AppSwitcher fake `role=menu` → disclosure (`nav`>`ul`>`a`); SocialButton no-name dev warning
- DropdownMenu disabled opacity 38→50 + items-center rows; NavDrawerItem reuses `NavItemVariant`
- variant `danger` → `error` with a soft-deprecated `danger` alias (isDev warn) so downstream apps keep working

Part of the web-ui-kit `/simplify` audit (45 verified findings → 8 file-disjoint PRs). No version bump — a rollup release (0.3.11) lands after these merge.

Tests: green except 4 pre-existing `ThemeProvider` `localStorage.clear` failures (present on `main`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)