### PR TITLE
feat: SettingRow muted surface variant

### DIFF
--- a/src/components/ui/display/setting-row/SettingRow.stories.tsx
+++ b/src/components/ui/display/setting-row/SettingRow.stories.tsx
@@ -50,3 +50,11 @@ export const Success: Story = {
 export const NoDescription: Story = {
   args: { description: undefined },
 };
+
+export const Muted: Story = {
+  args: {
+    surface: "muted",
+    title: "Module tunnel",
+    description: "Lighter, lower-emphasis row for list-style settings.",
+  },
+};

--- a/src/components/ui/display/setting-row/SettingRow.test.tsx
+++ b/src/components/ui/display/setting-row/SettingRow.test.tsx
@@ -55,6 +55,23 @@ describe("SettingRow", () => {
     expect(container.firstChild).toHaveClass(expected);
   });
 
+  it("applies the muted surface tokens", () => {
+    const { container } = render(
+      <SettingRow title="X" control={<span />} surface="muted" />,
+    );
+    expect(container.firstChild).toHaveClass("bg-surface-container-low");
+    expect(container.firstChild).toHaveClass("border-outline-variant/40");
+  });
+
+  it("keeps the tone border accent on a muted row", () => {
+    const { container } = render(
+      <SettingRow title="X" control={<span />} surface="muted" tone="warning" />,
+    );
+    expect(container.firstChild).toHaveClass("bg-surface-container-low");
+    expect(container.firstChild).toHaveClass("border-warning/40");
+    expect(container.firstChild).not.toHaveClass("border-outline-variant/40");
+  });
+
   it("forwards the className prop", () => {
     const { container } = render(
       <SettingRow title="X" control={<span />} className="custom-class" />,

--- a/src/components/ui/display/setting-row/SettingRow.tsx
+++ b/src/components/ui/display/setting-row/SettingRow.tsx
@@ -7,7 +7,7 @@ import { toneBorderClass, type Tone } from "@/types/tone";
 export const meta: ComponentMeta = {
   name: "SettingRow",
   description:
-    "Title + optional description on the left, control slot on the right. Used to compose settings forms; supports an optional Tone border accent (primary, secondary, tertiary, error, warning, or success).",
+    "Title + optional description on the left, control slot on the right. Used to compose settings forms; supports an optional Tone border accent (primary, secondary, tertiary, error, warning, or success) and a muted surface variant for lighter, lower-emphasis rows.",
 };
 
 export interface SettingRowProps {
@@ -22,6 +22,13 @@ export interface SettingRowProps {
    * (omitted) renders with the neutral outline-variant border.
    */
   tone?: Tone;
+  /**
+   * Surface emphasis. "default" uses bg-surface-container with a solid
+   * outline-variant border; "muted" uses the lower bg-surface-container-low
+   * with a faint (/40) border for lighter, lower-emphasis rows. A `tone`
+   * border accent still takes precedence over the muted neutral border.
+   */
+  surface?: "default" | "muted";
   className?: string;
 }
 
@@ -30,13 +37,21 @@ export function SettingRow({
   description,
   control,
   tone,
+  surface = "default",
   className,
 }: SettingRowProps) {
-  const border = tone ? toneBorderClass[tone] : "border-outline-variant";
+  const muted = surface === "muted";
+  const bg = muted ? "bg-surface-container-low" : "bg-surface-container";
+  const border = tone
+    ? toneBorderClass[tone]
+    : muted
+      ? "border-outline-variant/40"
+      : "border-outline-variant";
   return (
     <div
       className={cn(
-        "flex items-center gap-4 px-4 py-3 rounded-xl border bg-surface-container",
+        "flex items-center gap-4 px-4 py-3 rounded-xl border",
+        bg,
         border,
         className,
       )}


### PR DESCRIPTION
Adds **`surface="muted"`** to `SettingRow` — `bg-surface-container-low` + a faint `border-outline-variant/40` — for lighter, lower-emphasis rows. A `tone` border accent still takes precedence over the muted neutral border.

This was the **most-duplicated chrome** the className audit found (~6 sites across both apps: navigator NavRow, dev tunnel row, billing InfraRow/meter, CreateOrgForm card row).

Default (`surface="default"`) unchanged. New `Muted` story + 2 tests (muted tokens, and tone-over-muted precedence).

Verified locally: `pnpm typecheck` ✅ · `pnpm test` ✅ · `pnpm components validate` ✅ · `pnpm build` ✅

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)