### PR TITLE
chore(release): web-ui-kit v0.3.11 — simplify + structure waves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,49 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.3.11
+
+Internal simplify + structure pass (a 45-finding audit + a structure review).
+**No component public export names were removed**; one behavior change (below).
+
+### Fixed
+
+- **FloatingLabelInput** now forwards native HTML attributes (`autoFocus`,
+  `name`, `required`, `onKeyDown`, `autoComplete`, …) — fixes focus in
+  `EditableField` and `TypeToConfirmDialog`.
+- **Accessibility** — focus-visible rings on Button/IconButton/nav controls,
+  `aria-current` on active nav items, AppSwitcher disclosure semantics,
+  accessible names for StarRating/StatusIndicator/status dots, ReauthDialog
+  title, OptionList empty-row role, disabled Combobox chevron, MultiQuestion.
+- Shared `status → CSS var` helper (`dataStatusVarColor`); deduped Gauge/
+  DataList/Timeline. Doc/comment rot (`info` variant; `Graph` `nodeSize`).
+
+### Added
+
+- **Icon** `fill` prop (Material Symbols FILL axis); StarRating uses it.
+- Exported `ButtonVariant`/`ButtonColor`/`ButtonSize`, `ComboboxSize`,
+  `FloatingLabelInputSize`.
+
+### Changed (structure — internal moves, public export names unchanged)
+
+- New `blocks/` category for the 8 NotchGrid tile primitives; `chart/` dissolved;
+  `data/`→`display/`, `files/drop-zone`→`inputs/`, `state/`→`dev/`;
+  `LogoMirrorStack`→`Logo` (export name unchanged).
+- Removed the `AgentSidebar`/`GraphSide` re-export barrels; extracted
+  `PrimitiveRegistry`/`ItemKey` and `GraphSideNode` into local `types.ts`.
+- Navigation `variant="danger"` deprecated for `"error"` (soft alias, still works).
+
+### ⚠️ Behavior change
+
+- **NotchGrid** `primitives` now defaults to `{}` (previously the built-in
+  eight). Opt in: `<NotchGrid items={…} primitives={defaultPrimitives} />`.
+  Removes the static surface→viz import edge so grid-only consumers don't bundle
+  all eight block components.
+
+### Removed
+
+- Demo-only `mockAgentHistory` / `mockAgentMessages` from the public API.
+
 ## 0.3.10
 
 Keeps the 0.3.9 drop-`info` change (`Alert` and `Badge` have no `info`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
Rollup release: bumps 0.3.10 → **0.3.11** + CHANGELOG, with the `release` label so `release.yml` publishes on merge.

Covers the already-merged **simplify wave** (#241–#249) plus the **structure wave** (#250 reorg, #251 docs).

⚠️ **Merge LAST** — after #250 and #251 are in `main` — so 0.3.11 publishes with the structure changes included. (This branch is off the pre-structure `main`; CHANGELOG/package.json don't conflict with #250/#251, so it merges cleanly after them.)

Headline behavior change in 0.3.11: `NotchGrid` `primitives` defaults to `{}` (opt in with `primitives={defaultPrimitives}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)