### PR TITLE
feat: AvatarStack total prop for server-capped previews (0.4.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.4.7
+
+- `AvatarStack`: new `total` prop — when `items` is a server-capped preview,
+  the `+N` overflow chip reports `total - visible` instead of deriving from
+  `items.length`. Defaults to `items.length`. **No breaking changes.** (#271)
+
 ## 0.4.6
 
 - `AvatarStack` (new): overlapping row of `Avatar`s for member previews —

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/media/avatar-stack/AvatarStack.stories.tsx
+++ b/src/components/ui/media/avatar-stack/AvatarStack.stories.tsx
@@ -42,6 +42,18 @@ export const Overflow: Story = {
 };
 
 /**
+ * When `items` is a server-capped preview, pass `total` and the chip reports
+ * the real remainder — here a 4-item preview of a 12-member list renders
+ * three avatars + `+9`.
+ */
+export const CappedPreview: Story = {
+  args: {
+    items: people.slice(0, 4),
+    total: 12,
+  },
+};
+
+/**
  * `trailing` always renders last and never collapses into the chip — here a
  * square org avatar pinned after the member stack, the /apps tile layout
  * (members + owning org).

--- a/src/components/ui/media/avatar-stack/AvatarStack.test.tsx
+++ b/src/components/ui/media/avatar-stack/AvatarStack.test.tsx
@@ -27,6 +27,19 @@ describe("AvatarStack", () => {
     expect(screen.getByText("99+")).toBeInTheDocument();
   });
 
+  it("derives the chip from total when items are a server-capped preview", () => {
+    render(<AvatarStack items={items(4)} max={4} total={10} />);
+    expect(screen.getByText("P2")).toBeInTheDocument();
+    expect(screen.queryByText("P3")).not.toBeInTheDocument();
+    expect(screen.getByText("+7")).toBeInTheDocument();
+  });
+
+  it("ignores a total below items.length", () => {
+    render(<AvatarStack items={items(3)} max={4} total={1} />);
+    expect(screen.getByText("P2")).toBeInTheDocument();
+    expect(screen.queryByText(/^\+/)).not.toBeInTheDocument();
+  });
+
   it("renders the trailing avatar square and uncollapsed, even when overflowing", () => {
     const { container } = render(
       <AvatarStack items={items(6)} max={4} trailing={{ fallback: "ORG", square: true }} />,

--- a/src/components/ui/media/avatar-stack/AvatarStack.tsx
+++ b/src/components/ui/media/avatar-stack/AvatarStack.tsx
@@ -32,6 +32,13 @@ export interface AvatarStackProps {
    * member stack.
    */
   trailing?: AvatarStackItem;
+  /**
+   * Total items the stack represents when `items` is a server-capped
+   * preview — the overflow chip then shows `total - visible` instead of
+   * `items.length - visible`. Defaults to `items.length`; values below it
+   * are clamped up.
+   */
+  total?: number;
   className?: string;
 }
 
@@ -48,6 +55,7 @@ export function AvatarStack({
   max = 4,
   size = "sm",
   trailing,
+  total,
   className,
 }: AvatarStackProps) {
   if (isDev && max < 2) {
@@ -56,9 +64,10 @@ export function AvatarStack({
     );
   }
   const cap = Math.max(max, 2);
-  const overflowing = items.length > cap;
+  const represented = Math.max(total ?? 0, items.length);
+  const overflowing = represented > cap;
   const visible = overflowing ? items.slice(0, cap - 1) : items;
-  const hidden = items.length - visible.length;
+  const hidden = represented - visible.length;
   const overlap = overlapMap[size];
 
   const rendered: AvatarStackItem[] = [


### PR DESCRIPTION
## Summary

Additive `total?: number` on `AvatarStack`: when `items` is a server-capped preview, the `+N` overflow chip reports `total - visible` instead of `items.length - visible`. Defaults to `items.length`; values below it are clamped up, so existing usage is unchanged.

Needed by the /apps tile redesign: `GET /v1/apps` returns ≤4 `membersPreview` + `memberCount` (api-platform#213), so the stack must show the real remainder.

Release: 0.4.7 patch bump + `release` label.

## Verification

- 10 stack tests pass (2 new: total-driven chip, total-below-length clamp), typecheck + components validate clean
- New `CappedPreview` story documents the contract

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)