### PR TITLE
chore: release 0.4.2 — boxed SegmentedButton variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,6 @@ Additive component variants — adopted to replace chrome the consumer apps were
 hand-rolling (surfaced by the className-duplication audit). **No breaking
 changes**; all defaults unchanged.
 
-- `Alert`: new `neutral` variant — an untinted resting-state box
-  (`bg-surface-container-low` + outline-variant border + on-surface text) for
-  informational state that isn't a severity. (#256)
 - `SegmentedButton`: new `variant="boxed"` — a bordered connected track with an
   inset selected pill, alongside the default gapped `"pills"`. Exports
   `SegmentedButtonVariant`. (#257)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.4.2
+
+Additive component variants — adopted to replace chrome the consumer apps were
+hand-rolling (surfaced by the className-duplication audit). **No breaking
+changes**; all defaults unchanged.
+
+- `Alert`: new `neutral` variant — an untinted resting-state box
+  (`bg-surface-container-low` + outline-variant border + on-surface text) for
+  informational state that isn't a severity. (#256)
+- `SegmentedButton`: new `variant="boxed"` — a bordered connected track with an
+  inset selected pill, alongside the default gapped `"pills"`. Exports
+  `SegmentedButtonVariant`. (#257)
+- `SettingRow`: new `surface="muted"` — `bg-surface-container-low` + a faint
+  (`/40`) border for lighter, lower-emphasis rows; a `tone` accent still takes
+  precedence. (#258)
+
 ## 0.4.1
 
 Internal cleanup from the structure-review follow-up. **No consumer-facing API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,13 @@ Notable API additions and breaking changes. For the full commit log, see
 
 ## 0.4.2
 
-Additive component variants — adopted to replace chrome the consumer apps were
+Additive component variant — adopted to replace chrome the consumer apps were
 hand-rolling (surfaced by the className-duplication audit). **No breaking
 changes**; all defaults unchanged.
 
 - `SegmentedButton`: new `variant="boxed"` — a bordered connected track with an
   inset selected pill, alongside the default gapped `"pills"`. Exports
   `SegmentedButtonVariant`. (#257)
-- `SettingRow`: new `surface="muted"` — `bg-surface-container-low` + a faint
-  (`/40`) border for lighter, lower-emphasis rows; a `tone` accent still takes
-  precedence. (#258)
 
 ## 0.4.1
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
**Merge LAST.** Bumps `0.4.1 → 0.4.2` + CHANGELOG so `release.yml` publishes the boxed SegmentedButton variant. Has the `release` label.

#260 (the variant) is already merged to main, so this is the final step — mark ready and merge to publish 0.4.2.

- #257 → #260 SegmentedButton `variant="boxed"` ✅ merged

_(Neutral Alert #256/#259 and muted SettingRow #258/#261 were dropped — not needed.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)