### PR TITLE
chore(release): web-ui-kit v0.4.1 — structure-cleanup follow-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.4.1
+
+Internal cleanup from the structure-review follow-up. **No consumer-facing API
+change** (no export names, props, or behavior changed).
+
+- Re-sectioned the public barrel (`index.ts`) by category (export surface
+  verified identical).
+- `ButtonColor` is now derived from `Tone` (`Exclude<Tone, "success">`) — same
+  five members.
+- graph-side cards compose `Surface` instead of a duplicated class constant.
+- CONTRIBUTING: corrected the component-category list and added the
+  vocabulary + hook-placement conventions.
+
 ## 0.4.0
 
 Minor bump (not patch) because this release contains a breaking **behavior**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
Publishes the #254 internal cleanup as **0.4.1** (`release` label → `release.yml` publishes on merge).

**No consumer-facing change** — barrel re-section, `ButtonColor` derived from `Tone` (same members), graph-side `Surface` compose, docs. Bump is for hygiene (published version == main).

Merge to publish 0.4.1; then web-applications + web-account pin to `^0.4.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)