### PR TITLE
feat: NotchGrid bleed + contentPad + drag polish (0.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.4.3
+
+Additive `NotchGrid` props for fine-resolution and framed layouts, plus drag
+polish. **No breaking changes**; all defaults unchanged.
+
+- `NotchGrid`: new `contentPad` prop (default `"16px 8px"`) — lower it for
+  fine-resolution grids where a tile may be only a fraction of a block tall and
+  the default would over-pad short cells.
+- `NotchGrid`: new `panelBleed` prop (default `0`) — expands a panel's outline
+  outward so its frame can match the full inter-tile gap instead of half of it.
+- `BlockShape` / `gridOutlinePath`: new `bleed` option (the inverse of `gap`) —
+  dilates the outline outward; the SVG grows so the widened frame isn't clipped.
+- Drag: the drop target now shows a dashed indicator for both outer-tile and
+  sub-item drags; a tile dropped on an occupied cell lands at the nearest free
+  cell to where it was aimed; a window-level backstop guarantees the drag
+  releases even when pointer capture is lost. (#263)
+
 ## 0.4.2
 
 Additive component variant — adopted to replace chrome the consumer apps were

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/surfaces/notch-grid/BlockShape.tsx
+++ b/src/components/ui/surfaces/notch-grid/BlockShape.tsx
@@ -35,6 +35,10 @@ export interface BlockShapeProps {
    *  neighbours / nested items leave a `gap`-px space. Footprint size is
    *  unchanged. Normally set by the parent `NotchGrid`; default 0. */
   gap?: number;
+  /** Expand the outline OUTWARD by `bleed` px (inverse of `gap`) so the frame
+   *  can sit beyond the cells. The SVG grows to avoid clipping; content stays
+   *  in the cell box. Default 0. */
+  bleed?: number;
   /** Convex corner radius (px). Default 24. */
   radius?: number;
   /** Concave / notch corner radius (px). Default 32. */
@@ -59,6 +63,7 @@ export function BlockShape({
   tier = 1,
   block = BLOCK_SIZE,
   gap = 0,
+  bleed = 0,
   radius = 24,
   inverseRadius = 32,
   fill = "var(--color-surface-container-low)",
@@ -83,10 +88,14 @@ export function BlockShape({
   const w = cols * block;
   const h = rows * block;
   const pathD = useMemo(
-    () => gridOutlinePath(mask, { cell: block, gap, radius, inverseRadius }),
-    [mask, block, gap, radius, inverseRadius],
+    () => gridOutlinePath(mask, { cell: block, gap, bleed, radius, inverseRadius }),
+    [mask, block, gap, bleed, radius, inverseRadius],
   );
   const inset = strokeWidth / 2;
+  // When the outline bleeds outward, the SVG must extend past the w×h box so
+  // the dilated path isn't clipped — grow it by `bleed` on every side and offset
+  // it back. The content layer (children) stays at the cell box (0..w).
+  const m = bleed + inset;
 
   return (
     <div
@@ -94,10 +103,11 @@ export function BlockShape({
       style={{ width: w, height: h, ...style }}
     >
       <svg
-        width={w}
-        height={h}
-        viewBox={`${-inset} ${-inset} ${w + strokeWidth} ${h + strokeWidth}`}
-        className="pointer-events-none absolute inset-0"
+        width={w + 2 * bleed}
+        height={h + 2 * bleed}
+        viewBox={`${-m} ${-m} ${w + 2 * m} ${h + 2 * m}`}
+        className="pointer-events-none absolute"
+        style={{ left: -bleed, top: -bleed }}
         aria-hidden="true"
       >
         {!noClip && (

--- a/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
+++ b/src/components/ui/surfaces/notch-grid/NotchGrid.tsx
@@ -106,6 +106,15 @@ export interface NotchGridProps {
   blockMin?: number;
   /** Gap between blocks in px (notch erosion). Default 8. */
   gap?: number;
+  /** CSS padding inset on each tile / sub-cell's content. Default `"16px 8px"`.
+   *  Lower it (or `0`) for fine-resolution grids where a tile may be only a
+   *  fraction of a block tall — the default would over-pad short cells. */
+  contentPad?: number | string;
+  /** Expand each panel's outline OUTWARD by `panelBleed` px so its frame can sit
+   *  beyond the cells — lets the outer frame match the inter-tile gap instead of
+   *  being half of it. Pair with a `contentPad` of the same value for uniform
+   *  spacing. Default 0. */
+  panelBleed?: number;
   /** Reserved — already implied by the solver's cell-level collision. */
   nest?: boolean;
   /** Map from `ui.type` → React component. Receives the full `ui` object as
@@ -127,7 +136,7 @@ export interface NotchGridProps {
 // --- Internal helpers ------------------------------------------------------
 
 /** Content inset inside a tile / sub-cell (8px sides, 16px top/bottom). Matches BlockShape's default. */
-const CONTENT_PAD = "16px 8px";
+const DEFAULT_CONTENT_PAD = "16px 8px";
 
 /** Pointer capture, tolerant of test envs (jsdom) that lack the API. */
 function safePointerCapture(el: Element, pointerId: number): void {
@@ -145,11 +154,79 @@ function safePointerRelease(el: Element, pointerId: number): void {
   }
 }
 
+/** The window-level drag backstop receives DOM PointerEvents, but the drag
+ *  handlers are typed for React's synthetic event. They only read fields both
+ *  share (pointerId, clientX/Y, currentTarget), so this bridges the two without
+ *  repeating the cast at every call site. */
+const toReact = (e: PointerEvent): ReactPointerEvent =>
+  e as unknown as ReactPointerEvent;
+
 /** Stable key for a sub-item within its panel. Index-based since sub-items
  *  may omit `key`. */
 type SubKey = string;
 const subKeyOf = (parentKey: ItemKey, index: number): SubKey =>
   `${parentKey}::${index}`;
+
+/** The grid cell a sub-drag will land in: the ghost's top-left (origin + drag
+ *  delta) rounded to the nearest cell. Shared by the drop handler and the drop
+ *  indicator so the preview matches the landing spot. */
+function subDropCell(
+  s: {
+    panelCol: number;
+    subCol: number;
+    panelRow: number;
+    subRow: number;
+    dx: number;
+    dy: number;
+  },
+  blockPx: number,
+): Pos {
+  return [
+    Math.max(0, Math.round(((s.panelCol + s.subCol) * blockPx + s.dx) / blockPx)),
+    Math.max(0, Math.round(((s.panelRow + s.subRow) * blockPx + s.dy) / blockPx)),
+  ];
+}
+
+/** Dashed outline marking the cell a dragged tile will land in. Shared by the
+ *  sub-drag and outer-drag indicators so both read identically — each caller
+ *  computes its own landing geometry (their drop math differs) and this only
+ *  renders it. */
+function DropIndicator({
+  col,
+  row,
+  cols,
+  rows,
+  blockPx,
+  contentPad,
+  color,
+}: {
+  col: number;
+  row: number;
+  cols: number;
+  rows: number;
+  blockPx: number;
+  contentPad: number | string;
+  color: string;
+}) {
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute z-20"
+      style={{
+        left: col * blockPx,
+        top: row * blockPx,
+        width: cols * blockPx,
+        height: rows * blockPx,
+        padding: contentPad,
+      }}
+    >
+      <div
+        className="h-full w-full rounded-[22px] border-2 border-dashed"
+        style={{ borderColor: color, opacity: 0.6 }}
+      />
+    </div>
+  );
+}
 
 /** A sub-item paired with its original index in the panel's `subItems` (kept
  *  through filtering/overriding so drag handlers can identify the cell). */
@@ -305,8 +382,14 @@ interface DragState {
   /** Origin position in block units (where the item sits at drag start). */
   originCol: number;
   originRow: number;
-  /** Footprint width in blocks (to clamp the dropped column). */
+  /** Footprint in blocks (to clamp the dropped column + size the drop
+   *  indicator). Captured at drag-start so the indicator needs no placement
+   *  lookup mid-drag. */
   originCols: number;
+  originRows: number;
+  /** Resolved theme color, captured at drag-start to tint the drop indicator
+   *  without re-resolving the theme on every pointer move. */
+  color: string;
   /** Live pointer delta in px. */
   dx: number;
   dy: number;
@@ -356,6 +439,8 @@ export function NotchGrid({
   cols = "auto",
   blockMin = BLOCK_SIZE,
   gap = 8,
+  contentPad = DEFAULT_CONTENT_PAD,
+  panelBleed = 0,
   nest = true,
   primitives = {},
   onItemError,
@@ -420,6 +505,8 @@ export function NotchGrid({
         originCol: p.col,
         originRow: p.row,
         originCols: p.cols,
+        originRows: p.rows,
+        color: resolveNotchTheme(p.item?.theme ?? {}).color,
         dx: 0,
         dy: 0,
       });
@@ -442,6 +529,8 @@ export function NotchGrid({
         originCol: lead.col,
         originRow: lead.row,
         originCols: lead.cols,
+        originRows: lead.rows,
+        color: resolveNotchTheme(lead.item?.theme ?? {}).color,
         dx: 0,
         dy: 0,
         members: members.map((m) => ({
@@ -504,6 +593,9 @@ export function NotchGrid({
     (e: ReactPointerEvent) => {
       const d = dragRef.current;
       if (!d || e.pointerId !== d.pointerId) return;
+      // Clear synchronously so the element + window backstop firing in the same
+      // tick can't run this twice.
+      dragRef.current = null;
       safePointerRelease(e.currentTarget, e.pointerId);
       setDrag(null);
       const blockPx = block || blockMin;
@@ -551,21 +643,19 @@ export function NotchGrid({
     (e: ReactPointerEvent) => {
       const s = subDragRef.current;
       if (!s || e.pointerId !== s.pointerId) return;
+      // Clear synchronously so the element + window backstop firing in the same
+      // tick can't run this twice (which would double-promote the sub-item).
+      subDragRef.current = null;
       safePointerRelease(e.currentTarget, e.pointerId);
       setSubDrag(null);
       // Unified drop: the sub lands at the cursor's outer-grid cell as a
       // group member. Render-time auto-link re-unions it with same-group
       // tiles it's adjacent to (so a drop next to the panel reads as "stayed
       // in the panel"); dropped far, it stands alone.
-      const blockPx = block || blockMin;
-      const rect = wrapperRef.current?.getBoundingClientRect();
-      const dropCol = rect
-        ? Math.max(0, Math.floor((e.clientX - rect.left) / blockPx))
-        : s.panelCol + s.subCol;
-      const dropRow = rect
-        ? Math.max(0, Math.floor((e.clientY - rect.top) / blockPx))
-        : s.panelRow + s.subRow;
-      const pos: Pos = [dropCol, dropRow];
+      // Drop where the ghost visually sits (origin + drag delta, rounded to the
+      // nearest cell) so the landing spot matches both the ghost and the drop
+      // indicator the user was aiming with.
+      const pos = subDropCell(s, block || blockMin);
       const sk = subKeyOf(s.parentKey, s.subIndex);
       const parent = keyedItems.find((it) => it.key === s.parentKey);
       const sub = parent?.subItems?.[s.subIndex];
@@ -596,6 +686,40 @@ export function NotchGrid({
     },
     [block, blockMin, keyedItems, onSubItemPromote],
   );
+
+  // Window-level drag backstop: the element handlers rely on pointer capture,
+  // but capture can be lost (capture failed, or the captured cell detached mid
+  // re-render) — then the element never sees pointerup and the tile sticks to
+  // the cursor. Listening on window guarantees the drag ALWAYS ends on release,
+  // wherever the pointer is. Element handlers still fire first when capture
+  // works; these handlers are idempotent (they no-op once the drag is cleared),
+  // so the double path is harmless.
+  const dragging = drag !== null || subDrag !== null;
+  useEffect(() => {
+    if (!dragging) return;
+    const onMove = (e: PointerEvent) => {
+      if (subDragRef.current) handleSubPointerMove(toReact(e));
+      else if (dragRef.current) handlePointerMove(toReact(e));
+    };
+    const onEnd = (e: PointerEvent) => {
+      if (subDragRef.current) handleSubPointerEnd(toReact(e));
+      else if (dragRef.current) handlePointerEnd(toReact(e));
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onEnd);
+    window.addEventListener("pointercancel", onEnd);
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onEnd);
+      window.removeEventListener("pointercancel", onEnd);
+    };
+  }, [
+    dragging,
+    handlePointerMove,
+    handlePointerEnd,
+    handleSubPointerMove,
+    handleSubPointerEnd,
+  ]);
 
   // Solve: panels get their desire.shape replaced by the union of their
   // *effective* sub-item footprints; promoted subs are appended as top-level
@@ -691,6 +815,8 @@ export function NotchGrid({
             members={members}
             block={block}
             gap={gap}
+            contentPad={contentPad}
+            panelBleed={panelBleed}
             primitives={primitives}
             onItemError={onItemError}
             draggable={draggable}
@@ -711,6 +837,54 @@ export function NotchGrid({
         );
       })}
 
+      {/* Drop indicator — a dashed outline at the cell the dragged sub-item
+          will land in (same `subDropCell` the drop uses), so the user can aim. */}
+      {subDrag &&
+        (() => {
+          const blockPx = block || blockMin;
+          const [tCol, tRow] = subDropCell(subDrag, blockPx);
+          return (
+            <DropIndicator
+              col={tCol}
+              row={tRow}
+              cols={subDrag.ghostShape[0]?.length ?? 1}
+              rows={subDrag.ghostShape.length}
+              blockPx={blockPx}
+              contentPad={contentPad}
+              color={subDrag.ghostColor}
+            />
+          );
+        })()}
+
+      {/* Drop indicator for an OUTER drag (a top-level tile / promoted sub) —
+          after a sub-item is dragged out it becomes top-level, so the SECOND
+          drag is an outer drag and needs its own indicator. Footprint + color
+          are captured in `drag` at drag-start, so no placement lookup is needed.
+          Single-tile drags only (a whole-component move keeps members together). */}
+      {drag &&
+        !drag.members &&
+        (() => {
+          const blockPx = block || blockMin;
+          const colCount = resolvedCols ?? 1;
+          const maxCol = Math.max(0, colCount - drag.originCols);
+          const tCol = Math.min(
+            maxCol,
+            Math.max(0, drag.originCol + Math.round(drag.dx / blockPx)),
+          );
+          const tRow = Math.max(0, drag.originRow + Math.round(drag.dy / blockPx));
+          return (
+            <DropIndicator
+              col={tCol}
+              row={tRow}
+              cols={drag.originCols}
+              rows={drag.originRows}
+              blockPx={blockPx}
+              contentPad={contentPad}
+              color={drag.color}
+            />
+          );
+        })()}
+
       {/* Cursor-follow ghost for the sub-item being dragged — carries the
           sub's own content so it reads as the real cell, not a blank chrome. */}
       {subDrag &&
@@ -730,6 +904,8 @@ export function NotchGrid({
                 shape={subDrag.ghostShape}
                 block={block}
                 gap={gap}
+                bleed={panelBleed}
+                pad={contentPad}
                 fill={subDrag.ghostFill}
                 stroke={subDrag.ghostStroke}
                 strokeWidth={subDrag.ghostStrokeWidth}
@@ -755,6 +931,8 @@ interface NotchComponentProps {
   members: Placement<NotchGridItem>[];
   block: number;
   gap: number;
+  contentPad: number | string;
+  panelBleed: number;
   primitives?: PrimitiveRegistry;
   onItemError?: (key: ItemKey, error: NotchGridError) => void;
   draggable?: boolean;
@@ -793,6 +971,8 @@ const NotchComponent = memo(function NotchComponent({
   members,
   block,
   gap,
+  contentPad,
+  panelBleed,
   primitives,
   onItemError,
   draggable = false,
@@ -841,17 +1021,22 @@ const NotchComponent = memo(function NotchComponent({
     return grid;
   }, [members, compCols, compRows, minCol, minRow]);
 
+  const isPlainSingleton =
+    members.length === 1 && !panelSubLayouts.has(members[0].key);
+
   // Outline of the chrome (same path BlockShape draws). Used to hit-clip the
   // wrapper so its bounding-box rectangle doesn't intercept pointer events over
   // empty notch cells — otherwise an overlapping neighbour's rectangle would
-  // steal clicks meant for this component (and vice-versa).
+  // steal clicks meant for this component (and vice-versa). Every component
+  // (incl. a dragged-out singleton) bleeds by `panelBleed` so frames stay
+  // consistent.
   const chromePath = useMemo(
     () =>
       gridOutlinePath(
         unionShape.map((row) => row.map(Boolean)),
-        { cell: block, gap, radius: 24, inverseRadius: 32 },
+        { cell: block, gap, bleed: panelBleed, radius: 24, inverseRadius: 32 },
       ),
-    [unionShape, block, gap],
+    [unionShape, block, gap, panelBleed],
   );
 
   // Theme from the lead member — same-group members share their theme.
@@ -876,8 +1061,6 @@ const NotchComponent = memo(function NotchComponent({
   // A lone non-panel tile drags as a whole (chrome + content move together);
   // panels & multi-member chromes drag per sub-cell / per content tile, OR as
   // a whole unit when the chrome (connection area) itself is grabbed.
-  const isPlainSingleton =
-    members.length === 1 && !panelSubLayouts.has(lead.key);
   // The whole wrapper moves as a unit — for a plain singleton always, or for a
   // panel/linked chrome when the chrome itself (not a cell) is being dragged.
   const wrapperMoves = (isPlainSingleton || wholeDrag) && dragKey === lead.key;
@@ -885,6 +1068,12 @@ const NotchComponent = memo(function NotchComponent({
   // (multi-member outer drag). A unit move keeps its clip so notched content
   // stays inside the outline; a sub-drag uses a separate ghost.
   const memberEscaping = dragKey != null && !isPlainSingleton && !wholeDrag;
+  // A chromeless (ghost) panel draws no fill and no border, so clipping its
+  // content to the rounded outline only shaves the corners of self-shaped
+  // children (e.g. bordered cards). Skip the clip entirely for ghost — the
+  // children define their own shape. (`noChrome` is resolved by the theme, not
+  // re-inferred from CSS strings here.)
+  const skipClip = memberEscaping || resolved.noChrome;
 
   const wrapperStyle: CSSProperties = {
     position: "absolute",
@@ -905,7 +1094,7 @@ const NotchComponent = memo(function NotchComponent({
   // Hit-clip the wrapper rectangle to the chrome outline so it only catches
   // pointers over the actual shape — except while a member is escaping (then
   // the un-clipped tile needs to render past the bounds).
-  if (!memberEscaping) {
+  if (!skipClip) {
     wrapperStyle.clipPath = `path('${chromePath}')`;
   }
 
@@ -975,7 +1164,7 @@ const NotchComponent = memo(function NotchComponent({
               top: (offRow + sp.row) * block,
               width: sp.cols * block,
               height: sp.rows * block,
-              padding: CONTENT_PAD,
+              padding: contentPad,
               opacity: beingDragged ? 0 : undefined,
             }}
           >
@@ -1029,7 +1218,7 @@ const NotchComponent = memo(function NotchComponent({
             top: offRow * block,
             width: m.cols * block,
             height: m.rows * block,
-            padding: CONTENT_PAD,
+            padding: contentPad,
             // Follow the cursor while this member is outer-dragged so it reads
             // as picked up (the sub-drag has its own ghost; standalone members
             // move their own tile). The themed background + rounded corners
@@ -1076,11 +1265,12 @@ const NotchComponent = memo(function NotchComponent({
         shape={unionShape}
         block={block}
         gap={gap}
+        bleed={panelBleed}
         fill={resolved.fill}
         stroke={resolved.stroke}
         strokeWidth={resolved.strokeWidth}
         pad={0}
-        noClip={memberEscaping}
+        noClip={skipClip}
       >
         {resolved.accentBar && (
           <div

--- a/src/components/ui/surfaces/notch-grid/layout.ts
+++ b/src/components/ui/surfaces/notch-grid/layout.ts
@@ -276,26 +276,36 @@ export function solveLayout<T = unknown>(
     return out;
   };
 
+  /** Mark a candidate's cells occupied and build its `Placement`. Shared by the
+   *  exact/flow placement in `tryPlace` and the nearest-free drop fallback so
+   *  the placement shape is built in one place. */
+  const commitPlacement = (
+    item: SolverItem<T>,
+    cand: Candidate,
+    col: number,
+    row: number,
+  ): Placement<T> => {
+    occupy(cand.mask, col, row);
+    return {
+      key: item.key,
+      item: item.item,
+      col,
+      row,
+      mask: cand.mask,
+      cols: maskCols(cand.mask),
+      rows: cand.mask.length,
+      priorityUsed: { position: cand.posKey, shape: cand.shapeKey },
+      scale: cand.scale,
+      cost: cand.cost,
+    };
+  };
+
   const tryPlace = (item: SolverItem<T>, cand: Candidate): Placement<T> | null => {
     const w = maskCols(cand.mask);
-    const h = cand.mask.length;
     if (w > C) return null;
 
-    const commit = (col: number, row: number): Placement<T> => {
-      occupy(cand.mask, col, row);
-      return {
-        key: item.key,
-        item: item.item,
-        col,
-        row,
-        mask: cand.mask,
-        cols: w,
-        rows: h,
-        priorityUsed: { position: cand.posKey, shape: cand.shapeKey },
-        scale: cand.scale,
-        cost: cand.cost,
-      };
-    };
+    const commit = (col: number, row: number) =>
+      commitPlacement(item, cand, col, row);
 
     if (cand.pos) {
       const [col, row] = cand.pos;
@@ -320,6 +330,32 @@ export function solveLayout<T = unknown>(
     return null;
   };
 
+  /** A fixed-position item whose exact cell is taken: instead of re-flowing it
+   *  from the top-left (which lands it far from the drop), search outward in
+   *  expanding Chebyshev rings from the desired cell and take the NEAREST free
+   *  fit — so a dropped tile lands where the user aimed. */
+  const placeNearestFree = (item: SolverItem<T>): Placement<T> | null => {
+    const p = item.desire.position;
+    if (p === undefined || isPriorityMap(p)) return null;
+    const [dCol, dRow] = p as Pos;
+    const cand = candidatesFor(item)[0];
+    if (!cand) return null;
+    const w = maskCols(cand.mask);
+    if (w > C) return null;
+    for (let radius = 0; radius < MAX_ROWS; radius++) {
+      for (let row = Math.max(0, dRow - radius); row <= dRow + radius; row++) {
+        for (let col = Math.max(0, dCol - radius); col + w <= C; col++) {
+          const ring = Math.max(Math.abs(row - dRow), Math.abs(col - dCol));
+          if (ring !== radius) continue; // only the new outer ring each pass
+          if (!collides(cand.mask, col, row)) {
+            return commitPlacement(item, cand, col, row);
+          }
+        }
+      }
+    }
+    return null;
+  };
+
   const isFixedPos = (item: SolverItem<T>): boolean => {
     const p = item.desire.position;
     return p !== undefined && !isPriorityMap(p);
@@ -333,11 +369,15 @@ export function solveLayout<T = unknown>(
       const placed = place(item);
       if (placed) placements.push(placed);
       else {
-        // Demote: try again with position dropped so the item flows freely.
-        flowQueue.push({
-          ...item,
-          desire: { ...item.desire, position: undefined },
-        });
+        // Exact cell taken — land at the nearest free cell to the drop before
+        // falling back to a free flow.
+        const near = placeNearestFree(item);
+        if (near) placements.push(near);
+        else
+          flowQueue.push({
+            ...item,
+            desire: { ...item.desire, position: undefined },
+          });
       }
     } else {
       flowQueue.push(item);

--- a/src/components/ui/surfaces/notch-grid/theme.ts
+++ b/src/components/ui/surfaces/notch-grid/theme.ts
@@ -46,6 +46,11 @@ export interface ResolvedTheme {
    *  traces the rendered shape (e.g. Tailwind's `drop-shadow-lg`, which is a
    *  `filter` so it follows the notched SVG outline, not the bounding box). */
   elevated: boolean;
+  /** Whether this chrome is invisible — no fill and no border (the `ghost`
+   *  theme). Renderers can skip clipping content to the outline, since there's
+   *  no visible chrome to define a boundary and clipping would only shave the
+   *  corners of self-shaped children. */
+  noChrome: boolean;
 }
 
 const DEFAULT_VARIANT: Exclude<ThemeVariant, "auto"> = "neutral";
@@ -164,6 +169,7 @@ export function resolveNotchTheme(theme?: NotchTheme): ResolvedTheme {
         stroke: "none",
         strokeWidth: 0,
         elevated: false,
+        noChrome: false,
       };
     }
     case "outlined": {
@@ -174,6 +180,7 @@ export function resolveNotchTheme(theme?: NotchTheme): ResolvedTheme {
         stroke: OUTLINE_BORDER[variant],
         strokeWidth: 1,
         elevated: false,
+        noChrome: false,
       };
     }
     case "elevated": {
@@ -189,6 +196,7 @@ export function resolveNotchTheme(theme?: NotchTheme): ResolvedTheme {
         strokeWidth: 0,
         ...(isAlert ? { accentBar: ACCENT[variant] } : {}),
         elevated: true,
+        noChrome: false,
       };
     }
     case "ghost": {
@@ -199,6 +207,7 @@ export function resolveNotchTheme(theme?: NotchTheme): ResolvedTheme {
         stroke: "none",
         strokeWidth: 0,
         elevated: false,
+        noChrome: true,
       };
     }
   }

--- a/src/utils/grid-outline.ts
+++ b/src/utils/grid-outline.ts
@@ -30,6 +30,10 @@ export interface GridOutlineOptions {
    *  this shape and anything flush against it (incl. items in its notches).
    *  Clamped below `cell` so the shape can't collapse. Default 0. */
   gap?: number;
+  /** Expand the boundary OUTWARD by `bleed` px — the inverse of `gap`. Lets a
+   *  panel's outline sit outside its cells so its frame can match the inter-cell
+   *  gap. Applied after erosion (net offset = gap/2 − bleed). Default 0. */
+  bleed?: number;
 }
 
 type Pt = readonly [number, number];
@@ -54,13 +58,15 @@ export function maskFromShape(
 
 export function gridOutlinePath(
   mask: readonly (readonly boolean[])[],
-  { cell, radius = 24, inverseRadius = 32, gap = 0 }: GridOutlineOptions,
+  { cell, radius = 24, inverseRadius = 32, gap = 0, bleed = 0 }: GridOutlineOptions,
 ): string {
   const rows = mask.length;
   const filled = (r: number, c: number): boolean =>
     r >= 0 && r < rows && c >= 0 && c < mask[r].length && !!mask[r][c];
-  // Keep at least a sliver of shape even when gap is set absurdly high.
-  const erosion = Math.max(0, Math.min(gap, cell - 2)) / 2;
+  // Net boundary offset: positive erodes inward (gap), negative dilates outward
+  // (bleed). `gap` is still clamped so the shape can't collapse; `bleed` has no
+  // inward limit (it only grows the shape).
+  const erosion = Math.max(0, Math.min(gap, cell - 2)) / 2 - bleed;
 
   // Directed boundary edges, oriented so the filled cell sits on the *right*
   // of travel — every cell contributes its 4 boundary edges clockwise in
@@ -138,7 +144,7 @@ export function gridOutlinePath(
         ([x, y]) => [x * cell, y * cell] as Pt,
       );
       if (corners.length >= 3) {
-        const offset = erosion > 0 ? erodeRectilinear(corners, erosion) : corners;
+        const offset = erosion !== 0 ? erodeRectilinear(corners, erosion) : corners;
         subpaths.push(roundedRectilinearPath(offset, radius, inverseRadius));
       }
     }


### PR DESCRIPTION
## What

Additive `NotchGrid` capabilities used by the app-overview dashboard, plus drag UX. **No breaking changes**; all defaults unchanged. Patch bump (0.x patch-only rule) → **0.4.3** with `release` label.

### New API
- **`NotchGrid.contentPad`** (default `"16px 8px"`) — tunable content inset (was a fixed const). Lower it for fine-resolution grids where a tile may be a fraction of a block tall.
- **`NotchGrid.panelBleed`** (default `0`) — dilates a panel's outline outward so its frame can match the *full* inter-tile gap instead of half of it.
- **`BlockShape.bleed` / `gridOutlinePath({ bleed })`** (default `0`) — the inverse of `gap`; the SVG grows so the widened outline isn't clipped.

### Drag UX
- Dashed **drop indicator** at the destination cell for both outer-tile and sub-item drags.
- **Nearest-free placement**: a tile dropped on an occupied cell lands at the closest free cell to where it was aimed (was: re-flow from top-left).
- **Window-level pointer backstop**: the drag always releases on pointerup even if pointer capture is lost mid-drag.

## Simplify pass (applied)
- Ghost "no-chrome" is now a **resolved-theme flag** (`ResolvedTheme.noChrome`) instead of inferred from CSS value strings (`fill === "transparent" && stroke === "none"`) — the fragile string compare is gone.
- Extracted shared **`<DropIndicator>`** (was two near-identical JSX blocks) and **`commitPlacement`** in the solver (was a duplicated Placement build).
- Drag color + footprint captured into drag state at drag-start → the indicator no longer does an O(n) `placements.find` + `resolveNotchTheme` on every pointer move.
- Dropped the no-op `effectiveBleed` alias; added a `toReact` cast helper.

Skipped (noted): the `placeNearestFree` ring scan (cold path) and the dual-indicator root cause (the promote model — architectural, out of scope).

## Verification
- `pnpm typecheck` clean
- `pnpm test` → **567 passed** (incl. notch-grid layout/theme/BlockShape/grid-outline)
- `pnpm build` clean

## Scope note
Touches only the NotchGrid feature (`notch-grid/*`, `grid-outline.ts`) + version/changelog. The concurrent mobile-nav changes (AppShell, DropdownMenu, NavigationRail, index.ts) are intentionally **not** in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)