### PR TITLE
feat(agent): tool-call message block (AgentSidebarToolCall)

### DIFF
--- a/src/components/ui/agent/messages/AgentSidebarMessages.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.tsx
@@ -80,6 +80,27 @@ export interface AgentSidebarMessagesProps {
   className?: string;
 }
 
+type ToolMessage = Extract<AgentSidebarMessage, { role: "tool" }>;
+
+/** Collapse runs of consecutive tool rows so they can render in one gap-1
+ *  group — the spec caps tool-stack spacing at gap-1 ("a 16-row stack stays
+ *  calm") while regular messages keep the list's gap-4. */
+function groupToolRuns(
+  messages: AgentSidebarMessage[],
+): (Exclude<AgentSidebarMessage, ToolMessage> | ToolMessage[])[] {
+  const out: (Exclude<AgentSidebarMessage, ToolMessage> | ToolMessage[])[] = [];
+  for (const m of messages) {
+    if (m.role === "tool") {
+      const last = out[out.length - 1];
+      if (Array.isArray(last)) last.push(m);
+      else out.push([m]);
+    } else {
+      out.push(m);
+    }
+  }
+  return out;
+}
+
 const NEAR_BOTTOM_PX = 80;
 
 function findScrollParent(el: HTMLElement | null): HTMLElement | null {
@@ -149,14 +170,19 @@ export function AgentSidebarMessages({
 
   return (
     <div className={cn("flex flex-col gap-4", className)}>
-      {messages.map((m) => {
+      {groupToolRuns(messages).map((entry) => {
+        if (Array.isArray(entry)) {
+          return (
+            <div key={entry[0].id} className="flex flex-col gap-1">
+              {entry.map((m) => (
+                <AgentSidebarToolCall key={m.id} tool={m.tool} toolLabels={toolLabels} />
+              ))}
+            </div>
+          );
+        }
+        const m = entry;
         if (m.role === "user") {
           return <AgentSidebarUserMessage key={m.id} content={m.content} />;
-        }
-        if (m.role === "tool") {
-          return (
-            <AgentSidebarToolCall key={m.id} tool={m.tool} toolLabels={toolLabels} />
-          );
         }
         if ("kind" in m) {
           return (

--- a/src/components/ui/agent/messages/AgentSidebarMessages.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.tsx
@@ -15,6 +15,11 @@ import {
   type AgentSidebarMultiQuestionAnswer,
   type AgentSidebarMultiQuestionLayout,
 } from "../asks/AgentSidebarMultiQuestion";
+import {
+  AgentSidebarToolCall,
+  type AgentToolCall,
+  type AgentToolCallLabels,
+} from "./AgentSidebarToolCall";
 
 export type AgentSidebarMessage =
   | {
@@ -39,6 +44,11 @@ export type AgentSidebarMessage =
       submitLabel?: string;
       status?: AgentSidebarMultiQuestionStatus;
       layout?: AgentSidebarMultiQuestionLayout;
+    }
+  | {
+      id: string;
+      role: "tool";
+      tool: AgentToolCall;
     };
 
 export interface AgentSidebarMessagesProps {
@@ -60,6 +70,8 @@ export interface AgentSidebarMessagesProps {
   onRerunMessage?: (messageId: string) => void;
   /** Localizable aria-labels for the action buttons (English defaults). */
   actionLabels?: AgentSidebarMessageActionLabels;
+  /** Localizable status/aria text for tool-call rows (English defaults). */
+  toolLabels?: AgentToolCallLabels;
   /** Render the brand logo once below the list when the last message is a
    *  finished agent message — a clear platform signature, never per-message. */
   showLogo?: boolean;
@@ -87,6 +99,7 @@ export function AgentSidebarMessages({
   onRateMessage,
   onRerunMessage,
   actionLabels,
+  toolLabels,
   showLogo = false,
   autoScroll = true,
   className,
@@ -139,6 +152,11 @@ export function AgentSidebarMessages({
       {messages.map((m) => {
         if (m.role === "user") {
           return <AgentSidebarUserMessage key={m.id} content={m.content} />;
+        }
+        if (m.role === "tool") {
+          return (
+            <AgentSidebarToolCall key={m.id} tool={m.tool} toolLabels={toolLabels} />
+          );
         }
         if ("kind" in m) {
           return (

--- a/src/components/ui/agent/messages/AgentSidebarToolCall.stories.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarToolCall.stories.tsx
@@ -1,0 +1,157 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { AgentSidebarToolCall } from "./AgentSidebarToolCall";
+import {
+  AgentSidebarMessages,
+  type AgentSidebarMessage,
+} from "./AgentSidebarMessages";
+
+const meta: Meta = {
+  title: "UI/Agent/ToolCall",
+  decorators: [
+    (Story) => (
+      <div className="w-[420px] rounded-2xl bg-on-background p-4 flex flex-col gap-2">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+export const Started: StoryObj = {
+  render: () => (
+    <AgentSidebarToolCall
+      tool={{ moduleSlug: "cms", tool: "get_page", status: "started" }}
+    />
+  ),
+};
+
+export const Done: StoryObj = {
+  render: () => (
+    <AgentSidebarToolCall
+      tool={{ moduleSlug: "cms", tool: "get_page", status: "done", durationMs: 1234 }}
+    />
+  ),
+};
+
+export const DoneWithDetail: StoryObj = {
+  render: () => (
+    <AgentSidebarToolCall
+      tool={{
+        moduleSlug: "cms",
+        tool: "get_page",
+        status: "done",
+        durationMs: 842,
+        args: { slug: "home" },
+        result: { id: "abc123", title: "Home", status: "published" },
+      }}
+    />
+  ),
+};
+
+export const ErrorNoDetail: StoryObj = {
+  render: () => (
+    <AgentSidebarToolCall
+      tool={{ moduleSlug: "cms", tool: "create_post", status: "error" }}
+    />
+  ),
+};
+
+export const ErrorWithDetail: StoryObj = {
+  render: () => (
+    <AgentSidebarToolCall
+      tool={{
+        moduleSlug: "cms",
+        tool: "create_post",
+        status: "error",
+        durationMs: 310,
+        args: { title: "Draft 1", body: "..." },
+        error: "permission_denied: you are not an admin of this app",
+      }}
+    />
+  ),
+};
+
+/** Account-scope call: 3-segment app · module · tool label. */
+export const WithAppSlug: StoryObj = {
+  render: () => (
+    <AgentSidebarToolCall
+      tool={{
+        appSlug: "kaohsiung-pet",
+        moduleSlug: "cms",
+        tool: "list_posts",
+        status: "done",
+        durationMs: 93,
+        args: { limit: 10 },
+        result: [{ id: "1" }, { id: "2" }],
+      }}
+    />
+  ),
+};
+
+/** B-2 caps 16 calls per turn — the stack must stay calm. */
+export const SixteenRowStack: StoryObj = {
+  render: () => {
+    const messages: AgentSidebarMessage[] = Array.from({ length: 16 }, (_, i) => ({
+      id: `tool-${i}`,
+      role: "tool" as const,
+      tool: {
+        moduleSlug: `module-${(i % 3) + 1}`,
+        tool: ["fetch_data", "write_record", "send_event"][i % 3],
+        status: (["started", "done", "error"] as const)[i % 3],
+        durationMs: i % 3 !== 0 ? 100 + i * 50 : undefined,
+      },
+    }));
+    return <AgentSidebarMessages messages={messages} autoScroll={false} />;
+  },
+};
+
+/** Replay: persisted rows carry full meta (args/result/duration). */
+export const ReplayShape: StoryObj = {
+  render: () => (
+    <AgentSidebarMessages
+      autoScroll={false}
+      messages={[
+        { id: "u1", role: "user", content: "List my recent posts" },
+        {
+          id: "t1",
+          role: "tool",
+          tool: {
+            moduleSlug: "cms",
+            tool: "list_posts",
+            status: "done",
+            durationMs: 214,
+            args: { limit: 5 },
+            result: [{ id: "p1", title: "Hello world" }],
+          },
+        },
+        {
+          id: "a1",
+          role: "agent",
+          content: 'You have 1 recent post: "Hello world".',
+        },
+      ]}
+    />
+  ),
+};
+
+/** Live: the SSE `tool` event carries no args/result — a transient started row. */
+export const LiveShape: StoryObj = {
+  render: () => (
+    <AgentSidebarMessages
+      autoScroll={false}
+      messages={[
+        { id: "u1", role: "user", content: "Publish the draft" },
+        {
+          id: "t1",
+          role: "tool",
+          tool: {
+            moduleSlug: "cms",
+            tool: "publish_post",
+            status: "started",
+          },
+        },
+      ]}
+    />
+  ),
+};

--- a/src/components/ui/agent/messages/AgentSidebarToolCall.test.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarToolCall.test.tsx
@@ -1,0 +1,183 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { AgentSidebarToolCall } from "./AgentSidebarToolCall";
+import { AgentSidebarMessages } from "./AgentSidebarMessages";
+
+beforeAll(() => {
+  // jsdom doesn't implement scrollIntoView (used by AgentSidebarMessages).
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(cleanup);
+
+describe("AgentSidebarToolCall", () => {
+  it("renders module · tool label in started state", () => {
+    render(
+      <AgentSidebarToolCall
+        tool={{ moduleSlug: "cms", tool: "get_page", status: "started" }}
+      />,
+    );
+    expect(screen.getByText("cms · get_page")).toBeInTheDocument();
+  });
+
+  it("renders app · module · tool label when appSlug present", () => {
+    render(
+      <AgentSidebarToolCall
+        tool={{ appSlug: "my-app", moduleSlug: "cms", tool: "get_page", status: "done" }}
+      />,
+    );
+    expect(screen.getByText("my-app · cms · get_page")).toBeInTheDocument();
+  });
+
+  it("formats durations of 1s and over as seconds", () => {
+    render(
+      <AgentSidebarToolCall
+        tool={{ moduleSlug: "cms", tool: "get_page", status: "done", durationMs: 1234 }}
+      />,
+    );
+    expect(screen.getByText("1.2s")).toBeInTheDocument();
+  });
+
+  it("formats durations under 1s as milliseconds", () => {
+    render(
+      <AgentSidebarToolCall
+        tool={{ moduleSlug: "cms", tool: "get_page", status: "done", durationMs: 842 }}
+      />,
+    );
+    expect(screen.getByText("842ms")).toBeInTheDocument();
+  });
+
+  it("is collapsed by default", () => {
+    render(
+      <AgentSidebarToolCall
+        tool={{ moduleSlug: "cms", tool: "get_page", status: "done", args: { slug: "home" } }}
+      />,
+    );
+    expect(screen.queryByText(/"slug"/)).not.toBeInTheDocument();
+  });
+
+  it("expands the detail panel on click when args exist", () => {
+    render(
+      <AgentSidebarToolCall
+        tool={{ moduleSlug: "cms", tool: "get_page", status: "done", args: { slug: "home" } }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText(/"slug"/)).toBeInTheDocument();
+  });
+
+  it("collapses the panel on second click", () => {
+    render(
+      <AgentSidebarToolCall
+        tool={{ moduleSlug: "cms", tool: "get_page", status: "done", args: { slug: "home" } }}
+      />,
+    );
+    const btn = screen.getByRole("button");
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    expect(screen.queryByText(/"slug"/)).not.toBeInTheDocument();
+  });
+
+  it("aria-expanded reflects open state", () => {
+    render(
+      <AgentSidebarToolCall
+        tool={{ moduleSlug: "cms", tool: "get_page", status: "done", result: { ok: true } }}
+      />,
+    );
+    const btn = screen.getByRole("button");
+    expect(btn).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(btn);
+    expect(btn).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("renders a non-interactive row when there is no detail", () => {
+    render(
+      <AgentSidebarToolCall
+        tool={{ moduleSlug: "cms", tool: "get_page", status: "done" }}
+      />,
+    );
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("shows the error text in the detail panel", () => {
+    render(
+      <AgentSidebarToolCall
+        tool={{
+          moduleSlug: "cms",
+          tool: "create_post",
+          status: "error",
+          error: "permission_denied",
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText("permission_denied")).toBeInTheDocument();
+  });
+
+  it("shows args and result sections with headers when both present", () => {
+    render(
+      <AgentSidebarToolCall
+        tool={{
+          moduleSlug: "cms",
+          tool: "get_page",
+          status: "done",
+          args: { slug: "home" },
+          result: { title: "Home" },
+        }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText("args")).toBeInTheDocument();
+    expect(screen.getByText("result")).toBeInTheDocument();
+  });
+
+  it("uses custom toolLabels for the status aria text", () => {
+    render(
+      <AgentSidebarToolCall
+        tool={{ moduleSlug: "cms", tool: "get_page", status: "started" }}
+        toolLabels={{ running: "En cours" }}
+      />,
+    );
+    expect(screen.getByRole("status").getAttribute("aria-label")).toContain(
+      "En cours",
+    );
+  });
+});
+
+describe("AgentSidebarMessages tool rows", () => {
+  it("renders role:'tool' items as tool-call rows, not bubbles", () => {
+    render(
+      <AgentSidebarMessages
+        messages={[
+          { id: "u1", role: "user", content: "Do it" },
+          {
+            id: "t1",
+            role: "tool",
+            tool: { moduleSlug: "cms", tool: "publish_post", status: "done", durationMs: 120 },
+          },
+          { id: "a1", role: "agent", content: "Published." },
+        ]}
+      />,
+    );
+    expect(screen.getByText("cms · publish_post")).toBeInTheDocument();
+    expect(screen.getByText("120ms")).toBeInTheDocument();
+  });
+
+  it("passes the list-level toolLabels down to tool rows", () => {
+    render(
+      <AgentSidebarMessages
+        toolLabels={{ running: "執行中" }}
+        messages={[
+          {
+            id: "t1",
+            role: "tool",
+            tool: { moduleSlug: "cms", tool: "get_page", status: "started" },
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByRole("status").getAttribute("aria-label")).toContain(
+      "執行中",
+    );
+  });
+});

--- a/src/components/ui/agent/messages/AgentSidebarToolCall.test.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarToolCall.test.tsx
@@ -131,6 +131,18 @@ describe("AgentSidebarToolCall", () => {
     expect(screen.getByText("result")).toBeInTheDocument();
   });
 
+  it("announces a non-expandable error row as an alert, not a status", () => {
+    render(
+      <AgentSidebarToolCall
+        tool={{ moduleSlug: "cms", tool: "create_post", status: "error" }}
+      />,
+    );
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.getByRole("alert").getAttribute("aria-label")).toContain(
+      "Failed",
+    );
+  });
+
   it("uses custom toolLabels for the status aria text", () => {
     render(
       <AgentSidebarToolCall
@@ -161,6 +173,34 @@ describe("AgentSidebarMessages tool rows", () => {
     );
     expect(screen.getByText("cms · publish_post")).toBeInTheDocument();
     expect(screen.getByText("120ms")).toBeInTheDocument();
+  });
+
+  it("collapses consecutive tool rows into a single gap-1 group", () => {
+    const { container } = render(
+      <AgentSidebarMessages
+        autoScroll={false}
+        messages={[
+          {
+            id: "t1",
+            role: "tool",
+            tool: { moduleSlug: "cms", tool: "get_page", status: "done" },
+          },
+          {
+            id: "t2",
+            role: "tool",
+            tool: { moduleSlug: "cms", tool: "publish_post", status: "done" },
+          },
+          { id: "a1", role: "agent", content: "Done." },
+        ]}
+      />,
+    );
+    // One gap-1 group + the agent bubble + the scroll anchor — the two tool
+    // rows must NOT be direct children of the gap-4 list.
+    const list = container.firstElementChild!;
+    expect(list.children).toHaveLength(3);
+    const group = list.children[0]!;
+    expect(group.className).toContain("gap-1");
+    expect(group.children).toHaveLength(2);
   });
 
   it("passes the list-level toolLabels down to tool rows", () => {

--- a/src/components/ui/agent/messages/AgentSidebarToolCall.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarToolCall.tsx
@@ -140,7 +140,8 @@ export function AgentSidebarToolCall({
       ) : (
         <div
           className="flex items-center gap-1.5 min-h-[24px]"
-          role="status"
+          // Errors are assertive (alert); anything else is an advisory status.
+          role={isError ? "alert" : "status"}
           aria-label={`${statusLabel}: ${label}`}
         >
           {rowContent}

--- a/src/components/ui/agent/messages/AgentSidebarToolCall.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarToolCall.tsx
@@ -1,0 +1,185 @@
+import { useState } from "react";
+import { cn } from "@/utils/cn";
+import { Icon } from "@/components/ui/media/icon/Icon";
+import { isDev } from "@/utils/env";
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "AgentSidebarToolCall",
+  description:
+    "Compact collapsible row showing one executed module tool call inside the agent message thread.",
+};
+
+/** One module tool call, camelCase at the kit boundary — the consumer maps
+ *  wire meta (snake_case replay rows, `slug__tool` SSE names) into this. */
+export interface AgentToolCall {
+  /** Present only for account-scope 3-segment calls (app · module · tool). */
+  appSlug?: string;
+  moduleSlug: string;
+  tool: string;
+  status: "started" | "done" | "error";
+  error?: string;
+  /** Milliseconds. Shown right-aligned (e.g. "1.2s") when present. */
+  durationMs?: number;
+  /** Raw args value — pretty-printed in the expandable detail panel. */
+  args?: unknown;
+  /** Raw result value — pretty-printed in the expandable detail panel. */
+  result?: unknown;
+}
+
+/** Localizable status/aria text for tool-call rows (English defaults). */
+export interface AgentToolCallLabels {
+  running?: string;
+  done?: string;
+  failed?: string;
+  showDetail?: string;
+  hideDetail?: string;
+}
+
+export interface AgentSidebarToolCallProps {
+  tool: AgentToolCall;
+  toolLabels?: AgentToolCallLabels;
+  className?: string;
+}
+
+const DEFAULT_LABELS: Required<AgentToolCallLabels> = {
+  running: "Running",
+  done: "Done",
+  failed: "Failed",
+  showDetail: "Show detail",
+  hideDetail: "Hide detail",
+};
+
+function formatDuration(ms: number): string {
+  return ms < 1000 ? `${ms}ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+
+export function AgentSidebarToolCall({
+  tool,
+  toolLabels,
+  className,
+}: AgentSidebarToolCallProps) {
+  const labels = { ...DEFAULT_LABELS, ...toolLabels };
+  const [open, setOpen] = useState(false);
+
+  const hasDetail =
+    tool.args !== undefined ||
+    tool.result !== undefined ||
+    tool.error !== undefined;
+  const isError = tool.status === "error";
+  const isStarted = tool.status === "started";
+
+  if (isDev && isError && !hasDetail) {
+    console.warn(
+      "[AgentSidebarToolCall] status=error without error/args/result — the row cannot explain the failure.",
+    );
+  }
+
+  const statusLabel = isStarted
+    ? labels.running
+    : isError
+      ? labels.failed
+      : labels.done;
+
+  const label = [tool.appSlug, tool.moduleSlug, tool.tool]
+    .filter(Boolean)
+    .join(" · ");
+
+  const leadingIcon = isStarted ? (
+    // Material Symbols has no animated glyph — border-arc spinner instead.
+    <span
+      className="inline-block w-[14px] h-[14px] rounded-full border-2 border-inverse-on-surface/30 border-t-inverse-on-surface animate-spin shrink-0"
+      aria-hidden
+    />
+  ) : (
+    <Icon
+      name={isError ? "error" : "check_circle"}
+      size={14}
+      className={cn("shrink-0", isError ? "text-error" : "text-inverse-on-surface/60")}
+    />
+  );
+
+  const rowContent = (
+    <>
+      {leadingIcon}
+      <span
+        className={cn(
+          "font-mono text-[11px] leading-none min-w-0 truncate flex-1",
+          isError ? "text-error" : "text-inverse-on-surface/60",
+        )}
+      >
+        {label}
+      </span>
+      {tool.durationMs !== undefined && !isStarted && (
+        <span className="font-mono text-[11px] leading-none text-inverse-on-surface/40 shrink-0 tabular-nums">
+          {formatDuration(tool.durationMs)}
+        </span>
+      )}
+      {hasDetail && (
+        <Icon
+          name={open ? "expand_less" : "expand_more"}
+          size={14}
+          className="text-inverse-on-surface/40 shrink-0"
+        />
+      )}
+    </>
+  );
+
+  return (
+    <div className={cn("flex flex-col gap-1", className)}>
+      {hasDetail ? (
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          aria-label={`${statusLabel}: ${label}. ${open ? labels.hideDetail : labels.showDetail}`}
+          className="flex items-center gap-1.5 min-h-[24px] w-full text-left"
+        >
+          {rowContent}
+        </button>
+      ) : (
+        <div
+          className="flex items-center gap-1.5 min-h-[24px]"
+          role="status"
+          aria-label={`${statusLabel}: ${label}`}
+        >
+          {rowContent}
+        </div>
+      )}
+      {open && hasDetail && (
+        <div className="rounded bg-inverse-on-surface/[0.08] max-h-40 overflow-y-auto p-2 space-y-2 font-mono text-[11px] leading-relaxed text-inverse-on-surface/70">
+          {tool.args !== undefined && (
+            <DetailSection label="args" text={JSON.stringify(tool.args, null, 2)} />
+          )}
+          {tool.result !== undefined && (
+            <DetailSection label="result" text={JSON.stringify(tool.result, null, 2)} />
+          )}
+          {tool.error !== undefined && (
+            <DetailSection label="error" text={tool.error} error />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DetailSection({
+  label,
+  text,
+  error = false,
+}: {
+  label: string;
+  text: string;
+  error?: boolean;
+}) {
+  return (
+    <section>
+      <p className={cn("mb-0.5", error ? "text-error/70" : "text-inverse-on-surface/40")}>
+        {label}
+      </p>
+      <pre className={cn("whitespace-pre-wrap break-all", error && "text-error")}>
+        {text}
+      </pre>
+    </section>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,12 @@ export {
   type AgentSidebarMessagesProps,
 } from "./components/ui/agent/messages/AgentSidebarMessages";
 export {
+  AgentSidebarToolCall,
+  type AgentSidebarToolCallProps,
+  type AgentToolCall,
+  type AgentToolCallLabels,
+} from "./components/ui/agent/messages/AgentSidebarToolCall";
+export {
   type AgentSidebarHistoryGroup,
   type AgentSidebarHistoryItem,
 } from "./components/ui/agent/sidebar/types";


### PR DESCRIPTION
## Summary
- New `AgentSidebarToolCall` component in `src/components/ui/agent/messages/` per the committed design (docs-temp/agent-tool-message-view/design.md): a compact ~24px collapsed row — leading spinner (started) / check (done) / error-ink icon (error), `module · tool` label (`app · module · tool` when `appSlug` is present) in 11px mono, right-aligned duration ("1.2s" / "842ms").
- Expandable only when args/result/error exist: `button` with `aria-expanded` toggles a pretty-printed JSON detail panel (mono 11px, `max-h-40` scroll, `bg-inverse-on-surface/[0.08]` rounded). Collapsed by default, local state. Raw JSON only — no markdown. No retry/cancel affordances.
- New `AgentSidebarMessage` union member `{ id, role: "tool", tool: AgentToolCall }`; `AgentSidebarMessages` renders tool rows inline (not as chat bubbles) and forwards a new list-level `toolLabels` prop.
- `AgentToolCall` is camelCase at the kit boundary (`{ appSlug?, moduleSlug, tool, status, error?, durationMs?, args?, result? }`) — wire names/snake_case meta are the consumer's mapping.
- `toolLabels` (`{ running, done, failed, showDetail, hideDetail }`) with EN defaults for aria/status text.
- Exports `AgentSidebarToolCall`, `AgentSidebarToolCallProps`, `AgentToolCall`, `AgentToolCallLabels` from `src/index.ts`. No version bump (rollup release later).
- Stories: started/done/error, with/without detail, app-slug 3-segment label, 16-row stack, replay-vs-live shapes.

## Test plan
- `pnpm typecheck` — green
- `pnpm test` — 633/633 passing (13 new tests: label variants, duration formatting, collapsed-by-default, expand/collapse, `aria-expanded`, non-interactive row without detail, error panel text, args+result headers, custom labels, messages-list integration, list-level `toolLabels` passthrough)
- `pnpm build` — green

## Decisions
- `toolLabels` is a list-level prop on `AgentSidebarMessagesProps` (matching the existing `actionLabels` idiom), not a per-message field — the design's union member is `{ id, role: "tool", tool }` only.
- Spinner is a Tailwind `animate-spin` border-arc span: Material Symbols has no animated glyph, and the kit's `Icon` only sets static font props.
- Done/error leading icons are `check_circle` / `error` glyphs; the design's "build icon" line was read as the icon slot of the row, with the per-status glyphs it lists (spinner/check/error).
- Non-expandable rows render as a plain `role="status"` div (no dead button); the whole row is the toggle target when detail exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)