### PR TITLE
feat: mobile bottom navigation — horizontal rail, AppShell slot, BottomNavItem (0.4.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/AppShell.stories.tsx
+++ b/src/components/layout/app-shell/AppShell.stories.tsx
@@ -178,6 +178,40 @@ export const WithNavDrawer: Story = {
   },
 };
 
+export const WithMobileNavDrawer: Story = {
+  parameters: {
+    viewport: { defaultViewport: "mobile2" },
+  },
+  render: () => {
+    const [active, setActive] = useState("profile");
+    return (
+      <AppShell
+        // Below lg the side nav hides and the menu button (bottom-left)
+        // opens the same NavDrawer as a modal slide-in. Resize the viewport
+        // under 1024px to see it.
+        mobileNavigationVariant="drawer"
+        navigation={
+          <NavDrawer
+            sections={navSections}
+            activeItemId={active}
+            onItemClick={(item: NavDrawerItem) => setActive(item.id)}
+          />
+        }
+        appSwitcher={
+          <AppSwitcher
+            currentApp="Account"
+            logo={<div className="w-8 h-8"><Logo /></div>}
+            apps={apps}
+            activeAppId="account"
+          />
+        }
+      >
+        <DemoContent />
+      </AppShell>
+    );
+  },
+};
+
 function SnackbarDemoContent() {
   const { showSnackbar } = useSnackbar();
   return (

--- a/src/components/layout/app-shell/AppShell.stories.tsx
+++ b/src/components/layout/app-shell/AppShell.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { AppShell } from "./AppShell";
 import { NavigationRail } from "@/components/ui/navigation/navigation-rail/NavigationRail";
 import { NavigationButton } from "@/components/ui/navigation/navigation-button/NavigationButton";
+import { BottomNavItem } from "@/components/ui/navigation/bottom-nav-item/BottomNavItem";
 import { AppSwitcher } from "@/components/ui/navigation/app-switcher/AppSwitcher";
 import { Logo } from "@/components/ui/media/logo/Logo";
 import { NavDrawer, type NavDrawerItem } from "@/components/ui/navigation/nav-drawer/NavDrawer";
@@ -21,99 +22,23 @@ const meta: Meta<typeof AppShell> = {
 export default meta;
 type Story = StoryObj<typeof AppShell>;
 
+// --- Shared demo fixtures ---------------------------------------------------
+
 const apps = [
   { id: "account", label: "Account", description: "Profile & security settings", icon: "shield_person", href: "#" },
   { id: "apps", label: "Apps", description: "Manage your applications", icon: "data_table", href: "#" },
 ];
 
-const DemoContent = () => (
-  <div className="max-w-4xl mx-auto">
-    <h1 className="text-2xl font-bold text-on-surface mb-4">Dashboard</h1>
-    <p className="text-on-surface-variant">
-      Main content area. The agent sidebar can be toggled with the floating button.
-    </p>
-  </div>
-);
-
-export const WithNavigationRail: Story = {
-  render: () => {
-    const [selected, setSelected] = useState("apps");
-    return (
-      <AppShell
-        navigation={
-          <NavigationRail
-            logo={
-              <NavigationButton
-                customIcon={
-                  <div className="w-full h-full bg-primary/20 flex items-center justify-center">
-                    <span className="text-primary font-semibold text-lg">M</span>
-                  </div>
-                }
-                label="My App"
-                variant="secondary"
-                disableHoverExpand
-                className="border border-primary"
-              />
-            }
-          >
-            <div className="w-full gap-2 flex flex-col">
-              <NavigationButton
-                icon="space_dashboard"
-                label="Dashboard"
-                variant="primary"
-                selected={selected === "dashboard"}
-                onClick={() => setSelected("dashboard")}
-              />
-              <NavigationButton
-                icon="data_table"
-                label="Your Apps"
-                selected={selected === "apps"}
-                onClick={() => setSelected("apps")}
-              />
-            </div>
-            <div className="h-px rounded-full w-full bg-outline" />
-            <div className="w-full gap-2 flex flex-col">
-              <NavigationButton
-                icon="extension"
-                label="Add-ons"
-                selected={selected === "addons"}
-                onClick={() => setSelected("addons")}
-              />
-              <NavigationButton
-                icon="rocket_launch"
-                label="Deployment"
-                selected={selected === "deployment"}
-                onClick={() => setSelected("deployment")}
-              />
-              <NavigationButton
-                icon="settings"
-                label="Settings"
-                selected={selected === "settings"}
-                onClick={() => setSelected("settings")}
-              />
-            </div>
-          </NavigationRail>
-        }
-        appSwitcher={
-          <AppSwitcher
-            currentApp="Account"
-            logo={<div className="w-8 h-8"><Logo /></div>}
-            apps={apps}
-            activeAppId="account"
-          />
-        }
-        agentSidebarContent={
-          <div className="text-inverse-on-surface text-sm">
-            Chat messages would appear here...
-          </div>
-        }
-        onAgentSend={(msg) => console.log("Send:", msg)}
-      >
-        <DemoContent />
-      </AppShell>
-    );
-  },
-};
+const railGroups = [
+  [
+    { id: "dashboard", icon: "space_dashboard", label: "Dashboard" },
+    { id: "apps", icon: "data_table", label: "Your Apps" },
+  ],
+  [
+    { id: "addons", icon: "extension", label: "Add-ons" },
+    { id: "settings", icon: "settings", label: "Settings" },
+  ],
+];
 
 const navSections = [
   {
@@ -136,80 +61,168 @@ const navSections = [
   },
 ];
 
-export const WithNavDrawer: Story = {
-  render: () => {
-    const [active, setActive] = useState("profile");
-    return (
-      <AppShell
-        navigation={
-          <NavDrawer
-            contextSwitcher={
-              <div className="flex items-center gap-3 p-3 rounded-xl">
-                <Avatar size="md" fallback="J" />
-                <div className="min-w-0 flex-1 space-y-0.5">
-                  <p className="text-sm font-medium text-on-surface truncate">John Doe</p>
-                  <p className="text-xs text-on-surface-variant">Personal Account</p>
-                </div>
-              </div>
-            }
-            sections={navSections}
-            activeItemId={active}
-            onItemClick={(item: NavDrawerItem) => setActive(item.id)}
-          />
-        }
-        appSwitcher={
-          <AppSwitcher
-            currentApp="Account"
-            logo={<div className="w-8 h-8"><Logo /></div>}
-            apps={apps}
-            activeAppId="account"
-          />
-        }
-        agentSidebarContent={
-          <div className="text-inverse-on-surface text-sm">
-            Chat messages would appear here...
-          </div>
-        }
-        onAgentSend={(msg) => console.log("Send:", msg)}
-      >
-        <DemoContent />
-      </AppShell>
-    );
-  },
+const logoGlyph = (
+  <div className="w-full h-full bg-primary/20 flex items-center justify-center">
+    <span className="text-primary font-semibold text-lg">M</span>
+  </div>
+);
+
+const appSwitcher = (
+  <AppSwitcher
+    currentApp="Account"
+    logo={<div className="w-8 h-8"><Logo /></div>}
+    apps={apps}
+    activeAppId="account"
+  />
+);
+
+const agentProps = {
+  agentSidebarContent: (
+    <div className="text-inverse-on-surface text-sm">
+      Chat messages would appear here...
+    </div>
+  ),
+  onAgentSend: (msg: string) => console.log("Send:", msg),
 };
 
+/** The vertical side rail used by the desktop-nav stories. */
+function DemoRail() {
+  const [selected, setSelected] = useState("apps");
+  return (
+    <NavigationRail
+      logo={
+        <NavigationButton
+          customIcon={logoGlyph}
+          label="My App"
+          variant="secondary"
+          disableHoverExpand
+          className="border border-primary"
+        />
+      }
+    >
+      {railGroups.map((group, gi) => (
+        <div key={gi} className="contents">
+          {gi > 0 && <div className="h-px rounded-full w-full bg-outline" />}
+          <div className="w-full gap-2 flex flex-col">
+            {group.map((item) => (
+              <NavigationButton
+                key={item.id}
+                icon={item.icon}
+                label={item.label}
+                selected={selected === item.id}
+                onClick={() => setSelected(item.id)}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </NavigationRail>
+  );
+}
+
+/** The same destinations as DemoRail, as a mobile bottom-nav pill. */
+function DemoBottomNav() {
+  const [selected, setSelected] = useState("apps");
+  return (
+    <NavigationRail orientation="horizontal" containerClassName="gap-0 px-3 py-2">
+      <BottomNavItem
+        customIcon={logoGlyph}
+        label="My App"
+        showTitle={false}
+        onClick={() => setSelected("dashboard")}
+      />
+      {railGroups.flat().map((item) => (
+        <BottomNavItem
+          key={item.id}
+          icon={item.icon}
+          label={item.label}
+          selected={selected === item.id}
+          onClick={() => setSelected(item.id)}
+        />
+      ))}
+    </NavigationRail>
+  );
+}
+
+function DemoNavDrawer() {
+  const [active, setActive] = useState("profile");
+  return (
+    <NavDrawer
+      contextSwitcher={
+        <div className="flex items-center gap-3 p-3 rounded-xl">
+          <Avatar size="md" fallback="J" />
+          <div className="min-w-0 flex-1 space-y-0.5">
+            <p className="text-sm font-medium text-on-surface truncate">John Doe</p>
+            <p className="text-xs text-on-surface-variant">Personal Account</p>
+          </div>
+        </div>
+      }
+      sections={navSections}
+      activeItemId={active}
+      onItemClick={(item: NavDrawerItem) => setActive(item.id)}
+    />
+  );
+}
+
+const DemoContent = () => (
+  <div className="max-w-4xl mx-auto">
+    <h1 className="text-2xl font-bold text-on-surface mb-4">Dashboard</h1>
+    <p className="text-on-surface-variant">
+      Main content area. The agent sidebar can be toggled with the floating button.
+    </p>
+  </div>
+);
+
+// --- Stories -----------------------------------------------------------------
+
+export const WithNavigationRail: Story = {
+  render: () => (
+    <AppShell navigation={<DemoRail />} appSwitcher={appSwitcher} {...agentProps}>
+      <DemoContent />
+    </AppShell>
+  ),
+};
+
+export const WithNavDrawer: Story = {
+  render: () => (
+    <AppShell navigation={<DemoNavDrawer />} appSwitcher={appSwitcher} {...agentProps}>
+      <DemoContent />
+    </AppShell>
+  ),
+};
+
+// Below lg the side rail hides and the pill pins to the content area's bottom
+// edge; at lg+ the rail takes over. Resize the viewport to see the handoff.
+export const WithMobileBottomNav: Story = {
+  parameters: {
+    viewport: { defaultViewport: "mobile2" },
+  },
+  render: () => (
+    <AppShell
+      navigation={<DemoRail />}
+      mobileNavigation={<DemoBottomNav />}
+      appSwitcher={appSwitcher}
+    >
+      <DemoContent />
+    </AppShell>
+  ),
+};
+
+// Below lg the menu button (bottom-left) opens `navigation` as a modal
+// slide-in drawer — no separate mobile tree needed.
 export const WithMobileNavDrawer: Story = {
   parameters: {
     viewport: { defaultViewport: "mobile2" },
   },
-  render: () => {
-    const [active, setActive] = useState("profile");
-    return (
-      <AppShell
-        // Below lg the side nav hides and the menu button (bottom-left)
-        // opens the same NavDrawer as a modal slide-in. Resize the viewport
-        // under 1024px to see it.
-        mobileNavigationVariant="drawer"
-        navigation={
-          <NavDrawer
-            sections={navSections}
-            activeItemId={active}
-            onItemClick={(item: NavDrawerItem) => setActive(item.id)}
-          />
-        }
-        appSwitcher={
-          <AppSwitcher
-            currentApp="Account"
-            logo={<div className="w-8 h-8"><Logo /></div>}
-            apps={apps}
-            activeAppId="account"
-          />
-        }
-      >
-        <DemoContent />
-      </AppShell>
-    );
-  },
+  render: () => (
+    <AppShell
+      mobileNavigationVariant="drawer"
+      navigation={<DemoNavDrawer />}
+      appSwitcher={appSwitcher}
+    >
+      <DemoContent />
+    </AppShell>
+  ),
 };
 
 function SnackbarDemoContent() {
@@ -218,7 +231,9 @@ function SnackbarDemoContent() {
     <div className="max-w-4xl mx-auto">
       <h1 className="text-2xl font-bold text-on-surface mb-4">Dashboard</h1>
       <p className="text-on-surface-variant mb-6">
-        The snackbar outlet centers over the content area, not the full viewport. Click the button to see it.
+        The snackbar outlet centers over the content area, not the full viewport.
+        Click the button to see it — at mobile widths the bottom nav steps aside
+        while the snackbar is up.
       </p>
       <div className="flex gap-3">
         <Button
@@ -246,56 +261,15 @@ function SnackbarDemoContent() {
 }
 
 export const WithSnackbar: Story = {
-  render: () => {
-    const [selected, setSelected] = useState("apps");
-    return (
-      <AppShell
-        navigation={
-          <NavigationRail
-            logo={
-              <NavigationButton
-                customIcon={
-                  <div className="w-full h-full bg-primary/20 flex items-center justify-center">
-                    <span className="text-primary font-semibold text-lg">M</span>
-                  </div>
-                }
-                label="My App"
-                variant="secondary"
-                disableHoverExpand
-                className="border border-primary"
-              />
-            }
-          >
-            <div className="w-full gap-2 flex flex-col">
-              <NavigationButton
-                icon="space_dashboard"
-                label="Dashboard"
-                variant="primary"
-                selected={selected === "dashboard"}
-                onClick={() => setSelected("dashboard")}
-              />
-              <NavigationButton
-                icon="data_table"
-                label="Your Apps"
-                selected={selected === "apps"}
-                onClick={() => setSelected("apps")}
-              />
-            </div>
-          </NavigationRail>
-        }
-        appSwitcher={
-          <AppSwitcher
-            currentApp="Account"
-            logo={<div className="w-8 h-8"><Logo /></div>}
-            apps={apps}
-            activeAppId="account"
-          />
-        }
-      >
-        <SnackbarDemoContent />
-      </AppShell>
-    );
-  },
+  render: () => (
+    <AppShell
+      navigation={<DemoRail />}
+      mobileNavigation={<DemoBottomNav />}
+      appSwitcher={appSwitcher}
+    >
+      <SnackbarDemoContent />
+    </AppShell>
+  ),
 };
 
 function SnackbarScrollableDemoContent() {
@@ -343,114 +317,17 @@ export const SnackbarWithScrollableContent: Story = {
       },
     },
   },
-  render: () => {
-    const [selected, setSelected] = useState("apps");
-    return (
-      <AppShell
-        navigation={
-          <NavigationRail
-            logo={
-              <NavigationButton
-                customIcon={
-                  <div className="w-full h-full bg-primary/20 flex items-center justify-center">
-                    <span className="text-primary font-semibold text-lg">M</span>
-                  </div>
-                }
-                label="My App"
-                variant="secondary"
-                disableHoverExpand
-                className="border border-primary"
-              />
-            }
-          >
-            <div className="w-full gap-2 flex flex-col">
-              <NavigationButton
-                icon="space_dashboard"
-                label="Dashboard"
-                variant="primary"
-                selected={selected === "dashboard"}
-                onClick={() => setSelected("dashboard")}
-              />
-              <NavigationButton
-                icon="data_table"
-                label="Your Apps"
-                selected={selected === "apps"}
-                onClick={() => setSelected("apps")}
-              />
-            </div>
-          </NavigationRail>
-        }
-        appSwitcher={
-          <AppSwitcher
-            currentApp="Account"
-            logo={<div className="w-8 h-8"><Logo /></div>}
-            apps={apps}
-            activeAppId="account"
-          />
-        }
-      >
-        <SnackbarScrollableDemoContent />
-      </AppShell>
-    );
-  },
+  render: () => (
+    <AppShell navigation={<DemoRail />} appSwitcher={appSwitcher}>
+      <SnackbarScrollableDemoContent />
+    </AppShell>
+  ),
 };
 
 export const Playground: Story = {
-  render: () => {
-    const [selected, setSelected] = useState("apps");
-    return (
-      <AppShell
-        navigation={
-          <NavigationRail
-            logo={
-              <NavigationButton
-                customIcon={
-                  <div className="w-full h-full bg-primary/20 flex items-center justify-center">
-                    <span className="text-primary font-semibold text-lg">M</span>
-                  </div>
-                }
-                label="My App"
-                variant="secondary"
-                disableHoverExpand
-                className="border border-primary"
-              />
-            }
-          >
-            <div className="w-full gap-2 flex flex-col">
-              <NavigationButton
-                icon="space_dashboard"
-                label="Dashboard"
-                variant="primary"
-                selected={selected === "dashboard"}
-                onClick={() => setSelected("dashboard")}
-              />
-              <NavigationButton
-                icon="data_table"
-                label="Your Apps"
-                selected={selected === "apps"}
-                onClick={() => setSelected("apps")}
-              />
-            </div>
-            <div className="h-px rounded-full w-full bg-outline" />
-            <div className="w-full gap-2 flex flex-col">
-              <NavigationButton
-                icon="settings"
-                label="Settings"
-                selected={selected === "settings"}
-                onClick={() => setSelected("settings")}
-              />
-            </div>
-          </NavigationRail>
-        }
-        agentSidebarContent={
-          <div className="text-inverse-on-surface text-sm">
-            Chat messages would appear here...
-          </div>
-        }
-        onAgentSend={(msg) => console.log("Send:", msg)}
-      >
-        <DemoContent />
-      </AppShell>
-    );
-  },
+  render: () => (
+    <AppShell navigation={<DemoRail />} {...agentProps}>
+      <DemoContent />
+    </AppShell>
+  ),
 };

--- a/src/components/layout/app-shell/AppShell.test.tsx
+++ b/src/components/layout/app-shell/AppShell.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, afterEach } from "vitest";
+import { AppShell } from "./AppShell";
+
+afterEach(cleanup);
+
+describe("AppShell mobile navigation", () => {
+  it("hosts mobileNavigation as a pinned bar by default", () => {
+    render(
+      <AppShell mobileNavigation={<span>Bottom bar</span>}>content</AppShell>,
+    );
+    expect(screen.getByText("Bottom bar")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Open navigation")).not.toBeInTheDocument();
+  });
+
+  it("drawer variant renders a menu trigger and opens the drawer on click", () => {
+    render(
+      <AppShell
+        mobileNavigationVariant="drawer"
+        navigation={<span>Drawer nav</span>}
+      >
+        content
+      </AppShell>,
+    );
+    // Side nav markup exists (hidden via CSS below lg); the drawer is closed.
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Open navigation"));
+    const dialog = screen.getByRole("dialog", { name: "Navigation" });
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveTextContent("Drawer nav");
+  });
+
+  it("drawer prefers mobileNavigation content over navigation", () => {
+    render(
+      <AppShell
+        mobileNavigationVariant="drawer"
+        navigation={<span>Desktop nav</span>}
+        mobileNavigation={<span>Mobile nav</span>}
+      >
+        content
+      </AppShell>,
+    );
+    fireEvent.click(screen.getByLabelText("Open navigation"));
+    expect(screen.getByRole("dialog")).toHaveTextContent("Mobile nav");
+    expect(screen.getByRole("dialog")).not.toHaveTextContent("Desktop nav");
+  });
+
+  it("closes the drawer when a nav control inside is activated", () => {
+    render(
+      <AppShell
+        mobileNavigationVariant="drawer"
+        navigation={<button type="button">Profile</button>}
+      >
+        content
+      </AppShell>,
+    );
+    fireEvent.click(screen.getByLabelText("Open navigation"));
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(within(dialog).getByRole("button", { name: "Profile" }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("closes the drawer on Escape", () => {
+    render(
+      <AppShell mobileNavigationVariant="drawer" navigation={<span>Nav</span>}>
+        content
+      </AppShell>,
+    );
+    fireEvent.click(screen.getByLabelText("Open navigation"));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/layout/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/AppShell.tsx
@@ -3,7 +3,11 @@ import { cn } from "@/utils/cn";
 import type { ComponentMeta } from "@/types/component-meta";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 import { SidebarProvider, useSidebarWidth } from "@/context/sidebar/SidebarProvider";
-import { SnackbarProvider, SnackbarOutlet } from "@/context/snackbar/SnackbarProvider";
+import {
+  SnackbarProvider,
+  SnackbarOutlet,
+  useSnackbarVisible,
+} from "@/context/snackbar/SnackbarProvider";
 import { AgentSidebarHeader } from "@/components/ui/agent/sidebar/AgentSidebarHeader";
 import { AgentSidebarInput } from "@/components/ui/agent/sidebar/AgentSidebarInput";
 import type { AgentSidebarHistoryGroup } from "@/components/ui/agent/sidebar/types";
@@ -19,8 +23,13 @@ const PADDING = 20;
 
 export interface AppShellProps {
   children: ReactNode;
-  /** Navigation slot — inject a NavigationRail, NavDrawer, or custom nav */
+  /** Navigation slot — inject a NavigationRail, NavDrawer, or custom nav.
+   *  Shown on the side at lg+, hidden below it (use bottomNavigation for mobile). */
   navigation?: ReactNode;
+  /** Mobile navigation slot — pinned to the bottom of the content area below lg
+   *  and hidden at lg+ (where `navigation` takes over). Inject a horizontal
+   *  NavigationRail to mirror the side rail as a bottom-nav pill. */
+  bottomNavigation?: ReactNode;
   /** App switcher slot — positioned top-left after nav area */
   appSwitcher?: ReactNode;
   /** Class for the outer shell */
@@ -57,9 +66,42 @@ export function AppShell(props: AppShellProps) {
   );
 }
 
+/** Pins the mobile bottom nav to the content area's bottom edge. Isolated so
+ *  snackbar churn re-renders just this slot, not the whole shell. */
+function BottomNavRegion({ children }: { children: ReactNode }) {
+  const snackbarVisible = useSnackbarVisible();
+  return (
+    // `!important` on the responsive display/width: a mounted module bundle
+    // injects its own global Tailwind CSS (plain `.flex` / `.w-full`) after
+    // the host stylesheet, which would otherwise override our media-query
+    // utilities (`lg:hidden`, `sm:w-auto`) and leak the bottom nav onto
+    // desktop / force it full-width.
+    <div
+      className={cn(
+        "absolute inset-x-0 bottom-2 z-20 flex justify-center px-2 lg:!hidden pointer-events-none",
+        // Step aside while a snackbar is up — both pin to the same bottom
+        // edge, and the snackbar is the transient, actionable one. Slides
+        // back as soon as the snackbar starts exiting. `invisible` also
+        // drops it from tab order / a11y tree while hidden (visibility
+        // flips after the exit transition ends).
+        "transition-all duration-300",
+        snackbarVisible && "invisible translate-y-[150%] opacity-0",
+      )}
+    >
+      {/* Full-width pill only on tight phone widths (<640px); content-width
+          and centered from sm up. pointer-events re-enable only while shown —
+          the wrapper's `none` is the inherited default. */}
+      <div className={cn("w-full sm:!w-auto max-w-full", !snackbarVisible && "pointer-events-auto")}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
 function AppShellInner({
   children,
   navigation,
+  bottomNavigation,
   appSwitcher,
   className,
   appSwitcherClassName = "max-w-7xl",
@@ -156,8 +198,8 @@ function AppShellInner({
       <div className="flex-1 min-w-0 h-dvh overflow-hidden">
         <div className={cn("mx-auto w-full h-full relative", className)}>
           {appSwitcher && (
-            <div className="hidden lg:block absolute top-2 left-0 right-0 z-20 pointer-events-none">
-              <div className={cn("mx-auto w-full px-4", appSwitcherClassName)}>
+            <div className="absolute top-2 left-0 right-0 z-20 pointer-events-none">
+              <div className={cn("mx-auto w-full px-1 lg:px-2 xl:px-4", appSwitcherClassName)}>
                 <div className="pointer-events-auto w-fit">
                   {appSwitcher}
                 </div>
@@ -176,7 +218,13 @@ function AppShellInner({
               <main className="relative flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
                 <div
                   className={cn(
-                    "mx-auto w-full px-6 pt-12 pb-16",
+                    // Responsive gutters — tighter on phones / laptops, full on
+                    // wide desktops. Pages must NOT add their own horizontal
+                    // padding (it would double up); they own max-width only.
+                    "mx-auto w-full px-4 md:px-5 xl:px-6 pt-12",
+                    // Clear the pinned mobile bottom nav so content isn't hidden
+                    // behind it. No-op at lg+ and when no bottomNavigation is set.
+                    bottomNavigation ? "pb-28 lg:pb-16" : "pb-16",
                     contentClassName,
                   )}
                 >
@@ -184,6 +232,8 @@ function AppShellInner({
                 </div>
               </main>
               <SnackbarOutlet className={snackbarClassName} />
+
+              {bottomNavigation && <BottomNavRegion>{bottomNavigation}</BottomNavRegion>}
             </div>
           </div>
         </div>

--- a/src/components/layout/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/AppShell.tsx
@@ -24,12 +24,19 @@ const PADDING = 20;
 export interface AppShellProps {
   children: ReactNode;
   /** Navigation slot — inject a NavigationRail, NavDrawer, or custom nav.
-   *  Shown on the side at lg+, hidden below it (use bottomNavigation for mobile). */
+   *  Shown on the side at lg+, hidden below it (use mobileNavigation for mobile). */
   navigation?: ReactNode;
-  /** Mobile navigation slot — pinned to the bottom of the content area below lg
-   *  and hidden at lg+ (where `navigation` takes over). Inject a horizontal
-   *  NavigationRail to mirror the side rail as a bottom-nav pill. */
-  bottomNavigation?: ReactNode;
+  /** Mobile navigation slot — how `navigation` translates below lg (it's
+   *  hidden there). With the "bottom" variant, inject a horizontal
+   *  NavigationRail to mirror the side rail as a bottom-nav pill. With
+   *  "drawer", this is the drawer's content — omit it to reuse `navigation`. */
+  mobileNavigation?: ReactNode;
+  /** How mobile navigation is hosted below lg:
+   *  - `"bottom"` (default) — mobileNavigation pinned to the content area's
+   *    bottom edge as a bar.
+   *  - `"drawer"` — a menu button opens mobileNavigation (or `navigation`
+   *    when not set) as a modal slide-in drawer. */
+  mobileNavigationVariant?: "bottom" | "drawer";
   /** App switcher slot — positioned top-left after nav area */
   appSwitcher?: ReactNode;
   /** Class for the outer shell */
@@ -63,6 +70,61 @@ export function AppShell(props: AppShellProps) {
         <AppShellInner {...props} />
       </SnackbarProvider>
     </SidebarProvider>
+  );
+}
+
+/** Hosts mobile navigation as a modal drawer below lg: a floating menu button
+ *  opens the content in a slide-in panel over a scrim. Closes on scrim tap,
+ *  Escape, or any link/button activation inside (a nav selection). */
+function MobileNavDrawerRegion({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    panelRef.current?.focus();
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+
+  return (
+    <div className="lg:!hidden">
+      <IconButton
+        icon="menu"
+        variant="tonal"
+        size="md"
+        className="absolute bottom-2 left-2 z-20"
+        onClick={() => setOpen(true)}
+        aria-label="Open navigation"
+        aria-expanded={open}
+      />
+
+      {open && (
+        <div className="fixed inset-0 z-40">
+          <div className="absolute inset-0 bg-black/20" onClick={() => setOpen(false)} />
+          <div
+            ref={panelRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Navigation"
+            tabIndex={-1}
+            // `starting:` holds the panel off-canvas on mount so transition-all
+            // slides it in — same pattern as the agent sidebar's starting:!w-0.
+            className="absolute inset-y-0 left-0 w-fit max-w-[85vw] overflow-y-auto overscroll-contain bg-background shadow-2xl outline-none transition-transform duration-300 starting:-translate-x-full"
+            // A tap that activates a link or button inside is a navigation
+            // selection — dismiss the drawer with it (M3 modal drawer behavior).
+            onClickCapture={(e) => {
+              if ((e.target as HTMLElement).closest("a, button")) setOpen(false);
+            }}
+          >
+            {children}
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -101,7 +163,8 @@ function BottomNavRegion({ children }: { children: ReactNode }) {
 function AppShellInner({
   children,
   navigation,
-  bottomNavigation,
+  mobileNavigation,
+  mobileNavigationVariant = "bottom",
   appSwitcher,
   className,
   appSwitcherClassName = "max-w-7xl",
@@ -218,13 +281,16 @@ function AppShellInner({
               <main className="relative flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
                 <div
                   className={cn(
-                    // Responsive gutters — tighter on phones / laptops, full on
-                    // wide desktops. Pages must NOT add their own horizontal
+                    // Responsive gutters — tight on phones, roomier as the
+                    // viewport grows. Pages must NOT add their own horizontal
                     // padding (it would double up); they own max-width only.
-                    "mx-auto w-full px-4 md:px-5 xl:px-6 pt-12",
+                    "mx-auto w-full px-4 md:px-8 xl:px-12 pt-12",
                     // Clear the pinned mobile bottom nav so content isn't hidden
-                    // behind it. No-op at lg+ and when no bottomNavigation is set.
-                    bottomNavigation ? "pb-28 lg:pb-16" : "pb-16",
+                    // behind it. No-op at lg+, with no mobile navigation, and
+                    // for the drawer variant (an overlay, not a pinned bar).
+                    mobileNavigation && mobileNavigationVariant === "bottom"
+                      ? "pb-28 lg:pb-16"
+                      : "pb-16",
                     contentClassName,
                   )}
                 >
@@ -233,7 +299,15 @@ function AppShellInner({
               </main>
               <SnackbarOutlet className={snackbarClassName} />
 
-              {bottomNavigation && <BottomNavRegion>{bottomNavigation}</BottomNavRegion>}
+              {mobileNavigationVariant === "drawer"
+                ? (mobileNavigation ?? navigation) && (
+                    <MobileNavDrawerRegion>
+                      {mobileNavigation ?? navigation}
+                    </MobileNavDrawerRegion>
+                  )
+                : mobileNavigation && (
+                    <BottomNavRegion>{mobileNavigation}</BottomNavRegion>
+                  )}
             </div>
           </div>
         </div>

--- a/src/components/ui/navigation/bottom-nav-item/BottomNavItem.stories.tsx
+++ b/src/components/ui/navigation/bottom-nav-item/BottomNavItem.stories.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { BottomNavItem } from "./BottomNavItem";
+import { NavigationRail } from "@/components/ui/navigation/navigation-rail/NavigationRail";
+
+const meta: Meta<typeof BottomNavItem> = {
+  title: "UI/Navigation/BottomNavItem",
+  component: BottomNavItem,
+};
+
+export default meta;
+type Story = StoryObj<typeof BottomNavItem>;
+
+export const Playground: Story = {
+  args: {
+    icon: "dashboard",
+    label: "Overview",
+    selected: true,
+  },
+};
+
+export const BottomNavPill: Story = {
+  decorators: [
+    (Story) => (
+      <div className="h-40 w-[420px] flex items-end justify-center">
+        <Story />
+      </div>
+    ),
+  ],
+  render: () => {
+    const [selected, setSelected] = useState("overview");
+    const items = [
+      { id: "overview", icon: "dashboard", label: "Overview" },
+      { id: "users", icon: "group", label: "Users" },
+      { id: "billing", icon: "payments", label: "Billing" },
+      { id: "settings", icon: "settings", label: "Settings" },
+    ];
+    return (
+      <NavigationRail orientation="horizontal" containerClassName="gap-0 px-3 py-2">
+        <BottomNavItem
+          customIcon={
+            <div className="w-full h-full bg-primary/20 flex items-center justify-center">
+              <span className="text-primary font-semibold text-lg">M</span>
+            </div>
+          }
+          label="My App"
+          showTitle={false}
+          onClick={() => setSelected("overview")}
+        />
+        {items.map((item) => (
+          <BottomNavItem
+            key={item.id}
+            icon={item.icon}
+            label={item.label}
+            selected={selected === item.id}
+            onClick={() => setSelected(item.id)}
+          />
+        ))}
+      </NavigationRail>
+    );
+  },
+};
+
+export const CircleCustomIcon: Story = {
+  args: {
+    customIcon: (
+      <div className="w-full h-full bg-tertiary/30 flex items-center justify-center">
+        <span className="text-on-surface font-semibold">U</span>
+      </div>
+    ),
+    iconShape: "circle",
+    label: "Account",
+    selected: true,
+    showTitle: false,
+  },
+};

--- a/src/components/ui/navigation/bottom-nav-item/BottomNavItem.test.tsx
+++ b/src/components/ui/navigation/bottom-nav-item/BottomNavItem.test.tsx
@@ -1,0 +1,44 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { describe, expect, it, afterEach } from "vitest";
+import { BottomNavItem } from "./BottomNavItem";
+
+afterEach(cleanup);
+
+describe("BottomNavItem", () => {
+  it("shows the label only while selected", () => {
+    const { rerender } = render(<BottomNavItem icon="dashboard" label="Overview" />);
+    expect(screen.queryByText("Overview")).not.toBeInTheDocument();
+
+    rerender(<BottomNavItem icon="dashboard" label="Overview" selected />);
+    expect(screen.getByText("Overview")).toBeInTheDocument();
+  });
+
+  it("never shows the label when showTitle is false", () => {
+    render(<BottomNavItem icon="more_horiz" label="More" selected showTitle={false} />);
+    expect(screen.queryByText("More")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "More" })).toBeInTheDocument();
+  });
+
+  it("marks the selected item as the current page", () => {
+    render(<BottomNavItem icon="dashboard" label="Overview" selected />);
+    expect(screen.getByRole("button", { name: "Overview" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  it("renders customIcon in a bordered frame while selected", () => {
+    const { container } = render(
+      <BottomNavItem customIcon={<span>App</span>} label="My App" selected showTitle={false} />,
+    );
+    expect(screen.getByText("App")).toBeInTheDocument();
+    expect(container.querySelector(".border-primary")).toBeInTheDocument();
+  });
+
+  it("uses a circular frame for iconShape circle", () => {
+    const { container } = render(
+      <BottomNavItem customIcon={<span>U</span>} iconShape="circle" label="Account" />,
+    );
+    expect(container.querySelector(".rounded-full")).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/navigation/bottom-nav-item/BottomNavItem.tsx
+++ b/src/components/ui/navigation/bottom-nav-item/BottomNavItem.tsx
@@ -1,0 +1,90 @@
+import type { ReactNode } from "react";
+import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
+import type { ComponentMeta } from "@/types/component-meta";
+import { Icon } from "@/components/ui/media/icon/Icon";
+
+export const meta: ComponentMeta = {
+  name: "BottomNavItem",
+  description:
+    "Bottom-navigation destination: an icon with a stadium active-indicator, stacked over a label shown only while selected. Compose inside a horizontal NavigationRail.",
+};
+
+export interface BottomNavItemProps {
+  /** Material symbol name for the glyph variant. */
+  icon?: string;
+  /** Custom 1:1 icon (app logo, avatar) rendered in a framed box instead of a
+   *  glyph. The frame gets a primary border while selected. */
+  customIcon?: ReactNode;
+  /** Frame shape for customIcon — "square" for an app icon, "circle" for an
+   *  avatar. Default `"square"`. */
+  iconShape?: "square" | "circle";
+  /** Accessible name; rendered under the icon while selected (see showTitle). */
+  label: string;
+  selected?: boolean;
+  /** Whether the label may appear (only ever shown when also selected). Pass
+   *  false for icon-only entries like a branding shortcut or a menu trigger. */
+  showTitle?: boolean;
+  onClick?: () => void;
+}
+
+export function BottomNavItem({
+  icon,
+  customIcon,
+  iconShape = "square",
+  label,
+  selected = false,
+  showTitle = true,
+  onClick,
+}: BottomNavItemProps) {
+  if (isDev && !icon && !customIcon) {
+    console.warn("[BottomNavItem] pass either icon or customIcon.");
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      aria-current={selected ? "page" : undefined}
+      // Fixed height so items don't grow/shrink (and the pill doesn't jump)
+      // when a label appears. Width is a floor (min-w-16) that grows only for
+      // the selected item's title — pack items with no gap so the expanding
+      // label borrows the freed space instead of truncating early.
+      className="flex h-14 min-w-16 shrink-0 flex-col items-center justify-center gap-1 rounded-xl px-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+    >
+      {customIcon ? (
+        <span
+          className={cn(
+            // 1:1 frame (slightly larger than the glyph indicators).
+            "flex h-10 w-10 items-center justify-center overflow-hidden",
+            iconShape === "circle" ? "rounded-full" : "rounded-xl",
+            selected && "border border-primary",
+          )}
+        >
+          {customIcon}
+        </span>
+      ) : (
+        <span
+          className={cn(
+            "flex h-8 w-12 items-center justify-center rounded-full transition-colors",
+            selected && "bg-primary-container",
+          )}
+        >
+          <Icon
+            name={icon ?? ""}
+            size={22}
+            className={cn(
+              "shrink-0",
+              selected ? "text-on-primary-container" : "text-on-surface",
+            )}
+          />
+        </span>
+      )}
+      {showTitle && selected && (
+        <span className="max-w-20 truncate text-center text-[10px] font-medium leading-none text-on-surface">
+          {label}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
@@ -15,8 +15,14 @@ import { Notch } from "@/components/ui/surfaces/notch/Notch";
 
 const DD_NOTCH_W = 52;
 const DD_NOTCH_H = 46;
-const DD_R = 12;
+const DD_R = 16;
 const DD_IR = 10;
+
+// Item density tokens per `size` — "lg" pads up to comfortable touch targets.
+const SIZES = {
+  md: { item: "gap-2 px-2 py-1.5", icon: 16, minW: "min-w-[180px]", sep: "mx-1.5" },
+  lg: { item: "gap-2.5 px-3 py-2.5", icon: 18, minW: "min-w-[200px]", sep: "mx-2" },
+} as const;
 
 export const meta: ComponentMeta = {
   name: "DropdownMenu",
@@ -52,6 +58,18 @@ export interface DropdownMenuProps {
   /** Render the kit's signature notch wrapping the trigger. Default `true`. Set
    *  to `false` for a plain floating menu (e.g. selects, period pickers). */
   useNotch?: boolean;
+  /** Which side of the trigger the menu opens toward. `"top"` opens upward —
+   *  use it for triggers anchored to the bottom of the viewport (e.g. a mobile
+   *  bottom nav), where a downward menu would fall off-screen. Default `"bottom"`. */
+  placement?: "top" | "bottom";
+  /** Item density. `"lg"` enlarges padding, text, and icons to comfortable
+   *  touch targets — use it for menus opened on touch surfaces (e.g. a mobile
+   *  bottom nav). `"md"` is the default desktop density. */
+  size?: "md" | "lg";
+  /** Class applied to the floating menu element (the notched card) — use it to
+   *  fine-tune the menu's position relative to the trigger, e.g. a translate
+   *  to nudge the whole notched card off the auto-aligned anchor. */
+  menuClassName?: string;
   className?: string;
 }
 
@@ -71,9 +89,14 @@ export function DropdownMenu({
   notchWidth = DD_NOTCH_W,
   notchHeight = DD_NOTCH_H,
   useNotch = true,
+  placement = "bottom",
+  size = "md",
+  menuClassName,
   className,
 }: DropdownMenuProps) {
   const fromEnd = offset < 0 || Object.is(offset, -0);
+  const openUp = placement === "top";
+  const sz = SIZES[size];
   const [open, setOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -218,12 +241,13 @@ export function DropdownMenu({
           role="menu"
           tabIndex={-1}
           onKeyDown={handleKeyDown}
-          className="absolute z-50 overflow-visible outline-none"
+          className={cn("absolute z-50 overflow-visible outline-none", menuClassName)}
           style={{
-            top: useNotch ? -7 : "calc(100% + 8px)",
             // Notch mode adds extra -5/-7 to compensate for the curve
             // overlapping the trigger; no-notch mode anchors flush to
-            // the trigger edge.
+            // the trigger edge. `openUp` anchors to the trigger's bottom
+            // so the menu grows upward instead of down.
+            [openUp ? "bottom" : "top"]: useNotch ? -7 : "calc(100% + 8px)",
             [fromEnd ? "right" : "left"]: useNotch
               ? (fromEnd ? -5 : -7) - Math.abs(offset)
               : -Math.abs(offset),
@@ -236,23 +260,24 @@ export function DropdownMenu({
               height={contentH}
               notchWidth={notchWidth}
               notchHeight={notchHeight}
-              notchSide="bottom"
+              notchSide={openUp ? "top" : "bottom"}
               notchOffset={offset}
               radius={DD_R}
               inverseRadius={DD_IR}
               stroke="var(--color-primary)"
               strokeWidth={1.5}
-              className="absolute top-0 left-0"
+              className={cn("absolute left-0", openUp ? "bottom-0" : "top-0")}
             />
           )}
           <div
             ref={contentRef}
             className={cn(
-              "relative z-10 flex flex-col gap-1 min-w-[180px] p-2",
+              "relative z-10 flex flex-col gap-1 p-2",
+              sz.minW,
               !useNotch &&
                 "rounded-lg border border-outline-variant bg-surface-container-low",
             )}
-            style={{ marginTop: useNotch ? notchHeight : 0 }}
+            style={{ [openUp ? "marginBottom" : "marginTop"]: useNotch ? notchHeight : 0 }}
           >
             {items.map((entry, index) => {
               if (isSeparator(entry)) {
@@ -260,7 +285,7 @@ export function DropdownMenu({
                   <div
                     key={`sep-${index}`}
                     role="separator"
-                    className="my-1 h-px bg-outline-variant mx-1.5"
+                    className={cn("my-1 h-px bg-outline-variant", sz.sep)}
                   />
                 );
               }
@@ -281,7 +306,8 @@ export function DropdownMenu({
                   role="menuitem"
                   aria-disabled={item.disabled || undefined}
                   className={cn(
-                    "flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors",
+                    "flex cursor-pointer items-center rounded-lg text-left text-sm transition-colors",
+                    sz.item,
                     item.disabled && "pointer-events-none opacity-50",
                     isError ? "text-error" : "text-on-surface",
                     isActive &&
@@ -301,7 +327,7 @@ export function DropdownMenu({
                   {item.icon && (
                     <Icon
                       name={item.icon}
-                      size={16}
+                      size={sz.icon}
                       className={cn(
                         "shrink-0",
                         isError ? "text-error" : "text-on-surface-variant",

--- a/src/components/ui/navigation/navigation-rail/NavigationRail.stories.tsx
+++ b/src/components/ui/navigation/navigation-rail/NavigationRail.stories.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { NavigationRail } from "./NavigationRail";
 import { NavigationButton } from "@/components/ui/navigation/navigation-button/NavigationButton";
+import { BottomNavItem } from "@/components/ui/navigation/bottom-nav-item/BottomNavItem";
 
 const meta: Meta<typeof NavigationRail> = {
   title: "UI/Navigation/NavigationRail",
@@ -17,6 +18,48 @@ const meta: Meta<typeof NavigationRail> = {
 
 export default meta;
 type Story = StoryObj<typeof NavigationRail>;
+
+export const Horizontal: Story = {
+  decorators: [
+    (Story) => (
+      <div className="h-[600px] w-[500px] flex items-end justify-center">
+        <Story />
+      </div>
+    ),
+  ],
+  render: () => {
+    const [selected, setSelected] = useState("apps");
+    const items = [
+      { id: "dashboard", icon: "space_dashboard", label: "Dashboard" },
+      { id: "apps", icon: "apps", label: "Your Apps" },
+      { id: "addons", icon: "extension", label: "Add-ons" },
+      { id: "settings", icon: "settings", label: "Settings" },
+    ];
+    return (
+      <NavigationRail orientation="horizontal" containerClassName="gap-0 px-3 py-2">
+        <BottomNavItem
+          customIcon={
+            <div className="w-full h-full bg-primary/20 flex items-center justify-center">
+              <span className="text-primary font-semibold text-lg">M</span>
+            </div>
+          }
+          label="My App"
+          showTitle={false}
+          onClick={() => setSelected("dashboard")}
+        />
+        {items.map((item) => (
+          <BottomNavItem
+            key={item.id}
+            icon={item.icon}
+            label={item.label}
+            selected={selected === item.id}
+            onClick={() => setSelected(item.id)}
+          />
+        ))}
+      </NavigationRail>
+    );
+  },
+};
 
 export const Playground: Story = {
   render: () => {

--- a/src/components/ui/navigation/navigation-rail/NavigationRail.test.tsx
+++ b/src/components/ui/navigation/navigation-rail/NavigationRail.test.tsx
@@ -40,4 +40,22 @@ describe("NavigationRail", () => {
     );
     expect(screen.getByText("Footer")).toBeInTheDocument();
   });
+
+  it("lays out as a column by default", () => {
+    const { container } = render(
+      <NavigationRail logo={<span>Logo</span>}><span>Nav</span></NavigationRail>,
+    );
+    expect(container.querySelector(".flex-col")).toBeInTheDocument();
+    expect(container.querySelector(".bg-outline")).toHaveClass("w-full");
+  });
+
+  it("lays out as a row with a vertical divider when horizontal", () => {
+    const { container } = render(
+      <NavigationRail orientation="horizontal" logo={<span>Logo</span>}>
+        <span>Nav</span>
+      </NavigationRail>,
+    );
+    expect(container.querySelector(".flex-row")).toBeInTheDocument();
+    expect(container.querySelector(".bg-outline")).toHaveClass("w-px");
+  });
 });

--- a/src/components/ui/navigation/navigation-rail/NavigationRail.tsx
+++ b/src/components/ui/navigation/navigation-rail/NavigationRail.tsx
@@ -5,14 +5,18 @@ import type { ComponentMeta } from "@/types/component-meta";
 export const meta: ComponentMeta = {
   name: "NavigationRail",
   description:
-    "Vertical icon-based navigation rail with logo, header, main content, and footer slots",
+    'Icon-based navigation rail with logo, header, main content, and footer slots. Vertical by default; pass orientation="horizontal" for a bottom-nav pill.',
 };
+
+export type NavigationRailOrientation = "vertical" | "horizontal";
 
 export interface NavigationRailProps {
   logo?: ReactNode;
   header?: ReactNode;
   children: ReactNode;
   footer?: ReactNode;
+  /** Layout axis. "horizontal" lays the rail out as a row — used for the mobile bottom nav. */
+  orientation?: NavigationRailOrientation;
   className?: string;
   containerClassName?: string;
 }
@@ -22,21 +26,31 @@ export function NavigationRail({
   header,
   children,
   footer,
+  orientation = "vertical",
   className,
   containerClassName,
 }: NavigationRailProps) {
+  const horizontal = orientation === "horizontal";
   return (
-    <div className={cn("pl-2 py-4 overflow-visible", className)}>
+    <div
+      className={cn("overflow-visible", horizontal ? "px-2 pb-2" : "pl-2 py-4", className)}
+    >
       <div
         className={cn(
-          "ml-2 px-4 py-6 gap-6 flex flex-col items-center rounded-2xl shadow-2xl bg-surface-bright overflow-visible",
+          "gap-6 flex items-center rounded-2xl shadow-2xl bg-surface-bright overflow-visible",
+          horizontal ? "flex-row px-6 py-4" : "ml-2 flex-col px-4 py-6",
           containerClassName,
         )}
       >
         {logo}
         {header}
         {(logo || header) && (
-          <div className="h-px rounded-full w-full bg-outline" />
+          <div
+            className={cn(
+              "rounded-full bg-outline",
+              horizontal ? "w-px self-stretch" : "h-px w-full",
+            )}
+          />
         )}
         {children}
         {footer && (

--- a/src/components/ui/surfaces/notch/Notch.test.tsx
+++ b/src/components/ui/surfaces/notch/Notch.test.tsx
@@ -61,4 +61,37 @@ describe("Notch", () => {
     const path = container.querySelector("path");
     expect(path).toHaveAttribute("fill", "none");
   });
+
+  // notchOffset semantics: positive = from left, on the top AND bottom edges.
+  // The top edge renders via rotate(90), which mirrors the build axis — these
+  // pin the internal flip that compensates, so a given offset lands the tab at
+  // the same visual spot whichever edge it's on.
+  describe("notchOffset edge semantics", () => {
+    const pathD = (notchSide: "top" | "bottom", notchOffset: number) => {
+      const { container } = render(
+        <Notch
+          width={200}
+          height={150}
+          notchWidth={52}
+          notchHeight={46}
+          notchSide={notchSide}
+          notchOffset={notchOffset}
+        />,
+      );
+      const d = container.querySelector("path")?.getAttribute("d");
+      cleanup();
+      return d;
+    };
+
+    it("mirrors the build-space offset on the top edge", () => {
+      // Same visual spot (30px from the left) requires mirrored build paths:
+      // top(30) must match bottom's tab placed 30px from the RIGHT (-30).
+      expect(pathD("top", 30)).toBe(pathD("bottom", -30));
+      expect(pathD("top", -30)).toBe(pathD("bottom", 30));
+    });
+
+    it("keeps top and bottom build paths distinct for an uncentered offset", () => {
+      expect(pathD("top", 30)).not.toBe(pathD("bottom", 30));
+    });
+  });
 });

--- a/src/components/ui/surfaces/notch/Notch.tsx
+++ b/src/components/ui/surfaces/notch/Notch.tsx
@@ -111,8 +111,13 @@ function buildHeadPath(nw: number, nh: number, r: number, ir: number, atStart: b
 
 // --- Shared helpers ---
 
-function resolveOffset(offset: number, edge: number, notch: number) {
-  return offset >= 0 ? offset : edge - notch + offset;
+function resolveOffset(offset: number, edge: number, notch: number, side: NotchSide) {
+  const resolved = offset >= 0 ? offset : edge - notch + offset;
+  // Paths are built notch-on-right and rotated into place. The top edge's
+  // rotate(90) mirrors the build axis (build-y runs right-to-left after the
+  // turn), so flip the resolved offset to keep the documented semantics —
+  // positive = from left — true on every side.
+  return side === "top" ? edge - notch - resolved : resolved;
 }
 
 function resolveEdgeParams(side: NotchSide, width: number, height: number, nw: number, nh: number) {
@@ -175,7 +180,7 @@ export function Notch({
   const minGap = radius + ir;
 
   if (headOnly) {
-    const resolvedOff = resolveOffset(notchOffset, edge, notchLen);
+    const resolvedOff = resolveOffset(notchOffset, edge, notchLen, notchSide);
     const atStart = resolvedOff < minGap;
     const atEnd = (edge - notchLen - resolvedOff) < minGap;
 
@@ -208,7 +213,7 @@ export function Notch({
   const bh = horiz ? height : width;
   const bnw = horiz ? notchWidth : notchHeight;
   const bnh = horiz ? notchHeight : notchWidth;
-  const rawNy = resolveOffset(notchOffset, edge, notchLen);
+  const rawNy = resolveOffset(notchOffset, edge, notchLen, notchSide);
   const ny = clampOffset(rawNy, edge, notchLen, minGap, notchOffset);
 
   const path = buildPath(bw, bh, bnw, bnh, ny, radius, ir);

--- a/src/context/snackbar/SnackbarProvider.tsx
+++ b/src/context/snackbar/SnackbarProvider.tsx
@@ -125,6 +125,13 @@ export function useSnackbar() {
   };
 }
 
+/** Whether a snackbar is currently visible — true from show until dismiss
+ *  starts the exit animation. Safe outside a SnackbarProvider (always false).
+ *  AppShell uses it to slide the mobile bottom nav out of the snackbar's way. */
+export function useSnackbarVisible() {
+  return useContext(SnackbarContext)?._internal.open ?? false;
+}
+
 export interface UseUnsavedSnackbarOptions {
   snapshot: string;
   message?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -339,12 +339,17 @@ export {
 export {
   NavigationRail,
   type NavigationRailProps,
+  type NavigationRailOrientation,
 } from "./components/ui/navigation/navigation-rail/NavigationRail";
 export {
   NavigationButton,
   type NavigationButtonProps,
   type NavigationButtonVariant,
 } from "./components/ui/navigation/navigation-button/NavigationButton";
+export {
+  BottomNavItem,
+  type BottomNavItemProps,
+} from "./components/ui/navigation/bottom-nav-item/BottomNavItem";
 export {
   AppSwitcher,
   type AppSwitcherProps,
@@ -446,6 +451,7 @@ export {
   SnackbarProvider,
   SnackbarOutlet,
   useSnackbar,
+  useSnackbarVisible,
   useUnsavedSnackbar,
   type SnackbarProviderProps,
   type SnackbarOptions,


### PR DESCRIPTION
## Summary

Kit support for mobile RWD navigation (consumed by web-applications' shell):

- **NavigationRail** — `orientation="horizontal"` renders the rail as a bottom pill (logo | divider | children in a row). Stories + tests.
- **AppShell** — new `mobileNavigation` slot + `mobileNavigationVariant`:
  - `"bottom"` (default) — pinned to the content area's bottom edge below `lg` (where the side `navigation` hides); content bottom padding clears it. While a snackbar is showing, the bar slides down / fades out (leaving the tab order via `invisible`) and returns as the snackbar exits — isolated in a `BottomNavRegion` child so snackbar churn re-renders only the slot.
  - `"drawer"` — a floating menu button opens mobile navigation as a modal slide-in drawer (scrim + panel; closes on scrim tap, Escape, or nav selection). Content falls back to `navigation`, so NavDrawer consumers (web-account) get mobile nav by adding one prop. Story + tests.
- **BottomNavItem** (new component) — M3-style bottom-nav destination: stadium active indicator, label rendered only while selected (fixed `h-14` keeps the pill from jumping), `customIcon` square/circle frame for app icons / avatars, `aria-current="page"` on the selected item. Story + tests; the rail's `Horizontal` story now demos it (NavigationButton's hover-expand labels are a no-op on touch).
- **DropdownMenu** — `placement="top"` (opens upward for bottom-anchored triggers), `size="lg"` touch density, `menuClassName` positioning escape hatch, rounder card (`DD_R` 12→16).
- **Notch** — `notchOffset` now honors its documented semantics (*positive = from left*) on the **top** edge too: the `rotate(90)` build-axis mirror is compensated inside `resolveOffset` instead of by every `notchSide="top"` consumer. Pinned with path-equality tests; DropdownMenu's call-site negation is deleted.
- **SnackbarProvider** — `useSnackbarVisible()`: read-only visibility probe (safe outside a provider), used by AppShell.

## Version

`0.4.3 → 0.4.4` (pre-1.0 patch bump) + `release` label.

## Verification

- `pnpm typecheck` / `pnpm test` (579 tests, incl. new AppShell drawer + Notch offset + BottomNavItem suites) / `pnpm build` all green.
- Bottom variant verified live in web-applications at 390×844 via `file:` link: bottom nav renders, More menu opens upward with the notch centered on its trigger, snackbar show/dismiss slides the nav out/in (computed-style checked).
- Drawer variant covered by unit tests + `WithMobileNavDrawer` story (no consumer wired yet; web-account is the intended first).

## Follow-ups (deferred)

- DropdownMenu `align="start|center|end"` prop to compute notch-tab centering from measured trigger width — would remove the consumer's hand-tuned `offset`/x-translate pair (`menuClassName` stays for genuinely contextual nudges).
- Module-bundle CSS isolation (`@layer`) in web-applications so AppShell's `lg:!hidden` / `sm:!w-auto` importants can drop.
- web-account: adopt `mobileNavigationVariant="drawer"` (it currently has no nav below lg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)