### PR TITLE
fix: densify AgentGreeting model picker (0.4.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.4.8
+
+- `AgentGreeting`: model picker densified — smaller trigger pill
+  (`h-8`/13px hero, `h-7` compact), 200px menu, tighter rows and 14px
+  icons. **No breaking changes**; API unchanged. (#274)
+
 ## 0.4.7
 
 - `AvatarStack`: new `total` prop — when `items` is a server-capped preview,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/agent/greeting/AgentGreeting.tsx
+++ b/src/components/ui/agent/greeting/AgentGreeting.tsx
@@ -53,8 +53,8 @@ const TEXTAREA_BOUNDS = {
   hero: { min: 80, max: 200 },
   compact: { min: 40, max: 112 },
 } as const;
-const MENU_W = 220;
-const MENU_R = 14;
+const MENU_W = 200;
+const MENU_R = 12;
 const MENU_IR = 8;
 // Extra breathing room INSIDE the notch on the left of the trigger pill.
 // Right side stays flush — the send button sits there, so we don't intrude.
@@ -238,8 +238,8 @@ export function AgentGreeting({
                 type="button"
                 onClick={() => setModelMenuOpen((open) => !open)}
                 className={cn(
-                  "relative z-[51] flex cursor-pointer items-center gap-1.5 rounded-full text-on-surface-variant transition-colors hover:bg-on-surface/8 hover:text-on-surface",
-                  compact ? "h-8 px-3 text-xs" : "h-9 px-4 text-sm",
+                  "relative z-[51] flex cursor-pointer items-center gap-1 rounded-full text-on-surface-variant transition-colors hover:bg-on-surface/8 hover:text-on-surface",
+                  compact ? "h-7 px-2.5 text-xs" : "h-8 px-3 text-[13px]",
                 )}
                 aria-label={`Model: ${activeModel.label}`}
                 aria-haspopup="listbox"
@@ -248,7 +248,7 @@ export function AgentGreeting({
                 <span className="max-w-[140px] truncate">
                   {activeModel.label}
                 </span>
-                <Icon name="expand_more" size={16} />
+                <Icon name="expand_more" size={14} />
               </button>
               {modelMenuOpen && (
                 <div
@@ -279,7 +279,7 @@ export function AgentGreeting({
                     ref={modelContentRef}
                     role="listbox"
                     aria-label="Model"
-                    className="relative z-10 flex flex-col gap-1 p-2"
+                    className="relative z-10 flex flex-col gap-0.5 p-1.5"
                     style={{
                       marginTop: notchTabHeight || 32,
                       width: MENU_W,
@@ -295,7 +295,7 @@ export function AgentGreeting({
                           aria-selected={selected}
                           onClick={() => handleSelectModel(m.id)}
                           className={cn(
-                            "flex items-baseline gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors",
+                            "flex items-baseline gap-1.5 rounded-lg px-2 py-1 text-left text-[13px] transition-colors",
                             selected
                               ? "bg-on-surface/8 text-on-surface"
                               : "text-on-surface hover:bg-on-surface/8",
@@ -303,7 +303,7 @@ export function AgentGreeting({
                         >
                           <Icon
                             name="check"
-                            size={16}
+                            size={14}
                             className={cn(
                               "shrink-0 translate-y-0.5",
                               selected ? "text-on-surface" : "text-transparent",
@@ -313,7 +313,7 @@ export function AgentGreeting({
                             {m.label}
                           </span>
                           {m.description && (
-                            <span className="text-xs text-on-surface-variant">
+                            <span className="text-[11px] text-on-surface-variant">
                               {m.description}
                             </span>
                           )}


### PR DESCRIPTION
## Summary

The model trigger + notched dropdown read oversized in the composer (live-usage report). One density step down across the assembly, no API change:

- Trigger pill: `h-9 px-4 text-sm` → `h-8 px-3 text-[13px]` (compact `h-8` → `h-7 px-2.5`), `expand_more` 16 → 14
- Menu: 220px → 200px wide, radius 14 → 12; body `gap-1 p-2` → `gap-0.5 p-1.5`
- Rows: `py-1.5 text-sm` → `py-1 text-[13px]`, check icon 16 → 14, description `text-xs` → `text-[11px]`
- The notch tab auto-follows the smaller trigger (measured at runtime)

## Verification

- Before/after captured from the live Storybook render (menu opened via scripted click)
- 25 AgentGreeting tests pass, typecheck + components validate clean

Release: 0.4.8 patch + `release` label.

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)