### PR TITLE
fix(a11y): feedback/surfaces/inputs accessibility

### DIFF
--- a/src/components/ui/agent/asks/AgentSidebarMultiQuestion.tsx
+++ b/src/components/ui/agent/asks/AgentSidebarMultiQuestion.tsx
@@ -259,7 +259,7 @@ function renderField(
   return (
     <div
       role={isMulti ? "group" : "radiogroup"}
-      aria-labelledby={fieldId}
+      aria-label={q.label}
       className="flex flex-col gap-1.5"
     >
       {q.options.map((opt) => {
@@ -467,12 +467,9 @@ export function AgentSidebarMultiQuestion({
                     className="rounded-md border border-outline-variant/20 px-3 py-2.5 flex items-center justify-between gap-3"
                   >
                     <div className="flex-1 min-w-0">
-                      <label
-                        htmlFor={fieldId}
-                        className="text-sm font-medium text-inverse-on-surface block leading-snug"
-                      >
+                      <span className="text-sm font-medium text-inverse-on-surface block leading-snug">
                         {q.label}
-                      </label>
+                      </span>
                       {q.description && (
                         <span className="text-xs text-inverse-on-surface/55 block mt-0.5 leading-relaxed">
                           {q.description}
@@ -490,7 +487,7 @@ export function AgentSidebarMultiQuestion({
                 >
                   <div>
                     <label
-                      htmlFor={fieldId}
+                      htmlFor={q.type === "text" ? fieldId : undefined}
                       className="text-sm font-medium text-inverse-on-surface block leading-snug"
                     >
                       {q.label}

--- a/src/components/ui/feedback/status-indicator/StatusIndicator.test.tsx
+++ b/src/components/ui/feedback/status-indicator/StatusIndicator.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { describe, expect, it, afterEach } from "vitest";
+import { StatusIndicator } from "./StatusIndicator";
+
+afterEach(cleanup);
+
+describe("StatusIndicator", () => {
+  it("renders the dot (no icon) by default", () => {
+    const { container } = render(
+      <StatusIndicator status="online" label="API" />,
+    );
+    // Icon renders its name as text; absent in dot mode.
+    expect(screen.queryByText("cloud")).not.toBeInTheDocument();
+    // The dot is a rounded-full span.
+    expect(
+      container.querySelector("[class*='rounded-full']"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an icon when icon prop is provided", () => {
+    render(<StatusIndicator status="online" label="API" icon="cloud" />);
+    expect(screen.getByText("cloud")).toBeInTheDocument();
+  });
+
+  it("pulses by default for online", () => {
+    const { container } = render(
+      <StatusIndicator status="online" label="API" />,
+    );
+    expect(container.querySelector(".animate-pulse")).toBeInTheDocument();
+  });
+
+  it("pulses by default for warning", () => {
+    const { container } = render(
+      <StatusIndicator status="warning" label="API" />,
+    );
+    expect(container.querySelector(".animate-pulse")).toBeInTheDocument();
+  });
+
+  it("does not pulse by default for offline, error, and unknown", () => {
+    for (const status of ["offline", "error", "unknown"] as const) {
+      const { container } = render(
+        <StatusIndicator status={status} label="API" />,
+      );
+      expect(container.querySelector(".animate-pulse")).not.toBeInTheDocument();
+      cleanup();
+    }
+  });
+
+  it("honors an explicit pulse override", () => {
+    const { container } = render(
+      <StatusIndicator status="offline" label="API" pulse />,
+    );
+    expect(container.querySelector(".animate-pulse")).toBeInTheDocument();
+  });
+
+  it("renders offline and unknown dots at different opacities", () => {
+    const offline = render(
+      <StatusIndicator status="offline" label="API" />,
+    ).container.querySelector("[class*='opacity-30']");
+    expect(offline).toBeInTheDocument();
+    cleanup();
+    const unknown = render(
+      <StatusIndicator status="unknown" label="API" />,
+    ).container.querySelector("[class*='opacity-20']");
+    expect(unknown).toBeInTheDocument();
+  });
+
+  it("exposes an sr-only status name for each status", () => {
+    const cases: [Parameters<typeof StatusIndicator>[0]["status"], string][] = [
+      ["online", "Status: Online"],
+      ["offline", "Status: Offline"],
+      ["warning", "Status: Warning"],
+      ["error", "Status: Error"],
+      ["unknown", "Status: Unknown"],
+    ];
+    for (const [status, text] of cases) {
+      render(<StatusIndicator status={status} label="API" />);
+      expect(screen.getByText(text)).toBeInTheDocument();
+      cleanup();
+    }
+  });
+
+  it("threads an aria-label onto the icon branch", () => {
+    render(<StatusIndicator status="offline" label="API" icon="cloud_off" />);
+    expect(screen.getByLabelText("Offline")).toBeInTheDocument();
+  });
+
+  it("exposes role=status on the root", () => {
+    render(<StatusIndicator status="online" label="API" />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("renders label and sub", () => {
+    render(<StatusIndicator status="online" label="API" sub="us-east-1" />);
+    expect(screen.getByText("API")).toBeInTheDocument();
+    expect(screen.getByText("us-east-1")).toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <StatusIndicator status="online" label="API" className="mt-4" />,
+    );
+    expect(container.firstChild).toHaveClass("mt-4");
+  });
+});

--- a/src/components/ui/feedback/status-indicator/StatusIndicator.tsx
+++ b/src/components/ui/feedback/status-indicator/StatusIndicator.tsx
@@ -42,6 +42,14 @@ const defaultPulse: Record<StatusLevel, boolean> = {
   unknown: false,
 };
 
+const statusLabelMap: Record<StatusLevel, string> = {
+  online: "Online",
+  offline: "Offline",
+  warning: "Warning",
+  error: "Error",
+  unknown: "Unknown",
+};
+
 export function StatusIndicator({
   status,
   label,
@@ -52,13 +60,18 @@ export function StatusIndicator({
 }: StatusIndicatorProps) {
   const color = colorMap[status];
   const shouldPulse = pulse ?? defaultPulse[status];
+  const statusLabel = statusLabelMap[status];
 
   return (
-    <div className={cn("h-full w-full flex flex-col justify-between", className)}>
+    <div
+      className={cn("h-full w-full flex flex-col justify-between", className)}
+      role="status"
+    >
+      <span className="sr-only">{`Status: ${statusLabel}`}</span>
       {/* Top section: dot or icon */}
       <div>
         {icon ? (
-          <span style={{ color }}>
+          <span style={{ color }} aria-label={statusLabel}>
             <Icon name={icon} size={20} />
           </span>
         ) : (

--- a/src/components/ui/inputs/combobox/Combobox.tsx
+++ b/src/components/ui/inputs/combobox/Combobox.tsx
@@ -232,7 +232,9 @@ export function Combobox({
           type="button"
           tabIndex={-1}
           aria-label="Toggle options"
+          disabled={disabled}
           onClick={() => {
+            if (disabled) return;
             if (open) {
               setOpen(false);
               setIsTyping(false);
@@ -242,7 +244,10 @@ export function Combobox({
               inputRef.current?.focus();
             }
           }}
-          className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center justify-center p-1 text-on-surface-variant hover:text-primary transition-colors"
+          className={cn(
+            "absolute right-3 top-1/2 -translate-y-1/2 flex items-center justify-center p-1 text-on-surface-variant transition-colors",
+            disabled ? "cursor-not-allowed" : "hover:text-primary",
+          )}
         >
           <Icon
             name="expand_more"

--- a/src/components/ui/surfaces/option-list/OptionList.tsx
+++ b/src/components/ui/surfaces/option-list/OptionList.tsx
@@ -65,8 +65,8 @@ export function OptionList({
       <ul className="py-1">
         {items.length === 0 ? (
           <li
-            role="option"
-            aria-selected={false}
+            role="status"
+            aria-live="polite"
             className="px-3 py-1.5 text-sm text-on-surface-variant italic"
           >
             No matches

--- a/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
+++ b/src/components/ui/surfaces/reauth-dialog/ReauthDialog.tsx
@@ -138,7 +138,7 @@ export function ReauthDialog({
       open={open}
       onClose={handleClose}
       className={className}
-      actions={undefined}
+      title={title}
     >
       {error && (
         <Alert variant="error" onDismiss={() => setError(null)} className="mb-4">
@@ -146,7 +146,6 @@ export function ReauthDialog({
         </Alert>
       )}
 
-      <h3 className="text-lg font-semibold text-on-surface mb-2">{title}</h3>
       <p className="text-sm text-on-surface-variant mb-4">{description}</p>
 
       {!showingEmail && (


### PR DESCRIPTION
- StatusIndicator: sr-only status name + role=status + new test (color/pulse were the only state signal)
- ReauthDialog: pass `title` to Dialog (restores aria-labelledby), drop duplicate `<h3>`
- OptionList: 'No matches' row no longer mis-roled as `option` → `role=status`
- Combobox: chevron toggle disabled when the combobox is disabled
- AgentSidebarMultiQuestion: fix dangling `aria-labelledby`/`htmlFor`

Part of the web-ui-kit `/simplify` audit (45 verified findings → 8 file-disjoint PRs). No version bump — a rollup release (0.3.11) lands after these merge.

Tests: green except 4 pre-existing `ThemeProvider` `localStorage.clear` failures (present on `main`, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)