### PR TITLE
fix: widen DataList leading-icon gap

### DIFF
--- a/src/components/ui/blocks/data-list/DataList.tsx
+++ b/src/components/ui/blocks/data-list/DataList.tsx
@@ -70,7 +70,7 @@ export function DataList({
         <div
           key={index}
           className={cn(
-            "flex items-center gap-2 px-1 py-1.5 border-b border-current/5",
+            "flex items-center gap-2.5 px-1 py-1.5 border-b border-current/5",
             index === items.length - 1 && "border-b-0",
           )}
         >


### PR DESCRIPTION
One-liner: row `gap-2` → `gap-2.5` in `DataList` — 8px read too tight between the leading icon and the title/description block in dashboard list cards (app-overview Issues / Notifications).

No version bump or `release` label — **merge this before #265** so the 0.4.4 release picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)