### PR TITLE
fix(test): polyfill localStorage/sessionStorage in vitest setup

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,35 @@
 import "@testing-library/jest-dom/vitest";
+
+// jsdom's Storage implementation is unreliable under vitest (localStorage.clear
+// throws "is not a function"), which broke every test that resets storage in a
+// beforeEach. Provide a complete in-memory Storage so tests relying on
+// localStorage / sessionStorage work deterministically.
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>();
+  get length(): number {
+    return this.store.size;
+  }
+  clear(): void {
+    this.store.clear();
+  }
+  getItem(key: string): string | null {
+    return this.store.has(key) ? (this.store.get(key) as string) : null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.store.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, String(value));
+  }
+}
+
+for (const name of ["localStorage", "sessionStorage"] as const) {
+  Object.defineProperty(globalThis, name, {
+    value: new MemoryStorage(),
+    configurable: true,
+    writable: true,
+  });
+}


### PR DESCRIPTION
jsdom's Storage was throwing `localStorage.clear is not a function` in the `beforeEach` of `ThemeProvider.test.tsx`, failing 4 tests on **every** run. Since `pnpm test` is a CI gate (`ci.yml`), `main` is currently red. This adds a complete in-memory `localStorage`/`sessionStorage` mock to `vitest.setup.ts`.

Suite goes from **581/585** to **585/585**.

**Merge this first** — the 8 `/simplify` PRs (#241–#248) inherit these 4 pre-existing failures from `main`; once this is in, their checks go green on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)