### PR TITLE
chore: release 0.4.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
Rollup patch release for the two merged kit PRs (deferred-bump convention):
- #277 — agent message action row (copy/👍/👎/rerun) + 40px bottom logo, new exports `AgentSidebarMessageFeedback` / `AgentSidebarMessageActionLabels`, `IconButton fill` prop
- #276 — AgentGreeting picker compaction + price detail / info icon / 240px-menu parity with the sidebar selector (closes #273 behavior)

Version bump only; release.yml publishes 0.4.10 on merge via the release label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)