### PR TITLE
docs(contributing): component-vocabulary + hook-placement conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,22 +169,35 @@ export { Button, type ButtonProps } from "./components/ui/actions/button/Button"
 ## Adding a layout
 
 ```
-src/components/layout/<category>/<layout>/
+src/components/layout/<layout>/
   Layout.tsx
   Layout.stories.tsx
 ```
 
 Layouts compose UI components into page-level structures. They get stories (for visual review) but no unit tests — they're covered by app-level E2E tests.
 
-Private subcomponents that only a layout uses live in the same folder:
+Private subcomponents that only a layout uses live in the same folder.
 
-```
-layout/app-shell/app-shell/
-  AppShell.tsx
-  AppShell.stories.tsx
-  AgentSidebarHeader.tsx    # internal, not exported
-  AgentSidebarInput.tsx     # internal, not exported
-```
+## Component vocabulary
+
+Use one consistent prop name per axis so the kit reads predictably:
+
+| Axis | Prop | Values | Notes |
+|------|------|--------|-------|
+| Palette | `tone` / `color` | from `Tone` — `primary` `secondary` `tertiary` `error` `warning` `success` | Derive subsets from `Tone` (`type ButtonColor = Exclude<Tone, "success">`) instead of re-listing members, so a palette change propagates. |
+| Structural style | `variant` | component-specific (`filled` `tonal` `outline` `text`, …) | Shape/emphasis, never color. |
+| Scale | `size` | `xs` `sm` `md` `lg` (subset as needed) | |
+| State | `status` / `level` | domain states (`online`, `offline`, …) | Distinct from palette — don't fold into `tone`. |
+
+Don't reintroduce an `info` variant (dropped in 0.3.9 — use `primary`/`secondary`).
+
+## Hook placement
+
+| Hook kind | Lives in |
+|-----------|----------|
+| Context-bound (uses a provider) | `src/context/<context>/`, next to the provider |
+| Component-bound (1:1 with one component) | the component's own folder (e.g. `use-editable-fields.ts`) |
+| Cross-cutting (shared by unrelated components) | `src/hooks/` (e.g. `useClickOutside`, `useAutoGrowTextarea`) — internal, not exported from `index.ts` |
 
 ## Testing guidelines
 


### PR DESCRIPTION
Codifies the conventions from the structure-review audit (R5 vocab + SF8 hook placement) so new components stop drifting:
- **Vocabulary**: one prop per axis — `variant`=structural, `tone`/`color`=palette (derive subsets from `Tone` via `Exclude`/`Extract`, don't re-list members), `size`=scale, `status`/`level`=state. No `info` (dropped 0.3.9).
- **Hook placement**: context-bound → `context/`; component-bound → co-located; cross-cutting → `src/hooks/` (internal).
- Corrects the `layout/` folder example to the flattened single-level form (matches #250).

Docs-only; no code/exports touched (disjoint from #250). The risky cosmetic part of R5 — rewriting palette unions as `Exclude<Tone,…>` in each component — is **deferred** to the noted follow-up because a wrong member set would break consumers silently (CI can't catch it). The `warn` token in notch-grid is left as-is (it's an intentional, documented schema alias, not a defect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)