### PR TITLE
refactor(kit): finish structure cleanup — barrel re-section, Tone-derived ButtonColor, Surface compose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ src/components/ui/<category>/<component>/
   Component.test.tsx
 ```
 
-Categories: `actions`, `inputs`, `feedback`, `navigation`, `surfaces`, `media`, `data`, `files`, `state`
+Categories: `actions`, `agent`, `blocks`, `dev`, `display`, `feedback`, `graph`, `inputs`, `media`, `navigation`, `surfaces`
 
 ### 2. Write the component
 

--- a/src/components/ui/actions/shared/button-styles.ts
+++ b/src/components/ui/actions/shared/button-styles.ts
@@ -1,6 +1,19 @@
+import type { Tone } from "@/types/tone";
+
 export type ButtonVariant = "filled" | "tonal" | "outline" | "text";
-export type ButtonColor = "primary" | "secondary" | "tertiary" | "error" | "warning";
+/** The brand/semantic palette minus `success` (no success button in the design
+ *  system). Derived from {@link Tone} so a palette change propagates; the guard
+ *  below makes `tsc` fail if the member set ever drifts from the intended five. */
+export type ButtonColor = Exclude<Tone, "success">;
 export type ButtonSize = "xs" | "sm" | "md" | "lg";
+
+// Compile-time guard: ButtonColor must stay exactly these five members.
+type _Eq<A, B> = [A] extends [B] ? ([B] extends [A] ? true : never) : never;
+const _buttonColorGuard: _Eq<
+  ButtonColor,
+  "primary" | "secondary" | "tertiary" | "error" | "warning"
+> = true;
+void _buttonColorGuard;
 
 const filledStyles: Record<ButtonColor, string> = {
   primary:

--- a/src/components/ui/graph/graph-side/GraphSideContent.tsx
+++ b/src/components/ui/graph/graph-side/GraphSideContent.tsx
@@ -2,7 +2,7 @@ import { useState, type ReactNode } from "react";
 import { cn } from "@/utils/cn";
 import { Icon } from "@/components/ui/media/icon/Icon";
 import type { ComponentMeta } from "@/types/component-meta";
-import { SIDE_CARD_CLS } from "./styles";
+import { Surface } from "@/components/ui/surfaces/surface/Surface";
 
 export const meta: ComponentMeta = {
   name: "GraphSideContent",
@@ -52,10 +52,9 @@ export function GraphSideContent({ items, prepend, prependClassName, className }
   };
 
   return (
-    <div
+    <Surface
       className={cn(
-        SIDE_CARD_CLS,
-        "h-full overflow-y-auto [scrollbar-gutter:stable] pl-1.5 pr-0.5 pb-3 divide-y divide-outline-variant",
+        "rounded-xl shadow-xl h-full overflow-y-auto [scrollbar-gutter:stable] pl-1.5 pr-0.5 pb-3 divide-y divide-outline-variant",
         className,
       )}
     >
@@ -100,6 +99,6 @@ export function GraphSideContent({ items, prepend, prependClassName, className }
           </div>
         );
       })}
-    </div>
+    </Surface>
   );
 }

--- a/src/components/ui/graph/graph-side/GraphSideHeader.tsx
+++ b/src/components/ui/graph/graph-side/GraphSideHeader.tsx
@@ -3,7 +3,7 @@ import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 import { Badge } from "@/components/ui/feedback/badge/Badge";
 import type { ComponentMeta } from "@/types/component-meta";
 import type { GraphSideNode } from "./types";
-import { SIDE_CARD_CLS } from "./styles";
+import { Surface } from "@/components/ui/surfaces/surface/Surface";
 
 export const meta: ComponentMeta = {
   name: "GraphSideHeader",
@@ -28,10 +28,9 @@ export function GraphSideHeader({
   const hasTags = tagList.length > 0;
 
   return (
-    <div
+    <Surface
       className={cn(
-        SIDE_CARD_CLS,
-        "flex items-center gap-3 p-3",
+        "rounded-xl shadow-xl flex items-center gap-3 p-3",
         className,
       )}
     >
@@ -57,6 +56,6 @@ export function GraphSideHeader({
           </div>
         )}
       </div>
-    </div>
+    </Surface>
   );
 }

--- a/src/components/ui/graph/graph-side/styles.ts
+++ b/src/components/ui/graph/graph-side/styles.ts
@@ -1,3 +1,0 @@
-/** Shared chrome for the cards that make up the GraphSide panel. */
-export const SIDE_CARD_CLS =
-  "bg-surface-container-low border border-outline-variant rounded-xl shadow-xl";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,17 @@
+// Public API barrel for @mirrorstack-ai/web-ui-kit.
+// Grouped by category to mirror the on-disk taxonomy (src/components/ui/<category>).
+// Consumers import everything from the package root — internal file moves never
+// change these names.
+
+// --- utils ---
 export { cn } from "./utils/cn";
 export { formatDate, formatRelativeDate } from "./utils/date";
-export { Icon, type IconProps } from "./components/ui/media/icon/Icon";
 export { isDev, isProd, isStorybook } from "./utils/env";
+
+// --- design tokens ---
+export { type Tone, toneBorderClass, toneTextClass } from "./types/tone";
+
+// --- ui/actions ---
 export {
   Button,
   type ButtonProps,
@@ -14,131 +24,6 @@ export {
   type IconButtonProps,
 } from "./components/ui/actions/icon-button/IconButton";
 export {
-  Progress,
-  type ProgressProps,
-  type ProgressType,
-  type ProgressColor,
-  type ProgressVariant,
-  type ProgressSize,
-} from "./components/ui/feedback/progress/Progress";
-export {
-  Snackbar,
-  SNACKBAR_EXIT_MS,
-  type SnackbarProps,
-  type SnackbarVariant,
-  type SnackbarAction,
-} from "./components/ui/feedback/snackbar/Snackbar";
-export {
-  FloatingLabelInput,
-  type FloatingLabelInputProps,
-  type FloatingLabelInputSize,
-} from "./components/ui/inputs/floating-label-input/FloatingLabelInput";
-export {
-  SegmentedButton,
-  type SegmentedButtonProps,
-  type SegmentedButtonOption,
-  type SegmentedButtonSize,
-  type SegmentedButtonOptionTone,
-} from "./components/ui/inputs/segmented-button/SegmentedButton";
-export {
-  Switch,
-  type SwitchProps,
-  type SwitchColor,
-  type SwitchSize,
-} from "./components/ui/inputs/switch/Switch";
-export {
-  Slider,
-  type SliderProps,
-} from "./components/ui/inputs/slider/Slider";
-export {
-  PageHeader,
-  type PageHeaderProps,
-} from "./components/ui/display/page-header/PageHeader";
-export {
-  SectionHeader,
-  type SectionHeaderProps,
-} from "./components/ui/display/section-header/SectionHeader";
-export {
-  SectionLabel,
-  type SectionLabelProps,
-} from "./components/ui/display/section-label/SectionLabel";
-export {
-  DevToolbar,
-  type DevToolbarProps,
-  type DevToolbarItem,
-} from "./components/ui/dev/dev-toolbar/DevToolbar";
-export {
-  Alert,
-  type AlertProps,
-  type AlertVariant,
-} from "./components/ui/feedback/alert/Alert";
-export {
-  ConsequencesNotice,
-  type ConsequencesNoticeProps,
-} from "./components/ui/feedback/consequences-notice/ConsequencesNotice";
-export {
-  Dialog,
-  type DialogProps,
-  type DialogAction,
-} from "./components/ui/surfaces/dialog/Dialog";
-export {
-  TypeToConfirmDialog,
-  type TypeToConfirmDialogProps,
-} from "./components/ui/surfaces/type-to-confirm-dialog/TypeToConfirmDialog";
-export {
-  EditableField,
-  type EditableFieldProps,
-} from "./components/ui/inputs/editable-field/EditableField";
-export { useEditableFields } from "./components/ui/inputs/editable-field/use-editable-fields";
-export {
-  Surface,
-  type SurfaceProps,
-} from "./components/ui/surfaces/surface/Surface";
-export {
-  SettingsSection,
-  type SettingsSectionProps,
-} from "./components/ui/surfaces/settings-section/SettingsSection";
-export {
-  Card,
-  type CardProps,
-} from "./components/ui/surfaces/card/Card";
-export {
-  OptionList,
-  type OptionListProps,
-  type OptionListItem,
-} from "./components/ui/surfaces/option-list/OptionList";
-export {
-  Avatar,
-  type AvatarProps,
-  type AvatarSize,
-} from "./components/ui/media/avatar/Avatar";
-export {
-  AvatarCropper,
-  type AvatarCropperProps,
-} from "./components/ui/media/avatar-cropper/AvatarCropper";
-export { Logo, type LogoProps } from "./components/ui/media/logo/Logo";
-export {
-  Combobox,
-  type ComboboxProps,
-  type ComboboxOption,
-  type ComboboxSize,
-} from "./components/ui/inputs/combobox/Combobox";
-export {
-  ImageCarousel,
-  type ImageCarouselProps,
-  type CarouselImage,
-} from "./components/ui/media/image-carousel/ImageCarousel";
-export {
-  Badge,
-  type BadgeProps,
-  type BadgeVariant,
-  type BadgeSize,
-} from "./components/ui/feedback/badge/Badge";
-export {
-  Skeleton,
-  type SkeletonProps,
-} from "./components/ui/feedback/skeleton/Skeleton";
-export {
   ThemeToggle,
   type ThemeToggleProps,
   type Theme,
@@ -150,152 +35,8 @@ export {
   type SocialIconProps,
   type SocialProvider,
 } from "./components/ui/actions/social-button/SocialButton";
-export {
-  ReadOnlyField,
-  type ReadOnlyFieldProps,
-  type ReadOnlyFieldLayout,
-} from "./components/ui/display/read-only-field/ReadOnlyField";
-export {
-  Step,
-  type StepProps,
-  type StepStatus,
-} from "./components/ui/display/step/Step";
-export {
-  Markdown,
-  type MarkdownProps,
-} from "./components/ui/display/markdown/Markdown";
-export {
-  SettingRow,
-  type SettingRowProps,
-} from "./components/ui/display/setting-row/SettingRow";
-export { type Tone, toneBorderClass, toneTextClass } from "./types/tone";
-export {
-  ThemeProvider,
-  useTheme,
-  type ThemeProviderProps,
-  type ThemeContextType,
-} from "./context/theme/ThemeProvider";
-export {
-  SidebarProvider,
-  useSidebarWidth,
-  type SidebarProviderProps,
-  type SidebarContextType,
-} from "./context/sidebar/SidebarProvider";
-export {
-  SnackbarProvider,
-  SnackbarOutlet,
-  useSnackbar,
-  useUnsavedSnackbar,
-  type SnackbarProviderProps,
-  type SnackbarOptions,
-  type SnackbarOutletProps,
-  type UseUnsavedSnackbarOptions,
-} from "./context/snackbar/SnackbarProvider";
-export {
-  ActivityList,
-  type ActivityListProps,
-  type ActivityItem,
-} from "./components/ui/display/activity-list/ActivityList";
-export {
-  ReauthDialog,
-  type ReauthDialogProps,
-} from "./components/ui/surfaces/reauth-dialog/ReauthDialog";
-export {
-  VerificationCodeInput,
-  type VerificationCodeInputProps,
-} from "./components/ui/inputs/verification-code-input/VerificationCodeInput";
-export {
-  Breadcrumb,
-  type BreadcrumbItem,
-  type BreadcrumbProps,
-} from "./components/ui/navigation/breadcrumb/Breadcrumb";
-export {
-  NavItem,
-  type NavItemProps,
-  type NavItemVariant,
-} from "./components/ui/navigation/nav-item/NavItem";
-export {
-  NavDrawer,
-  type NavDrawerProps,
-  type NavDrawerItem,
-  type NavDrawerSection,
-} from "./components/ui/navigation/nav-drawer/NavDrawer";
-export {
-  NavigationRail,
-  type NavigationRailProps,
-} from "./components/ui/navigation/navigation-rail/NavigationRail";
-export {
-  NavigationButton,
-  type NavigationButtonProps,
-  type NavigationButtonVariant,
-} from "./components/ui/navigation/navigation-button/NavigationButton";
-export {
-  AppSwitcher,
-  type AppSwitcherProps,
-  type AppLink,
-} from "./components/ui/navigation/app-switcher/AppSwitcher";
-export {
-  DropdownMenu,
-  type DropdownMenuProps,
-  type DropdownMenuItem,
-  type DropdownMenuEntry,
-  type DropdownMenuSeparator,
-} from "./components/ui/navigation/dropdown-menu/DropdownMenu";
-export {
-  Notch,
-  type NotchProps,
-  type NotchSide,
-} from "./components/ui/surfaces/notch/Notch";
-export {
-  NotchGrid,
-  type NotchGridProps,
-  type NotchGridItem,
-  type NotchSubItem,
-  type NotchGridUI,
-  type NotchGridError,
-  type PrimitiveRegistry,
-  type ItemKey,
-} from "./components/ui/surfaces/notch-grid/NotchGrid";
-export {
-  type Desire,
-  type Pos,
-  type Mask,
-  type Priority,
-} from "./components/ui/surfaces/notch-grid/layout";
-export {
-  type NotchTheme,
-  type ThemeType,
-  type ThemeVariant,
-} from "./components/ui/surfaces/notch-grid/theme";
-export { defaultPrimitives } from "./components/registry/notch-primitives";
-export {
-  DataList,
-  type DataListProps,
-  type DataListItem,
-} from "./components/ui/blocks/data-list/DataList";
-export {
-  DataTable,
-  type DataTableProps,
-  type DataTableColumn,
-} from "./components/ui/blocks/data-table/DataTable";
-export {
-  StatusIndicator,
-  type StatusIndicatorProps,
-  type StatusLevel,
-} from "./components/ui/blocks/status-indicator/StatusIndicator";
-export {
-  StarRating,
-  type StarRatingProps,
-} from "./components/ui/blocks/star-rating/StarRating";
-export {
-  Timeline,
-  type TimelineProps,
-  type TimelineEntry,
-} from "./components/ui/blocks/timeline/Timeline";
-export {
-  Gauge,
-  type GaugeProps,
-} from "./components/ui/blocks/gauge/Gauge";
+
+// --- ui/agent ---
 export {
   AgentSidebarHeader,
   type AgentSidebarHeaderProps,
@@ -333,23 +74,8 @@ export {
   type AgentSidebarHistoryGroup,
   type AgentSidebarHistoryItem,
 } from "./components/ui/agent/sidebar/types";
-export {
-  DropZone,
-  type DropZoneProps,
-} from "./components/ui/inputs/drop-zone/DropZone";
-export {
-  EmptyState,
-  type EmptyStateProps,
-} from "./components/ui/feedback/empty-state/EmptyState";
-export {
-  AppShell,
-  type AppShellProps,
-} from "./components/layout/app-shell/AppShell";
-export {
-  Sparkline,
-  type SparklineProps,
-  type SparklinePoint,
-} from "./components/ui/blocks/sparkline/Sparkline";
+
+// --- ui/blocks (NotchGrid tile primitives) ---
 export {
   MetricBlock,
   type MetricBlockProps,
@@ -359,13 +85,128 @@ export {
   type MetricStat,
 } from "./components/ui/blocks/metric-block/MetricBlock";
 export {
+  Sparkline,
+  type SparklineProps,
+  type SparklinePoint,
+} from "./components/ui/blocks/sparkline/Sparkline";
+export {
+  DataList,
+  type DataListProps,
+  type DataListItem,
+} from "./components/ui/blocks/data-list/DataList";
+export {
+  DataTable,
+  type DataTableProps,
+  type DataTableColumn,
+} from "./components/ui/blocks/data-table/DataTable";
+export {
+  StatusIndicator,
+  type StatusIndicatorProps,
+  type StatusLevel,
+} from "./components/ui/blocks/status-indicator/StatusIndicator";
+export {
+  StarRating,
+  type StarRatingProps,
+} from "./components/ui/blocks/star-rating/StarRating";
+export {
+  Timeline,
+  type TimelineProps,
+  type TimelineEntry,
+} from "./components/ui/blocks/timeline/Timeline";
+export {
+  Gauge,
+  type GaugeProps,
+} from "./components/ui/blocks/gauge/Gauge";
+
+// --- ui/dev ---
+export {
+  DevToolbar,
+  type DevToolbarProps,
+  type DevToolbarItem,
+} from "./components/ui/dev/dev-toolbar/DevToolbar";
+
+// --- ui/display ---
+export {
+  PageHeader,
+  type PageHeaderProps,
+} from "./components/ui/display/page-header/PageHeader";
+export {
+  SectionHeader,
+  type SectionHeaderProps,
+} from "./components/ui/display/section-header/SectionHeader";
+export {
+  SectionLabel,
+  type SectionLabelProps,
+} from "./components/ui/display/section-label/SectionLabel";
+export {
+  ReadOnlyField,
+  type ReadOnlyFieldProps,
+  type ReadOnlyFieldLayout,
+} from "./components/ui/display/read-only-field/ReadOnlyField";
+export {
+  Step,
+  type StepProps,
+  type StepStatus,
+} from "./components/ui/display/step/Step";
+export {
+  Markdown,
+  type MarkdownProps,
+} from "./components/ui/display/markdown/Markdown";
+export {
+  SettingRow,
+  type SettingRowProps,
+} from "./components/ui/display/setting-row/SettingRow";
+export {
+  ActivityList,
+  type ActivityListProps,
+  type ActivityItem,
+} from "./components/ui/display/activity-list/ActivityList";
+
+// --- ui/feedback ---
+export {
+  Progress,
+  type ProgressProps,
+  type ProgressType,
+  type ProgressColor,
+  type ProgressVariant,
+  type ProgressSize,
+} from "./components/ui/feedback/progress/Progress";
+export {
+  Snackbar,
+  SNACKBAR_EXIT_MS,
+  type SnackbarProps,
+  type SnackbarVariant,
+  type SnackbarAction,
+} from "./components/ui/feedback/snackbar/Snackbar";
+export {
+  Alert,
+  type AlertProps,
+  type AlertVariant,
+} from "./components/ui/feedback/alert/Alert";
+export {
+  ConsequencesNotice,
+  type ConsequencesNoticeProps,
+} from "./components/ui/feedback/consequences-notice/ConsequencesNotice";
+export {
+  Badge,
+  type BadgeProps,
+  type BadgeVariant,
+  type BadgeSize,
+} from "./components/ui/feedback/badge/Badge";
+export {
+  Skeleton,
+  type SkeletonProps,
+} from "./components/ui/feedback/skeleton/Skeleton";
+export {
+  EmptyState,
+  type EmptyStateProps,
+} from "./components/ui/feedback/empty-state/EmptyState";
+
+// --- ui/graph ---
+export {
   GraphAction,
   type GraphActionProps,
 } from "./components/ui/graph/action/GraphAction";
-export {
-  GraphLayout,
-  type GraphLayoutProps,
-} from "./components/layout/graph-layout/GraphLayout";
 export {
   GraphSide,
   type GraphSideProps,
@@ -415,3 +256,198 @@ export {
   type GraphEdge,
   type GraphHandle,
 } from "./components/ui/graph/graph/Graph";
+
+// --- ui/inputs ---
+export {
+  FloatingLabelInput,
+  type FloatingLabelInputProps,
+  type FloatingLabelInputSize,
+} from "./components/ui/inputs/floating-label-input/FloatingLabelInput";
+export {
+  SegmentedButton,
+  type SegmentedButtonProps,
+  type SegmentedButtonOption,
+  type SegmentedButtonSize,
+  type SegmentedButtonOptionTone,
+} from "./components/ui/inputs/segmented-button/SegmentedButton";
+export {
+  Switch,
+  type SwitchProps,
+  type SwitchColor,
+  type SwitchSize,
+} from "./components/ui/inputs/switch/Switch";
+export {
+  Slider,
+  type SliderProps,
+} from "./components/ui/inputs/slider/Slider";
+export {
+  EditableField,
+  type EditableFieldProps,
+} from "./components/ui/inputs/editable-field/EditableField";
+export { useEditableFields } from "./components/ui/inputs/editable-field/use-editable-fields";
+export {
+  Combobox,
+  type ComboboxProps,
+  type ComboboxOption,
+  type ComboboxSize,
+} from "./components/ui/inputs/combobox/Combobox";
+export {
+  VerificationCodeInput,
+  type VerificationCodeInputProps,
+} from "./components/ui/inputs/verification-code-input/VerificationCodeInput";
+export {
+  DropZone,
+  type DropZoneProps,
+} from "./components/ui/inputs/drop-zone/DropZone";
+
+// --- ui/media ---
+export { Icon, type IconProps } from "./components/ui/media/icon/Icon";
+export {
+  Avatar,
+  type AvatarProps,
+  type AvatarSize,
+} from "./components/ui/media/avatar/Avatar";
+export {
+  AvatarCropper,
+  type AvatarCropperProps,
+} from "./components/ui/media/avatar-cropper/AvatarCropper";
+export { Logo, type LogoProps } from "./components/ui/media/logo/Logo";
+export {
+  ImageCarousel,
+  type ImageCarouselProps,
+  type CarouselImage,
+} from "./components/ui/media/image-carousel/ImageCarousel";
+
+// --- ui/navigation ---
+export {
+  Breadcrumb,
+  type BreadcrumbItem,
+  type BreadcrumbProps,
+} from "./components/ui/navigation/breadcrumb/Breadcrumb";
+export {
+  NavItem,
+  type NavItemProps,
+  type NavItemVariant,
+} from "./components/ui/navigation/nav-item/NavItem";
+export {
+  NavDrawer,
+  type NavDrawerProps,
+  type NavDrawerItem,
+  type NavDrawerSection,
+} from "./components/ui/navigation/nav-drawer/NavDrawer";
+export {
+  NavigationRail,
+  type NavigationRailProps,
+} from "./components/ui/navigation/navigation-rail/NavigationRail";
+export {
+  NavigationButton,
+  type NavigationButtonProps,
+  type NavigationButtonVariant,
+} from "./components/ui/navigation/navigation-button/NavigationButton";
+export {
+  AppSwitcher,
+  type AppSwitcherProps,
+  type AppLink,
+} from "./components/ui/navigation/app-switcher/AppSwitcher";
+export {
+  DropdownMenu,
+  type DropdownMenuProps,
+  type DropdownMenuItem,
+  type DropdownMenuEntry,
+  type DropdownMenuSeparator,
+} from "./components/ui/navigation/dropdown-menu/DropdownMenu";
+
+// --- ui/surfaces ---
+export {
+  Dialog,
+  type DialogProps,
+  type DialogAction,
+} from "./components/ui/surfaces/dialog/Dialog";
+export {
+  TypeToConfirmDialog,
+  type TypeToConfirmDialogProps,
+} from "./components/ui/surfaces/type-to-confirm-dialog/TypeToConfirmDialog";
+export {
+  ReauthDialog,
+  type ReauthDialogProps,
+} from "./components/ui/surfaces/reauth-dialog/ReauthDialog";
+export {
+  Surface,
+  type SurfaceProps,
+} from "./components/ui/surfaces/surface/Surface";
+export {
+  SettingsSection,
+  type SettingsSectionProps,
+} from "./components/ui/surfaces/settings-section/SettingsSection";
+export {
+  Card,
+  type CardProps,
+} from "./components/ui/surfaces/card/Card";
+export {
+  OptionList,
+  type OptionListProps,
+  type OptionListItem,
+} from "./components/ui/surfaces/option-list/OptionList";
+export {
+  Notch,
+  type NotchProps,
+  type NotchSide,
+} from "./components/ui/surfaces/notch/Notch";
+export {
+  NotchGrid,
+  type NotchGridProps,
+  type NotchGridItem,
+  type NotchSubItem,
+  type NotchGridUI,
+  type NotchGridError,
+  type PrimitiveRegistry,
+  type ItemKey,
+} from "./components/ui/surfaces/notch-grid/NotchGrid";
+export {
+  type Desire,
+  type Pos,
+  type Mask,
+  type Priority,
+} from "./components/ui/surfaces/notch-grid/layout";
+export {
+  type NotchTheme,
+  type ThemeType,
+  type ThemeVariant,
+} from "./components/ui/surfaces/notch-grid/theme";
+
+// --- layout ---
+export {
+  AppShell,
+  type AppShellProps,
+} from "./components/layout/app-shell/AppShell";
+export {
+  GraphLayout,
+  type GraphLayoutProps,
+} from "./components/layout/graph-layout/GraphLayout";
+
+// --- registry ---
+export { defaultPrimitives } from "./components/registry/notch-primitives";
+
+// --- context ---
+export {
+  ThemeProvider,
+  useTheme,
+  type ThemeProviderProps,
+  type ThemeContextType,
+} from "./context/theme/ThemeProvider";
+export {
+  SidebarProvider,
+  useSidebarWidth,
+  type SidebarProviderProps,
+  type SidebarContextType,
+} from "./context/sidebar/SidebarProvider";
+export {
+  SnackbarProvider,
+  SnackbarOutlet,
+  useSnackbar,
+  useUnsavedSnackbar,
+  type SnackbarProviderProps,
+  type SnackbarOptions,
+  type SnackbarOutletProps,
+  type UseUnsavedSnackbarOptions,
+} from "./context/snackbar/SnackbarProvider";


### PR DESCRIPTION
Closes out the **deferred items** from the structure-review wave (#250):

- **SF1** — re-section `src/index.ts` by category with headers. **Export surface verified identical** by diffing `dist/index.d.ts` before/after (264 identifiers, nothing dropped/added) — the silent-drop risk that kept this out of #250 is now guarded.
- **R5** — `ButtonColor = Exclude<Tone, "success">` (derived from the palette so it propagates), with a compile-time `tsc` guard asserting the member set stays exactly the five. Left the rest of the palette types as-is (not clean `Tone` subsets) and `warn` untouched (intentional schema alias).
- **SF4** — compose `Surface` in `GraphSideHeader`/`GraphSideContent`; delete the duplicated `SIDE_CARD_CLS` (`styles.ts`).
- **docs** — fix the CONTRIBUTING category list to the new taxonomy.

No public export names change. typecheck + build + 562 tests + `components validate` (62) all green. Internal/non-breaking → rides into the next release (a 0.4.1 `release` PR when convenient).

🤖 Generated with [Claude Code](https://claude.com/claude-code)