### PR TITLE
feat: Alert neutral variant for resting-state status boxes

### DIFF
--- a/src/components/ui/feedback/alert/Alert.stories.tsx
+++ b/src/components/ui/feedback/alert/Alert.stories.tsx
@@ -11,7 +11,7 @@ const meta: Meta<typeof Alert> = {
   argTypes: {
     variant: {
       control: "select",
-      options: ["error", "success", "warning", "primary", "secondary"],
+      options: ["error", "success", "warning", "primary", "secondary", "neutral"],
     },
   },
 };
@@ -24,7 +24,7 @@ export const Playground: Story = {};
 export const Variants: Story = {
   render: () => (
     <div className="flex flex-col gap-3">
-      {(["primary", "secondary", "success", "warning", "error"] as AlertVariant[]).map((v) => (
+      {(["primary", "secondary", "success", "warning", "error", "neutral"] as AlertVariant[]).map((v) => (
         <Alert key={v} variant={v}>
           This is a {v} alert message.
         </Alert>
@@ -66,5 +66,15 @@ export const HideIcon: Story = {
     hideIcon: true,
     children:
       "Useful when the surrounding container (like a destructive Dialog) already conveys severity and a leading icon would crowd the title.",
+  },
+};
+
+export const Neutral: Story = {
+  args: {
+    variant: "neutral",
+    title: "Dev tunnel not running",
+    hideIcon: true,
+    children:
+      "A resting, untinted status box for informational state that isn't a severity. Use hideIcon when there's no signal to convey.",
   },
 };

--- a/src/components/ui/feedback/alert/Alert.test.tsx
+++ b/src/components/ui/feedback/alert/Alert.test.tsx
@@ -75,6 +75,15 @@ describe("Alert", () => {
     expect(screen.getByText("check_circle")).toHaveStyle({ fontSize: "20px" });
   });
 
+  it("renders the neutral variant with untinted surface tokens", () => {
+    render(<Alert variant="neutral">Resting state</Alert>);
+    const el = screen.getByRole("alert");
+    expect(el).toHaveClass("bg-surface-container-low");
+    expect(el).toHaveClass("text-on-surface");
+    // Not severity-tinted.
+    expect(el).not.toHaveClass("bg-error/10");
+  });
+
   it("hides leading icon and drops content margin when hideIcon is set", () => {
     render(
       <Alert variant="error" hideIcon>

--- a/src/components/ui/feedback/alert/Alert.tsx
+++ b/src/components/ui/feedback/alert/Alert.tsx
@@ -7,7 +7,7 @@ import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 export const meta: ComponentMeta = {
   name: "Alert",
   description:
-    "Dismissible inline alert banner with error/success/warning/primary/secondary variants",
+    "Dismissible inline alert banner with error/success/warning/primary/secondary/neutral variants",
 };
 
 export type AlertVariant =
@@ -15,7 +15,8 @@ export type AlertVariant =
   | "success"
   | "warning"
   | "primary"
-  | "secondary";
+  | "secondary"
+  | "neutral";
 
 export interface AlertProps {
   variant: AlertVariant;
@@ -38,6 +39,9 @@ const variantStyles: Record<AlertVariant, string> = {
   warning: "bg-warning/10 border-warning/30 text-warning",
   primary: "bg-primary/10 border-primary/30 text-primary",
   secondary: "bg-secondary/10 border-secondary/30 text-secondary",
+  // Neutral resting-state box: no severity tint. Pairs with `hideIcon`
+  // when used purely as an informational container.
+  neutral: "bg-surface-container-low border-outline-variant text-on-surface",
 };
 
 const variantIcons: Record<AlertVariant, string> = {
@@ -46,6 +50,7 @@ const variantIcons: Record<AlertVariant, string> = {
   warning: "warning",
   primary: "info",
   secondary: "info",
+  neutral: "info",
 };
 
 export function Alert({


### PR DESCRIPTION
Adds a non-severity **`neutral`** variant to `Alert`: `bg-surface-container-low` + solid `border-outline-variant` + `text-on-surface`, default icon `info`.

Every `Alert` was previously forced into a colored tone, so apps hand-rolled a neutral box matching Alert geometry when they just wanted an informational/resting container (e.g. web-applications `dev/module/[slug]/dev/page.tsx` — comment explicitly noted the kit lacked this).

Additive union member — existing variants and behavior unchanged. New `Neutral` story + a token test.

Verified locally: `pnpm typecheck` ✅ · `pnpm test` ✅ · `pnpm components validate` ✅ · `pnpm build` ✅

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)