### PR TITLE
feat(agent-sidebar): price detail on model rows (0.4.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.4.9
+
+- `AgentSidebarInput`: new optional `detail` field on `AgentSidebarInputModel` —
+  right-aligned secondary text at the end of each model row, before the info
+  icon (e.g. `"$3/$15"` per-MTok pricing). **No breaking changes.**
+
 ## 0.4.7
 
 - `AvatarStack`: new `total` prop — when `items` is a server-capped preview,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/agent/sidebar/AgentSidebarInput.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebarInput.tsx
@@ -18,6 +18,9 @@ export interface AgentSidebarInputModel {
   /** One-liner revealed when a disabled entry is hovered or keyboard-focused.
    *  Also exposed to assistive tech via aria-describedby. */
   disabledHint?: string;
+  /** Right-aligned secondary text at the end of the row, before the info
+   *  icon — e.g. "$3/$15" per-MTok pricing. */
+  detail?: string;
 }
 
 export interface AgentSidebarInputProps {
@@ -34,7 +37,7 @@ export interface AgentSidebarInputProps {
 
 // Model menu geometry — mirrors AgentGreeting's selector, flipped upward:
 // the input is pinned to the sidebar's bottom edge, so the menu opens up.
-const MENU_W = 240;
+const MENU_W = 288; // fits the longest label + price detail without truncation
 const MENU_R = 12;
 const MENU_IR = 8;
 // The notch tab bleeds this far past the trigger pill on each side…
@@ -308,6 +311,11 @@ export function AgentSidebarInput({
                           <span className={cn("flex-1 truncate", selected && "font-medium")}>
                             {m.label}
                           </span>
+                          {m.detail && (
+                            <span className="shrink-0 text-[11px] tabular-nums opacity-60">
+                              {m.detail}
+                            </span>
+                          )}
                           {m.disabled && (
                             <Icon
                               name="info"

--- a/src/components/ui/agent/sidebar/AgentSidebarInput.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebarInput.tsx
@@ -37,7 +37,7 @@ export interface AgentSidebarInputProps {
 
 // Model menu geometry — mirrors AgentGreeting's selector, flipped upward:
 // the input is pinned to the sidebar's bottom edge, so the menu opens up.
-const MENU_W = 288; // fits the longest label + price detail without truncation
+const MENU_W = 240; // long labels truncate; price detail stays fully visible
 const MENU_R = 12;
 const MENU_IR = 8;
 // The notch tab bleeds this far past the trigger pill on each side…
@@ -164,7 +164,7 @@ export function AgentSidebarInput({
           Tip — ctrl + c to interrupt
         </span>
       </div>
-      <div className="flex flex-col w-full border border-outline-variant/30 rounded-xl bg-inverse-on-surface/8 p-1">
+      <div className="flex flex-col w-full border border-outline-variant/30 rounded-xl bg-inverse-on-surface/8 p-1 pt-1.5 gap-0.5">
         <textarea
           ref={textareaRef}
           value={text}
@@ -312,7 +312,7 @@ export function AgentSidebarInput({
                             {m.label}
                           </span>
                           {m.detail && (
-                            <span className="shrink-0 text-[11px] tabular-nums opacity-60">
+                            <span className="shrink-0 text-[9px] tabular-nums opacity-60">
                               {m.detail}
                             </span>
                           )}

--- a/src/components/ui/agent/sidebar/mock-data.ts
+++ b/src/components/ui/agent/sidebar/mock-data.ts
@@ -2,32 +2,41 @@ import type { AgentSidebarMessage } from "../messages/AgentSidebarMessages";
 import type { AgentSidebarInputModel } from "./AgentSidebarInput";
 import type { AgentSidebarHistoryGroup } from "./types";
 
-// Milestone-A roster: Claude pair enabled; Gemini/GPT pairs visible but
-// disabled until their adapters ship.
+// Milestone-A roster, vendor-grouped (Claude → Gemini → GPT, small →
+// powerful): Claude pair enabled; Gemini/GPT pairs visible but disabled
+// until their adapters ship. detail = $/MTok in/out pricing.
 export const mockAgentModels: AgentSidebarInputModel[] = Object.freeze([
-  { id: "anthropic.claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
   {
-    id: "gemini-3.5-flash",
-    label: "Gemini 3.5 Flash",
-    disabled: true,
-    disabledHint: "Supported in the future",
+    id: "anthropic.claude-haiku-4-5-20251001-v1:0",
+    label: "Claude Haiku 4.5",
+    detail: "$1/$5",
   },
-  { id: "anthropic.claude-haiku-4-5-20251001-v1:0", label: "Claude Haiku 4.5" },
-  {
-    id: "gpt-5.4-mini",
-    label: "GPT-5.4 mini",
-    disabled: true,
-    disabledHint: "Supported in the future",
-  },
+  { id: "anthropic.claude-sonnet-4-6", label: "Claude Sonnet 4.6", detail: "$3/$15" },
   {
     id: "gemini-3.1-flash-lite",
     label: "Gemini 3.1 Flash-Lite",
+    detail: "$0.25/$1.50",
+    disabled: true,
+    disabledHint: "Supported in the future",
+  },
+  {
+    id: "gemini-3.5-flash",
+    label: "Gemini 3.5 Flash",
+    detail: "$1.50/$9",
     disabled: true,
     disabledHint: "Supported in the future",
   },
   {
     id: "gpt-5.4-nano",
     label: "GPT-5.4 nano",
+    detail: "$0.20/$1.25",
+    disabled: true,
+    disabledHint: "Supported in the future",
+  },
+  {
+    id: "gpt-5.4-mini",
+    label: "GPT-5.4 mini",
+    detail: "$0.75/$4.50",
     disabled: true,
     disabledHint: "Supported in the future",
   },


### PR DESCRIPTION
## Summary
- `AgentSidebarInputModel` gains optional `detail` — right-aligned secondary text (9px, tabular-nums) at the end of each dropdown row, before the info icon. The platform uses it for $in/$out per-MTok pricing from `GET /v1/models`.
- Menu stays at `MENU_W` 240 — long labels ellipsize; the price detail never clips.
- Composer container spacing tuned (`pt-1.5 gap-0.5`).
- Mock roster reordered to mirror the platform roster: vendor-grouped Claude → Gemini → GPT, small → powerful within each vendor.

## Verification
Live-reviewed in local Storybook (ui-agent-sidebar--input-with-model-selector): order, right-aligned prices on all 6 rows, disabled hints intact, only the longest label ("Gemini 3.1 Fl…") ellipsizes.

## Release
0.4.8 → 0.4.9 (pre-1.0 patch rule). #274 was closed (stale 0.4.8 bump) — this is the only open release PR.

## Test plan
- pnpm typecheck ✓
- pnpm test 600/600 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)