### PR TITLE
feat(agent): message action row (copy/feedback/rerun) + bottom logo

### DIFF
--- a/src/components/ui/actions/icon-button/IconButton.tsx
+++ b/src/components/ui/actions/icon-button/IconButton.tsx
@@ -27,6 +27,8 @@ export interface IconButtonProps
   size?: ButtonSize;
   loading?: boolean;
   tooltip?: string;
+  /** Render the filled variant of the icon (Material Symbols `FILL` axis). */
+  fill?: boolean;
 }
 
 const sizeStyles: Record<ButtonSize, string> = {
@@ -43,6 +45,7 @@ export function IconButton({
   size = "md",
   loading = false,
   tooltip,
+  fill,
   className,
   disabled,
   // Default to "button" — prevents implicit submit inside <form>.
@@ -77,7 +80,7 @@ export function IconButton({
           style={{ width: iconSizes[size], height: iconSizes[size] }}
         />
       ) : (
-        <Icon name={icon} size={iconSizes[size]} />
+        <Icon name={icon} size={iconSizes[size]} fill={fill} />
       )}
     </button>
   );

--- a/src/components/ui/agent/messages/AgentSidebarMessage.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessage.tsx
@@ -154,7 +154,7 @@ function AgentMessageActions({
   return (
     // -ml-1.5 cancels the icon button's inner padding so the first icon
     // optically aligns with the message text's left edge.
-    <div className="mt-1 -ml-1.5 flex items-center gap-0.5">
+    <div className="pt-2 -ml-1.5 flex items-center gap-0.5">
       {onCopy && (
         <IconButton
           icon={copied ? "check" : "content_copy"}

--- a/src/components/ui/agent/messages/AgentSidebarMessage.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessage.tsx
@@ -1,4 +1,6 @@
+import { useEffect, useRef, useState } from "react";
 import { cn } from "@/utils/cn";
+import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 
 export interface AgentSidebarUserMessageProps {
   content: string;
@@ -18,22 +20,52 @@ export function AgentSidebarUserMessage({
   );
 }
 
+/** Feedback rating on an agent message. `null` clears a previous rating. */
+export type AgentMessageFeedback = "up" | "down" | null;
+
+/** Localizable aria-labels for the message action buttons (English defaults). */
+export interface AgentMessageActionLabels {
+  copy?: string;
+  copied?: string;
+  good?: string;
+  bad?: string;
+  rerun?: string;
+}
+
 export interface AgentSidebarAgentMessageProps {
   content: string;
   /** When true, renders typing indicator (if no content) or blinking cursor (if content). */
   streaming?: boolean;
+  /** Current feedback rating reflected on the thumbs. */
+  feedback?: AgentMessageFeedback;
+  /** Copy was clicked. The kit only flashes the icon to a check — the
+   *  consumer performs the actual clipboard write. */
+  onCopy?: () => void;
+  /** Fired with the next rating: clicking the selected thumb yields null,
+   *  clicking the other thumb switches. */
+  onFeedback?: (rating: AgentMessageFeedback) => void;
+  onRerun?: () => void;
+  actionLabels?: AgentMessageActionLabels;
   className?: string;
 }
 
 export function AgentSidebarAgentMessage({
   content,
   streaming = false,
+  feedback = null,
+  onCopy,
+  onFeedback,
+  onRerun,
+  actionLabels,
   className,
 }: AgentSidebarAgentMessageProps) {
   const showThinking = streaming && content.length === 0;
+  // Actions appear on finished messages only, and only when the consumer
+  // wired at least one callback.
+  const showActions = !streaming && !!(onCopy || onFeedback || onRerun);
 
   return (
-    <div className={cn("flex justify-start", className)}>
+    <div className={cn("flex flex-col items-start", className)}>
       <div className="max-w-full text-sm text-inverse-on-surface whitespace-pre-wrap break-words leading-relaxed">
         {showThinking ? <ThinkingDots /> : content}
         {streaming && content.length > 0 && (
@@ -43,6 +75,100 @@ export function AgentSidebarAgentMessage({
           />
         )}
       </div>
+      {showActions && (
+        <AgentMessageActions
+          feedback={feedback}
+          onCopy={onCopy}
+          onFeedback={onFeedback}
+          onRerun={onRerun}
+          labels={actionLabels}
+        />
+      )}
+    </div>
+  );
+}
+
+const COPY_FLASH_MS = 1500;
+// Same muted ink as AgentSidebarInput's composer icons.
+const MUTED_INK = "text-inverse-on-surface/60 hover:text-inverse-on-surface";
+
+function AgentMessageActions({
+  feedback,
+  onCopy,
+  onFeedback,
+  onRerun,
+  labels,
+}: {
+  feedback: AgentMessageFeedback;
+  onCopy?: () => void;
+  onFeedback?: (rating: AgentMessageFeedback) => void;
+  onRerun?: () => void;
+  labels?: AgentMessageActionLabels;
+}) {
+  const [copied, setCopied] = useState(false);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+
+  useEffect(() => () => clearTimeout(copyTimerRef.current), []);
+
+  const handleCopy = () => {
+    onCopy?.();
+    setCopied(true);
+    clearTimeout(copyTimerRef.current);
+    copyTimerRef.current = setTimeout(() => setCopied(false), COPY_FLASH_MS);
+  };
+
+  // Clicking the selected thumb toggles it off; the other thumb switches.
+  const rate = (rating: "up" | "down") =>
+    onFeedback?.(feedback === rating ? null : rating);
+
+  const thumb = (rating: "up" | "down", icon: string, label: string) => {
+    const selected = feedback === rating;
+    return (
+      <IconButton
+        icon={icon}
+        fill={selected}
+        variant="text"
+        size="sm"
+        className={selected ? "text-inverse-on-surface" : MUTED_INK}
+        onClick={() => rate(rating)}
+        aria-label={label}
+        aria-pressed={selected}
+      />
+    );
+  };
+
+  return (
+    // -ml-1.5 cancels the icon button's inner padding so the first icon
+    // optically aligns with the message text's left edge.
+    <div className="mt-1 -ml-1.5 flex items-center gap-0.5">
+      {onCopy && (
+        <IconButton
+          icon={copied ? "check" : "content_copy"}
+          variant="text"
+          size="sm"
+          className={MUTED_INK}
+          onClick={handleCopy}
+          aria-label={copied ? (labels?.copied ?? "Copied") : (labels?.copy ?? "Copy")}
+        />
+      )}
+      {onFeedback && (
+        <>
+          {thumb("up", "thumb_up", labels?.good ?? "Good response")}
+          {thumb("down", "thumb_down", labels?.bad ?? "Bad response")}
+        </>
+      )}
+      {onRerun && (
+        <IconButton
+          icon="refresh"
+          variant="text"
+          size="sm"
+          className={MUTED_INK}
+          onClick={onRerun}
+          aria-label={labels?.rerun ?? "Rerun"}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/ui/agent/messages/AgentSidebarMessage.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessage.tsx
@@ -21,10 +21,10 @@ export function AgentSidebarUserMessage({
 }
 
 /** Feedback rating on an agent message. `null` clears a previous rating. */
-export type AgentMessageFeedback = "up" | "down" | null;
+export type AgentSidebarMessageFeedback = "up" | "down" | null;
 
 /** Localizable aria-labels for the message action buttons (English defaults). */
-export interface AgentMessageActionLabels {
+export interface AgentSidebarMessageActionLabels {
   copy?: string;
   copied?: string;
   good?: string;
@@ -37,15 +37,16 @@ export interface AgentSidebarAgentMessageProps {
   /** When true, renders typing indicator (if no content) or blinking cursor (if content). */
   streaming?: boolean;
   /** Current feedback rating reflected on the thumbs. */
-  feedback?: AgentMessageFeedback;
+  feedback?: AgentSidebarMessageFeedback;
   /** Copy was clicked. The kit only flashes the icon to a check — the
-   *  consumer performs the actual clipboard write. */
-  onCopy?: () => void;
+   *  consumer performs the actual clipboard write. Return `false` (sync or
+   *  resolved), or reject, to suppress the success flash. */
+  onCopy?: () => void | boolean | Promise<void | boolean>;
   /** Fired with the next rating: clicking the selected thumb yields null,
    *  clicking the other thumb switches. */
-  onFeedback?: (rating: AgentMessageFeedback) => void;
+  onFeedback?: (rating: AgentSidebarMessageFeedback) => void;
   onRerun?: () => void;
-  actionLabels?: AgentMessageActionLabels;
+  actionLabels?: AgentSidebarMessageActionLabels;
   className?: string;
 }
 
@@ -99,31 +100,42 @@ function AgentMessageActions({
   onRerun,
   labels,
 }: {
-  feedback: AgentMessageFeedback;
-  onCopy?: () => void;
-  onFeedback?: (rating: AgentMessageFeedback) => void;
+  feedback: AgentSidebarMessageFeedback;
+  onCopy?: () => void | boolean | Promise<void | boolean>;
+  onFeedback?: (rating: AgentSidebarMessageFeedback) => void;
   onRerun?: () => void;
-  labels?: AgentMessageActionLabels;
+  labels?: AgentSidebarMessageActionLabels;
 }) {
   const [copied, setCopied] = useState(false);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
+  const unmountedRef = useRef(false);
 
-  useEffect(() => () => clearTimeout(copyTimerRef.current), []);
+  useEffect(
+    () => () => {
+      unmountedRef.current = true;
+      clearTimeout(copyTimerRef.current);
+    },
+    [],
+  );
 
-  const handleCopy = () => {
-    onCopy?.();
+  const handleCopy = async () => {
+    try {
+      // A `false` return (sync or resolved) or a rejection means the
+      // consumer's clipboard write failed — don't flash success.
+      if ((await onCopy?.()) === false) return;
+    } catch {
+      return;
+    }
+    if (unmountedRef.current) return;
     setCopied(true);
     clearTimeout(copyTimerRef.current);
     copyTimerRef.current = setTimeout(() => setCopied(false), COPY_FLASH_MS);
   };
 
-  // Clicking the selected thumb toggles it off; the other thumb switches.
-  const rate = (rating: "up" | "down") =>
-    onFeedback?.(feedback === rating ? null : rating);
-
   const thumb = (rating: "up" | "down", icon: string, label: string) => {
+    // Clicking the selected thumb toggles it off; the other thumb switches.
     const selected = feedback === rating;
     return (
       <IconButton
@@ -132,7 +144,7 @@ function AgentMessageActions({
         variant="text"
         size="sm"
         className={selected ? "text-inverse-on-surface" : MUTED_INK}
-        onClick={() => rate(rating)}
+        onClick={() => onFeedback?.(selected ? null : rating)}
         aria-label={label}
         aria-pressed={selected}
       />

--- a/src/components/ui/agent/messages/AgentSidebarMessages.stories.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.stories.tsx
@@ -3,6 +3,10 @@ import {
   AgentSidebarUserMessage,
   AgentSidebarAgentMessage,
 } from "./AgentSidebarMessage";
+import {
+  AgentSidebarMessages,
+  type AgentSidebarMessage,
+} from "./AgentSidebarMessages";
 
 const meta: Meta = {
   title: "UI/Agent/Messages",
@@ -38,5 +42,78 @@ export const AgentStreaming: StoryObj = {
         streaming
       />
     </div>
+  ),
+};
+
+const noop = () => {};
+
+const actionCallbacks = {
+  onMessageCopy: noop,
+  onMessageFeedback: noop,
+  onMessageRerun: noop,
+};
+
+const finishedThread: AgentSidebarMessage[] = [
+  {
+    id: "m-1",
+    role: "user",
+    content: "Summarize my account changes this week.",
+  },
+  {
+    id: "m-2",
+    role: "agent",
+    content:
+      "You changed your username to alice2, enabled dark mode, and added a passkey from your MacBook.",
+  },
+];
+
+/** Copy / thumbs / rerun appear under finished agent messages only. */
+export const FinishedWithActions: StoryObj = {
+  render: () => (
+    <AgentSidebarMessages messages={finishedThread} {...actionCallbacks} />
+  ),
+};
+
+/** A previously-recorded rating renders the thumb filled at full ink. */
+export const FeedbackSelected: StoryObj = {
+  render: () => (
+    <AgentSidebarMessages
+      messages={[
+        finishedThread[0],
+        {
+          id: "m-2",
+          role: "agent",
+          content:
+            "You changed your username to alice2, enabled dark mode, and added a passkey from your MacBook.",
+          feedback: "up",
+        },
+      ]}
+      {...actionCallbacks}
+    />
+  ),
+};
+
+/** The action row stays hidden while the agent is still streaming. */
+export const StreamingHidesActions: StoryObj = {
+  render: () => (
+    <AgentSidebarMessages
+      messages={[
+        finishedThread[0],
+        {
+          id: "m-2",
+          role: "agent",
+          content: "Pulling your audit log",
+          streaming: true,
+        },
+      ]}
+      {...actionCallbacks}
+    />
+  ),
+};
+
+/** Subdued brand mark below the list when the last message is finished. */
+export const WithLogo: StoryObj = {
+  render: () => (
+    <AgentSidebarMessages messages={finishedThread} {...actionCallbacks} showLogo />
   ),
 };

--- a/src/components/ui/agent/messages/AgentSidebarMessages.stories.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.stories.tsx
@@ -48,10 +48,17 @@ export const AgentStreaming: StoryObj = {
 const noop = () => {};
 
 const actionCallbacks = {
-  onMessageCopy: noop,
-  onMessageFeedback: noop,
-  onMessageRerun: noop,
+  onCopyMessage: noop,
+  onRateMessage: noop,
+  onRerunMessage: noop,
 };
+
+const finishedAgentMsg = {
+  id: "m-2",
+  role: "agent",
+  content:
+    "You changed your username to alice2, enabled dark mode, and added a passkey from your MacBook.",
+} satisfies AgentSidebarMessage;
 
 const finishedThread: AgentSidebarMessage[] = [
   {
@@ -59,12 +66,7 @@ const finishedThread: AgentSidebarMessage[] = [
     role: "user",
     content: "Summarize my account changes this week.",
   },
-  {
-    id: "m-2",
-    role: "agent",
-    content:
-      "You changed your username to alice2, enabled dark mode, and added a passkey from your MacBook.",
-  },
+  finishedAgentMsg,
 ];
 
 /** Copy / thumbs / rerun appear under finished agent messages only. */
@@ -78,16 +80,7 @@ export const FinishedWithActions: StoryObj = {
 export const FeedbackSelected: StoryObj = {
   render: () => (
     <AgentSidebarMessages
-      messages={[
-        finishedThread[0],
-        {
-          id: "m-2",
-          role: "agent",
-          content:
-            "You changed your username to alice2, enabled dark mode, and added a passkey from your MacBook.",
-          feedback: "up",
-        },
-      ]}
+      messages={[finishedThread[0], { ...finishedAgentMsg, feedback: "up" }]}
       {...actionCallbacks}
     />
   ),

--- a/src/components/ui/agent/messages/AgentSidebarMessages.stories.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.stories.tsx
@@ -104,7 +104,7 @@ export const StreamingHidesActions: StoryObj = {
   ),
 };
 
-/** Subdued brand mark below the list when the last message is finished. */
+/** Brand mark in the sidebar accent below the list when the last message is finished. */
 export const WithLogo: StoryObj = {
   render: () => (
     <AgentSidebarMessages messages={finishedThread} {...actionCallbacks} showLogo />

--- a/src/components/ui/agent/messages/AgentSidebarMessages.test.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.test.tsx
@@ -1,0 +1,177 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  AgentSidebarMessages,
+  type AgentSidebarMessage,
+} from "./AgentSidebarMessages";
+
+beforeAll(() => {
+  // jsdom doesn't implement scrollIntoView (used by the auto-scroll effect).
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(cleanup);
+
+type AgentTextMessage = Extract<
+  AgentSidebarMessage,
+  { role: "agent"; content: string }
+>;
+
+const agentMsg = (over: Partial<AgentTextMessage> = {}): AgentSidebarMessage => ({
+  id: "a-1",
+  role: "agent",
+  content: "Done.",
+  ...over,
+});
+
+const allCallbacks = () => ({
+  onMessageCopy: vi.fn(),
+  onMessageFeedback: vi.fn(),
+  onMessageRerun: vi.fn(),
+});
+
+describe("AgentSidebarMessages action row", () => {
+  it("renders all four actions on a finished agent message", () => {
+    render(<AgentSidebarMessages messages={[agentMsg()]} {...allCallbacks()} />);
+    expect(screen.getByLabelText("Copy")).toBeInTheDocument();
+    expect(screen.getByLabelText("Good response")).toBeInTheDocument();
+    expect(screen.getByLabelText("Bad response")).toBeInTheDocument();
+    expect(screen.getByLabelText("Rerun")).toBeInTheDocument();
+  });
+
+  it("hides the row while the message is streaming", () => {
+    render(
+      <AgentSidebarMessages
+        messages={[agentMsg({ streaming: true })]}
+        {...allCallbacks()}
+      />,
+    );
+    expect(screen.queryByLabelText("Copy")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Good response")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Rerun")).not.toBeInTheDocument();
+  });
+
+  it("hides the row when no callbacks are provided", () => {
+    render(<AgentSidebarMessages messages={[agentMsg()]} />);
+    expect(screen.queryByLabelText("Copy")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Rerun")).not.toBeInTheDocument();
+  });
+
+  it("renders no row on user messages", () => {
+    render(
+      <AgentSidebarMessages
+        messages={[{ id: "u-1", role: "user", content: "Hi" }, agentMsg()]}
+        {...allCallbacks()}
+      />,
+    );
+    expect(screen.getAllByLabelText("Copy")).toHaveLength(1);
+  });
+
+  it("renders only the buttons whose callbacks are provided", () => {
+    render(
+      <AgentSidebarMessages messages={[agentMsg()]} onMessageRerun={vi.fn()} />,
+    );
+    expect(screen.getByLabelText("Rerun")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Copy")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Good response")).not.toBeInTheDocument();
+  });
+
+  it("copy fires onMessageCopy and flashes a check for 1.5s", () => {
+    vi.useFakeTimers();
+    try {
+      const callbacks = allCallbacks();
+      render(<AgentSidebarMessages messages={[agentMsg()]} {...callbacks} />);
+      fireEvent.click(screen.getByLabelText("Copy"));
+      expect(callbacks.onMessageCopy).toHaveBeenCalledWith("a-1");
+      expect(screen.getByLabelText("Copied")).toHaveTextContent("check");
+      act(() => {
+        vi.advanceTimersByTime(1500);
+      });
+      expect(screen.getByLabelText("Copy")).toHaveTextContent("content_copy");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clicking a thumb reports the rating with the message id", () => {
+    const callbacks = allCallbacks();
+    render(<AgentSidebarMessages messages={[agentMsg()]} {...callbacks} />);
+    fireEvent.click(screen.getByLabelText("Good response"));
+    expect(callbacks.onMessageFeedback).toHaveBeenCalledWith("a-1", "up");
+    fireEvent.click(screen.getByLabelText("Bad response"));
+    expect(callbacks.onMessageFeedback).toHaveBeenCalledWith("a-1", "down");
+  });
+
+  it("clicking the selected thumb toggles it off; the other switches", () => {
+    const callbacks = allCallbacks();
+    render(
+      <AgentSidebarMessages
+        messages={[agentMsg({ feedback: "up" })]}
+        {...callbacks}
+      />,
+    );
+    const up = screen.getByLabelText("Good response");
+    expect(up).toHaveAttribute("aria-pressed", "true");
+    fireEvent.click(up);
+    expect(callbacks.onMessageFeedback).toHaveBeenCalledWith("a-1", null);
+    fireEvent.click(screen.getByLabelText("Bad response"));
+    expect(callbacks.onMessageFeedback).toHaveBeenCalledWith("a-1", "down");
+  });
+
+  it("rerun fires onMessageRerun with the message id", () => {
+    const callbacks = allCallbacks();
+    render(<AgentSidebarMessages messages={[agentMsg()]} {...callbacks} />);
+    fireEvent.click(screen.getByLabelText("Rerun"));
+    expect(callbacks.onMessageRerun).toHaveBeenCalledWith("a-1");
+  });
+
+  it("uses provided actionLabels", () => {
+    render(
+      <AgentSidebarMessages
+        messages={[agentMsg()]}
+        onMessageCopy={vi.fn()}
+        actionLabels={{ copy: "複製" }}
+      />,
+    );
+    expect(screen.getByLabelText("複製")).toBeInTheDocument();
+  });
+});
+
+describe("AgentSidebarMessages showLogo", () => {
+  const logo = () => screen.queryAllByRole("img", { name: "MirrorStack Logo" });
+
+  it("renders exactly one logo when the last message is a finished agent message", () => {
+    render(
+      <AgentSidebarMessages
+        messages={[agentMsg({ id: "a-1" }), agentMsg({ id: "a-2" })]}
+        showLogo
+      />,
+    );
+    expect(logo()).toHaveLength(1);
+  });
+
+  it("renders no logo while the last message is streaming", () => {
+    render(
+      <AgentSidebarMessages
+        messages={[agentMsg({ streaming: true })]}
+        showLogo
+      />,
+    );
+    expect(logo()).toHaveLength(0);
+  });
+
+  it("renders no logo when the last message is a user message", () => {
+    render(
+      <AgentSidebarMessages
+        messages={[agentMsg(), { id: "u-1", role: "user", content: "Hi" }]}
+        showLogo
+      />,
+    );
+    expect(logo()).toHaveLength(0);
+  });
+
+  it("renders no logo when showLogo is omitted", () => {
+    render(<AgentSidebarMessages messages={[agentMsg()]} />);
+    expect(logo()).toHaveLength(0);
+  });
+});

--- a/src/components/ui/agent/messages/AgentSidebarMessages.test.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.test.tsx
@@ -25,9 +25,9 @@ const agentMsg = (over: Partial<AgentTextMessage> = {}): AgentSidebarMessage => 
 });
 
 const allCallbacks = () => ({
-  onMessageCopy: vi.fn(),
-  onMessageFeedback: vi.fn(),
-  onMessageRerun: vi.fn(),
+  onCopyMessage: vi.fn(),
+  onRateMessage: vi.fn(),
+  onRerunMessage: vi.fn(),
 });
 
 describe("AgentSidebarMessages action row", () => {
@@ -69,20 +69,21 @@ describe("AgentSidebarMessages action row", () => {
 
   it("renders only the buttons whose callbacks are provided", () => {
     render(
-      <AgentSidebarMessages messages={[agentMsg()]} onMessageRerun={vi.fn()} />,
+      <AgentSidebarMessages messages={[agentMsg()]} onRerunMessage={vi.fn()} />,
     );
     expect(screen.getByLabelText("Rerun")).toBeInTheDocument();
     expect(screen.queryByLabelText("Copy")).not.toBeInTheDocument();
     expect(screen.queryByLabelText("Good response")).not.toBeInTheDocument();
   });
 
-  it("copy fires onMessageCopy and flashes a check for 1.5s", () => {
+  it("copy fires onCopyMessage and flashes a check for 1.5s", async () => {
     vi.useFakeTimers();
     try {
       const callbacks = allCallbacks();
       render(<AgentSidebarMessages messages={[agentMsg()]} {...callbacks} />);
       fireEvent.click(screen.getByLabelText("Copy"));
-      expect(callbacks.onMessageCopy).toHaveBeenCalledWith("a-1");
+      expect(callbacks.onCopyMessage).toHaveBeenCalledWith("a-1");
+      await act(async () => {}); // flush the async success gate
       expect(screen.getByLabelText("Copied")).toHaveTextContent("check");
       act(() => {
         vi.advanceTimersByTime(1500);
@@ -93,13 +94,26 @@ describe("AgentSidebarMessages action row", () => {
     }
   });
 
+  it("does not flash success when onCopyMessage returns false", async () => {
+    render(
+      <AgentSidebarMessages
+        messages={[agentMsg()]}
+        onCopyMessage={vi.fn(() => false)}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText("Copy"));
+    await act(async () => {});
+    expect(screen.queryByLabelText("Copied")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Copy")).toBeInTheDocument();
+  });
+
   it("clicking a thumb reports the rating with the message id", () => {
     const callbacks = allCallbacks();
     render(<AgentSidebarMessages messages={[agentMsg()]} {...callbacks} />);
     fireEvent.click(screen.getByLabelText("Good response"));
-    expect(callbacks.onMessageFeedback).toHaveBeenCalledWith("a-1", "up");
+    expect(callbacks.onRateMessage).toHaveBeenCalledWith("a-1", "up");
     fireEvent.click(screen.getByLabelText("Bad response"));
-    expect(callbacks.onMessageFeedback).toHaveBeenCalledWith("a-1", "down");
+    expect(callbacks.onRateMessage).toHaveBeenCalledWith("a-1", "down");
   });
 
   it("clicking the selected thumb toggles it off; the other switches", () => {
@@ -113,23 +127,23 @@ describe("AgentSidebarMessages action row", () => {
     const up = screen.getByLabelText("Good response");
     expect(up).toHaveAttribute("aria-pressed", "true");
     fireEvent.click(up);
-    expect(callbacks.onMessageFeedback).toHaveBeenCalledWith("a-1", null);
+    expect(callbacks.onRateMessage).toHaveBeenCalledWith("a-1", null);
     fireEvent.click(screen.getByLabelText("Bad response"));
-    expect(callbacks.onMessageFeedback).toHaveBeenCalledWith("a-1", "down");
+    expect(callbacks.onRateMessage).toHaveBeenCalledWith("a-1", "down");
   });
 
-  it("rerun fires onMessageRerun with the message id", () => {
+  it("rerun fires onRerunMessage with the message id", () => {
     const callbacks = allCallbacks();
     render(<AgentSidebarMessages messages={[agentMsg()]} {...callbacks} />);
     fireEvent.click(screen.getByLabelText("Rerun"));
-    expect(callbacks.onMessageRerun).toHaveBeenCalledWith("a-1");
+    expect(callbacks.onRerunMessage).toHaveBeenCalledWith("a-1");
   });
 
   it("uses provided actionLabels", () => {
     render(
       <AgentSidebarMessages
         messages={[agentMsg()]}
-        onMessageCopy={vi.fn()}
+        onCopyMessage={vi.fn()}
         actionLabels={{ copy: "複製" }}
       />,
     );
@@ -138,7 +152,9 @@ describe("AgentSidebarMessages action row", () => {
 });
 
 describe("AgentSidebarMessages showLogo", () => {
-  const logo = () => screen.queryAllByRole("img", { name: "MirrorStack Logo" });
+  // The logo wrapper is aria-hidden (decorative), so opt into hidden elements.
+  const logo = () =>
+    screen.queryAllByRole("img", { name: "MirrorStack Logo", hidden: true });
 
   it("renders exactly one logo when the last message is a finished agent message", () => {
     render(

--- a/src/components/ui/agent/messages/AgentSidebarMessages.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.tsx
@@ -5,8 +5,8 @@ import { Logo } from "@/components/ui/media/logo/Logo";
 import {
   AgentSidebarUserMessage,
   AgentSidebarAgentMessage,
-  type AgentMessageFeedback,
-  type AgentMessageActionLabels,
+  type AgentSidebarMessageFeedback,
+  type AgentSidebarMessageActionLabels,
 } from "./AgentSidebarMessage";
 import {
   AgentSidebarMultiQuestion,
@@ -27,7 +27,7 @@ export type AgentSidebarMessage =
       role: "agent";
       content: string;
       streaming?: boolean;
-      feedback?: AgentMessageFeedback;
+      feedback?: AgentSidebarMessageFeedback;
     }
   | {
       id: string;
@@ -48,14 +48,18 @@ export interface AgentSidebarMessagesProps {
     answers: Record<string, AgentSidebarMultiQuestionAnswer>,
   ) => void;
   /** Copy was clicked on a finished agent message. The kit only flashes the
-   *  icon — the consumer performs the actual clipboard write. */
-  onMessageCopy?: (messageId: string) => void;
+   *  icon — the consumer performs the actual clipboard write. Return `false`
+   *  (sync or resolved), or reject, to suppress the success flash. */
+  onCopyMessage?: (messageId: string) => void | boolean | Promise<void | boolean>;
   /** Fired with the next rating: clicking the selected thumb yields null,
    *  clicking the other thumb switches. */
-  onMessageFeedback?: (messageId: string, rating: AgentMessageFeedback) => void;
-  onMessageRerun?: (messageId: string) => void;
+  onRateMessage?: (
+    messageId: string,
+    rating: AgentSidebarMessageFeedback,
+  ) => void;
+  onRerunMessage?: (messageId: string) => void;
   /** Localizable aria-labels for the action buttons (English defaults). */
-  actionLabels?: AgentMessageActionLabels;
+  actionLabels?: AgentSidebarMessageActionLabels;
   /** Render the brand logo once below the list when the last message is a
    *  finished agent message — a subdued platform signature, never per-message. */
   showLogo?: boolean;
@@ -79,9 +83,9 @@ function findScrollParent(el: HTMLElement | null): HTMLElement | null {
 export function AgentSidebarMessages({
   messages,
   onSubmitMultiQuestion,
-  onMessageCopy,
-  onMessageFeedback,
-  onMessageRerun,
+  onCopyMessage,
+  onRateMessage,
+  onRerunMessage,
   actionLabels,
   showLogo = false,
   autoScroll = true,
@@ -156,19 +160,18 @@ export function AgentSidebarMessages({
             content={m.content}
             streaming={m.streaming}
             feedback={m.feedback}
-            onCopy={onMessageCopy && (() => onMessageCopy(m.id))}
+            onCopy={onCopyMessage && (() => onCopyMessage(m.id))}
             onFeedback={
-              onMessageFeedback && ((rating) => onMessageFeedback(m.id, rating))
+              onRateMessage && ((rating) => onRateMessage(m.id, rating))
             }
-            onRerun={onMessageRerun && (() => onMessageRerun(m.id))}
+            onRerun={onRerunMessage && (() => onRerunMessage(m.id))}
             actionLabels={actionLabels}
           />
         );
       })}
       {showBrandLogo && (
-        // Single subdued brand mark "signing" the finished response —
-        // rendered once below the list, never per-message.
-        <div className="-mt-2 flex justify-start">
+        // Decorative signature only — hidden from the accessibility tree.
+        <div aria-hidden className="-mt-2 flex justify-start">
           <Logo className="h-4 w-4 bg-inverse-on-surface/40" />
         </div>
       )}

--- a/src/components/ui/agent/messages/AgentSidebarMessages.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@/utils/cn";
 import { Icon } from "@/components/ui/media/icon/Icon";
+import { Logo } from "@/components/ui/media/logo/Logo";
 import {
   AgentSidebarUserMessage,
   AgentSidebarAgentMessage,
+  type AgentMessageFeedback,
+  type AgentMessageActionLabels,
 } from "./AgentSidebarMessage";
 import {
   AgentSidebarMultiQuestion,
@@ -24,6 +27,7 @@ export type AgentSidebarMessage =
       role: "agent";
       content: string;
       streaming?: boolean;
+      feedback?: AgentMessageFeedback;
     }
   | {
       id: string;
@@ -43,6 +47,18 @@ export interface AgentSidebarMessagesProps {
     messageId: string,
     answers: Record<string, AgentSidebarMultiQuestionAnswer>,
   ) => void;
+  /** Copy was clicked on a finished agent message. The kit only flashes the
+   *  icon — the consumer performs the actual clipboard write. */
+  onMessageCopy?: (messageId: string) => void;
+  /** Fired with the next rating: clicking the selected thumb yields null,
+   *  clicking the other thumb switches. */
+  onMessageFeedback?: (messageId: string, rating: AgentMessageFeedback) => void;
+  onMessageRerun?: (messageId: string) => void;
+  /** Localizable aria-labels for the action buttons (English defaults). */
+  actionLabels?: AgentMessageActionLabels;
+  /** Render the brand logo once below the list when the last message is a
+   *  finished agent message — a subdued platform signature, never per-message. */
+  showLogo?: boolean;
   /** Auto-scroll to the latest message. Default: true. */
   autoScroll?: boolean;
   className?: string;
@@ -63,6 +79,11 @@ function findScrollParent(el: HTMLElement | null): HTMLElement | null {
 export function AgentSidebarMessages({
   messages,
   onSubmitMultiQuestion,
+  onMessageCopy,
+  onMessageFeedback,
+  onMessageRerun,
+  actionLabels,
+  showLogo = false,
   autoScroll = true,
   className,
 }: AgentSidebarMessagesProps) {
@@ -101,6 +122,14 @@ export function AgentSidebarMessages({
     endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   };
 
+  const lastMessage = messages[messages.length - 1];
+  const showBrandLogo =
+    showLogo &&
+    !!lastMessage &&
+    lastMessage.role === "agent" &&
+    !("kind" in lastMessage) &&
+    !lastMessage.streaming;
+
   return (
     <div className={cn("flex flex-col gap-4", className)}>
       {messages.map((m) => {
@@ -126,9 +155,23 @@ export function AgentSidebarMessages({
             key={m.id}
             content={m.content}
             streaming={m.streaming}
+            feedback={m.feedback}
+            onCopy={onMessageCopy && (() => onMessageCopy(m.id))}
+            onFeedback={
+              onMessageFeedback && ((rating) => onMessageFeedback(m.id, rating))
+            }
+            onRerun={onMessageRerun && (() => onMessageRerun(m.id))}
+            actionLabels={actionLabels}
           />
         );
       })}
+      {showBrandLogo && (
+        // Single subdued brand mark "signing" the finished response —
+        // rendered once below the list, never per-message.
+        <div className="-mt-2 flex justify-start">
+          <Logo className="h-4 w-4 bg-inverse-on-surface/40" />
+        </div>
+      )}
       <div ref={endRef} />
       {!isAtBottom && (
         // -mt-4 cancels the parent's gap-4 so the sticky pill sits flush

--- a/src/components/ui/agent/messages/AgentSidebarMessages.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.tsx
@@ -172,7 +172,7 @@ export function AgentSidebarMessages({
       {showBrandLogo && (
         // Decorative signature only — hidden from the accessibility tree.
         <div aria-hidden className="flex justify-start">
-          <Logo className="h-7 w-7 bg-inverse-primary" />
+          <Logo className="h-10 w-10 bg-inverse-primary" />
         </div>
       )}
       <div ref={endRef} />

--- a/src/components/ui/agent/messages/AgentSidebarMessages.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.tsx
@@ -61,7 +61,7 @@ export interface AgentSidebarMessagesProps {
   /** Localizable aria-labels for the action buttons (English defaults). */
   actionLabels?: AgentSidebarMessageActionLabels;
   /** Render the brand logo once below the list when the last message is a
-   *  finished agent message — a subdued platform signature, never per-message. */
+   *  finished agent message — a clear platform signature, never per-message. */
   showLogo?: boolean;
   /** Auto-scroll to the latest message. Default: true. */
   autoScroll?: boolean;
@@ -171,8 +171,8 @@ export function AgentSidebarMessages({
       })}
       {showBrandLogo && (
         // Decorative signature only — hidden from the accessibility tree.
-        <div aria-hidden className="-mt-2 flex justify-start">
-          <Logo className="h-4 w-4 bg-inverse-on-surface/40" />
+        <div aria-hidden className="flex justify-start">
+          <Logo className="h-7 w-7 bg-inverse-primary" />
         </div>
       )}
       <div ref={endRef} />

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,8 @@ export {
   type AgentSidebarUserMessageProps,
   AgentSidebarAgentMessage,
   type AgentSidebarAgentMessageProps,
+  type AgentMessageFeedback,
+  type AgentMessageActionLabels,
 } from "./components/ui/agent/messages/AgentSidebarMessage";
 export {
   AgentSidebarMultiQuestion,

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,8 +56,8 @@ export {
   type AgentSidebarUserMessageProps,
   AgentSidebarAgentMessage,
   type AgentSidebarAgentMessageProps,
-  type AgentMessageFeedback,
-  type AgentMessageActionLabels,
+  type AgentSidebarMessageFeedback,
+  type AgentSidebarMessageActionLabels,
 } from "./components/ui/agent/messages/AgentSidebarMessage";
 export {
   AgentSidebarMultiQuestion,


### PR DESCRIPTION
## What

Adds a compact action row under **finished** agent messages in the agent sidebar, plus a single brand logo below the message list as a clear platform signature.

### New props on `AgentSidebarMessages`

| Prop | Type | Behavior |
| --- | --- | --- |
| `onCopyMessage` | `(messageId: string) => void \| boolean \| Promise<void \| boolean>` | Fired on copy click. The kit only flashes the icon to a check (~1.5s) — the **consumer** performs the actual clipboard write. Return `false` (sync or resolved), or reject, to suppress the success flash. |
| `onRateMessage` | `(messageId: string, rating: "up" \| "down" \| null) => void` | Fired with the **next** rating: clicking the selected thumb yields `null` (toggle off), clicking the other thumb switches. |
| `onRerunMessage` | `(messageId: string) => void` | Plain callback. |
| `actionLabels` | `{ copy?, copied?, good?, bad?, rerun? }` | Localizable aria-labels for the four buttons (English defaults). |
| `showLogo` | `boolean` | Renders the kit `Logo` **once** below the list when the last message is a finished agent message — 28px in the sidebar accent (`bg-inverse-primary`), never per-message. |

### Behavior

- The row renders only when at least one callback is provided, and each button renders only when its own callback is wired (no dead buttons).
- Never on user messages, never while a message is streaming, never on multi-question cards.
- Selected thumb renders filled (Material Symbols `FILL` axis) at full ink; unselected buttons use the same muted ink as `AgentSidebarInput`'s composer icons (`text-inverse-on-surface/60 hover:text-inverse-on-surface`).
- The agent message data type gains `feedback?: "up" | "down" | null` — feedback state is data-driven, the consumer owns it.
- `IconButton` gains a backwards-compatible pass-through `fill?: boolean` prop (forwards to `Icon`'s existing `fill` axis) for the selected-thumb state.
- New exports: `AgentSidebarMessageFeedback`, `AgentSidebarMessageActionLabels`.

### Stories / tests

- Stories: `FinishedWithActions`, `FeedbackSelected`, `StreamingHidesActions`, `WithLogo`.
- 15 new tests: row hidden while streaming / without callbacks / on user messages, per-button callback gating, copy flash with fake timers, feedback toggle semantics, rerun, custom labels, logo render rules (exactly one, none while streaming, none when last is user).

### Verification

- `pnpm typecheck` ✓ · `pnpm test` ✓ (615 tests) · `pnpm build` ✓
- Visually verified all four new stories in Storybook via Playwright screenshots.

### Release

**No version bump and no `release` label on purpose** — a rollup release PR follows later, per the batch-release convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

