### PR TITLE
chore(release): web-ui-kit v0.4.0 — simplify + structure waves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,49 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.4.0
+
+Minor bump (not patch) because this release contains a breaking **behavior**
+change and a public-export removal, layered on the internal simplify + structure
+passes (a 45-finding audit + a structure review). All component public export
+**names** are otherwise unchanged.
+
+### ⚠️ Breaking
+
+- **NotchGrid** `primitives` now defaults to `{}` (previously the built-in
+  eight). Opt in explicitly:
+  `<NotchGrid items={…} primitives={defaultPrimitives} />`. This removes the
+  static surface→visualization import edge so grid-only consumers no longer
+  bundle all eight block components.
+- Removed demo-only `mockAgentHistory` / `mockAgentMessages` from the public API.
+
+### Fixed
+
+- **FloatingLabelInput** now forwards native HTML attributes (`autoFocus`,
+  `name`, `required`, `onKeyDown`, `autoComplete`, …) — fixes focus in
+  `EditableField` and `TypeToConfirmDialog`.
+- **Accessibility** — focus-visible rings on Button/IconButton/nav controls,
+  `aria-current` on active nav items, AppSwitcher disclosure semantics,
+  accessible names for StarRating/StatusIndicator/status dots, ReauthDialog
+  title, OptionList empty-row role, disabled Combobox chevron, MultiQuestion.
+- Shared `status → CSS var` helper (`dataStatusVarColor`); deduped Gauge/
+  DataList/Timeline. Doc/comment rot (`info` variant; `Graph` `nodeSize`).
+
+### Added
+
+- **Icon** `fill` prop (Material Symbols FILL axis); StarRating uses it.
+- Exported `ButtonVariant`/`ButtonColor`/`ButtonSize`, `ComboboxSize`,
+  `FloatingLabelInputSize`.
+
+### Changed (structure — internal moves, public export names unchanged)
+
+- New `blocks/` category for the 8 NotchGrid tile primitives; `chart/` dissolved;
+  `data/`→`display/`, `files/drop-zone`→`inputs/`, `state/`→`dev/`;
+  `LogoMirrorStack`→`Logo` (export name unchanged).
+- Removed the `AgentSidebar`/`GraphSide` re-export barrels; extracted
+  `PrimitiveRegistry`/`ItemKey` and `GraphSideNode` into local `types.ts`.
+- Navigation `variant="danger"` deprecated for `"error"` (soft alias, still works).
+
 ## 0.3.10
 
 Keeps the 0.3.9 drop-`info` change (`Alert` and `Badge` have no `info`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.3.10",
+  "version": "0.4.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
Rollup release: **0.3.10 → 0.4.0** + CHANGELOG, with the `release` label so `release.yml` publishes on merge.

**Minor (0.4.0), not patch** — this release breaks behavior, which a 0.x patch would hide:
- ⚠️ `NotchGrid` `primitives` now defaults to `{}` (opt in with `primitives={defaultPrimitives}`).
- ⚠️ removed demo-only `mockAgentHistory`/`mockAgentMessages` from the public API.

Covers the merged simplify wave (#241–#249) + structure wave (#250 reorg, #251 docs). Branched off the current `main` (both already merged), so just merge this to publish.

Supersedes #252 (which was 0.3.11 off the pre-structure main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)