### PR TITLE
feat(agent): controlled tabs with titles, history rename, queued-message slot

### DIFF
--- a/src/components/ui/agent/sidebar/AgentSidebar.stories.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebar.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { AgentSidebarHeader } from "./AgentSidebarHeader";
 import { AgentSidebarInput } from "./AgentSidebarInput";
@@ -7,6 +7,7 @@ import {
   type AgentSidebarMessage,
 } from "../messages/AgentSidebarMessages";
 import { mockAgentHistory, mockAgentMessages, mockAgentModels } from "./mock-data";
+import type { AgentSidebarHistoryGroup, ChatTab } from "./types";
 
 const meta: Meta = {
   title: "UI/Agent/Sidebar",
@@ -38,6 +39,76 @@ export const Header: StoryObj = {
   },
 };
 
+export const ControlledTabs: StoryObj = {
+  render: () => {
+    const [tabs, setTabs] = useState<ChatTab[]>([
+      { id: "conv-1", title: "New chat" },
+      { id: "conv-2", title: "Update display name" },
+    ]);
+    const [activeTabId, setActiveTabId] = useState("conv-1");
+    const nextIdRef = useRef(3);
+    const openTab = (title: string) => {
+      const tab = { id: `conv-${nextIdRef.current++}`, title };
+      setTabs((prev) => [...prev, tab]);
+      setActiveTabId(tab.id);
+    };
+    return (
+      <div className="bg-surface-container">
+        <AgentSidebarHeader
+          sidebarWidth={420}
+          onToggleCollapse={() => {}}
+          onClose={() => {}}
+          history={mockAgentHistory}
+          onSelectHistoryItem={(id) => {
+            // Consumer opens a history entry as a NEW tab.
+            const item = mockAgentHistory
+              .flatMap((g) => g.items)
+              .find((i) => i.id === id);
+            openTab(item?.title ?? "New chat");
+          }}
+          tabs={tabs}
+          activeTabId={activeTabId}
+          onSelectTab={setActiveTabId}
+          onCloseTab={(id) => {
+            const next = tabs.filter((t) => t.id !== id);
+            if (!next.length) return;
+            setTabs(next);
+            if (activeTabId === id) setActiveTabId(next[next.length - 1].id);
+          }}
+          onNewTab={() => openTab("New chat")}
+        />
+      </div>
+    );
+  },
+};
+
+export const HistoryRename: StoryObj = {
+  render: () => {
+    const [history, setHistory] = useState<AgentSidebarHistoryGroup[]>(mockAgentHistory);
+    return (
+      <div className="bg-surface-container">
+        <AgentSidebarHeader
+          sidebarWidth={420}
+          onToggleCollapse={() => {}}
+          onClose={() => {}}
+          history={history}
+          onSelectHistoryItem={(id) => console.log("open", id)}
+          onRenameConversation={(id, title) => {
+            setHistory((prev) =>
+              prev.map((g) => ({
+                ...g,
+                items: g.items.map((item) =>
+                  item.id === id ? { ...item, title } : item,
+                ),
+              })),
+            );
+          }}
+        />
+      </div>
+    );
+  },
+};
+
 export const Input: StoryObj = {
   render: () => (
     <div className="mt-auto bg-on-background rounded-b-2xl">
@@ -62,6 +133,46 @@ export const InputWithModelSelector: StoryObj = {
           models={mockAgentModels}
           selectedModelId={modelId}
           onSelectModel={setModelId}
+        />
+      </div>
+    );
+  },
+};
+
+export const QueuedMessage: StoryObj = {
+  render: () => {
+    const [queued, setQueued] = useState<string | undefined>(
+      "Summarize the last 3 deployments and show me any failures",
+    );
+    return (
+      <div className="mt-auto bg-on-background rounded-b-2xl">
+        <AgentSidebarInput
+          onSend={(msg) => console.log("Send:", msg)}
+          queuedMessage={queued}
+          onCancelQueued={() => setQueued(undefined)}
+        />
+      </div>
+    );
+  },
+};
+
+export const QueuedMessageWithModelSelector: StoryObj = {
+  render: () => {
+    const [queued, setQueued] = useState<string | undefined>(
+      "Summarize the last 3 deployments",
+    );
+    const [modelId, setModelId] = useState(
+      "anthropic.claude-haiku-4-5-20251001-v1:0",
+    );
+    return (
+      <div className="mt-auto bg-on-background rounded-b-2xl">
+        <AgentSidebarInput
+          onSend={(msg) => console.log("Send:", msg)}
+          models={mockAgentModels}
+          selectedModelId={modelId}
+          onSelectModel={setModelId}
+          queuedMessage={queued}
+          onCancelQueued={() => setQueued(undefined)}
         />
       </div>
     );

--- a/src/components/ui/agent/sidebar/AgentSidebar.stories.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebar.stories.tsx
@@ -1,7 +1,7 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { AgentSidebarHeader } from "./AgentSidebarHeader";
-import { AgentSidebarInput } from "./AgentSidebarInput";
+import { AgentSidebarInput, type AgentQueuedMessage } from "./AgentSidebarInput";
 import {
   AgentSidebarMessages,
   type AgentSidebarMessage,
@@ -140,12 +140,15 @@ export const Input: StoryObj = {
   },
 };
 
-/** Queued-message chip pinned above the textarea while a reply streams. */
+/** Queued messages pinned above the textarea while a reply streams —
+ *  several stack in send order, each individually cancellable. */
 export const QueuedMessage: StoryObj = {
   render: () => {
-    const [queued, setQueued] = useState<string | undefined>(
-      "Summarize the last 3 deployments and show me any failures",
-    );
+    const [queued, setQueued] = useState<AgentQueuedMessage[]>([
+      { id: "q-1", text: "Summarize the last 3 deployments and show me any failures" },
+      { id: "q-2", text: "Then list members who joined this week" },
+      { id: "q-3", text: "And draft a release note from the changelog" },
+    ]);
     const [modelId, setModelId] = useState(DEFAULT_MODEL_ID);
     return (
       <div className="mt-auto bg-on-background rounded-b-2xl">
@@ -154,18 +157,26 @@ export const QueuedMessage: StoryObj = {
           models={mockAgentModels}
           selectedModelId={modelId}
           onSelectModel={setModelId}
-          queuedMessage={queued}
-          onCancelQueued={() => setQueued(undefined)}
+          queuedMessages={queued}
+          onCancelQueued={(id) => setQueued((q) => q.filter((m) => m.id !== id))}
         />
       </div>
     );
   },
 };
 
+/** Full sidebar with live queue behavior: sending while the agent is still
+ *  replying queues the message above the input; queued messages auto-send
+ *  in order as each reply finishes. */
 export const Playground: StoryObj = {
   render: () => {
     const [messages, setMessages] = useState<AgentSidebarMessage[]>(
       mockAgentMessages,
+    );
+    const [queued, setQueued] = useState<AgentQueuedMessage[]>([]);
+    const nextQueueId = useRef(1);
+    const isStreaming = messages.some(
+      (m) => m.role === "agent" && "streaming" in m && m.streaming,
     );
 
     const patchMessage = (id: string, patch: Record<string, unknown>) => {
@@ -176,7 +187,7 @@ export const Playground: StoryObj = {
       );
     };
 
-    const handleSend = (content: string) => {
+    const reallySend = (content: string) => {
       const userId = `u-${Date.now()}`;
       const agentId = `a-${Date.now()}`;
       setMessages((prev) => [
@@ -189,8 +200,30 @@ export const Playground: StoryObj = {
           content: "Got it — let me look into that.",
           streaming: false,
         });
-      }, 1500);
+      }, 2500);
     };
+
+    // Send while a reply is streaming → queue instead (the consumer contract
+    // the kit's queuedMessages slot is designed for).
+    const handleSend = (content: string) => {
+      if (isStreaming) {
+        setQueued((q) => [
+          ...q,
+          { id: `q-${nextQueueId.current++}`, text: content },
+        ]);
+        return;
+      }
+      reallySend(content);
+    };
+
+    // Reply finished → flush the next queued message.
+    useEffect(() => {
+      if (isStreaming || queued.length === 0) return;
+      const [next, ...rest] = queued;
+      setQueued(rest);
+      reallySend(next.text);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isStreaming, queued.length]);
 
     return (
       <>
@@ -211,6 +244,10 @@ export const Playground: StoryObj = {
             onMic={() => console.log("mic")}
             models={mockAgentModels}
             selectedModelId={DEFAULT_MODEL_ID}
+            queuedMessages={queued}
+            onCancelQueued={(id) =>
+              setQueued((q) => q.filter((m) => m.id !== id))
+            }
           />
         </div>
       </>

--- a/src/components/ui/agent/sidebar/AgentSidebar.stories.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebar.stories.tsx
@@ -9,6 +9,8 @@ import {
 import { mockAgentHistory, mockAgentMessages, mockAgentModels } from "./mock-data";
 import type { AgentSidebarHistoryGroup, ChatTab } from "./types";
 
+const DEFAULT_MODEL_ID = "anthropic.claude-haiku-4-5-20251001-v1:0";
+
 const meta: Meta = {
   title: "UI/Agent/Sidebar",
   decorators: [
@@ -22,6 +24,7 @@ const meta: Meta = {
 
 export default meta;
 
+/** Uncontrolled header: internal tab state, history open/select only. */
 export const Header: StoryObj = {
   render: () => {
     const [width, setWidth] = useState(420);
@@ -39,6 +42,8 @@ export const Header: StoryObj = {
   },
 };
 
+/** Controlled tabs: titles from the consumer, history opens as a NEW tab,
+ *  long titles ellipsize within the strip's allotment. */
 export const ControlledTabs: StoryObj = {
   render: () => {
     const [tabs, setTabs] = useState<ChatTab[]>([
@@ -60,7 +65,6 @@ export const ControlledTabs: StoryObj = {
           onClose={() => {}}
           history={mockAgentHistory}
           onSelectHistoryItem={(id) => {
-            // Consumer opens a history entry as a NEW tab.
             const item = mockAgentHistory
               .flatMap((g) => g.items)
               .find((i) => i.id === id);
@@ -82,7 +86,8 @@ export const ControlledTabs: StoryObj = {
   },
 };
 
-export const HistoryRename: StoryObj = {
+/** History row actions: hover edit (inline rename) + hover delete. */
+export const History: StoryObj = {
   render: () => {
     const [history, setHistory] = useState<AgentSidebarHistoryGroup[]>(mockAgentHistory);
     return (
@@ -103,33 +108,29 @@ export const HistoryRename: StoryObj = {
               })),
             );
           }}
+          onDeleteConversation={(id) => {
+            setHistory((prev) =>
+              prev
+                .map((g) => ({ ...g, items: g.items.filter((item) => item.id !== id) }))
+                .filter((g) => g.items.length > 0),
+            );
+          }}
         />
       </div>
     );
   },
 };
 
+/** Composer with the model selector — the realistic host configuration. */
 export const Input: StoryObj = {
-  render: () => (
-    <div className="mt-auto bg-on-background rounded-b-2xl">
-      <AgentSidebarInput
-        onSend={(msg) => console.log("Send:", msg)}
-        onAttachFile={() => console.log("attach")}
-        onMic={() => console.log("mic")}
-      />
-    </div>
-  ),
-};
-
-export const InputWithModelSelector: StoryObj = {
   render: () => {
-    const [modelId, setModelId] = useState(
-      "anthropic.claude-haiku-4-5-20251001-v1:0",
-    );
+    const [modelId, setModelId] = useState(DEFAULT_MODEL_ID);
     return (
       <div className="mt-auto bg-on-background rounded-b-2xl">
         <AgentSidebarInput
           onSend={(msg) => console.log("Send:", msg)}
+          onAttachFile={() => console.log("attach")}
+          onMic={() => console.log("mic")}
           models={mockAgentModels}
           selectedModelId={modelId}
           onSelectModel={setModelId}
@@ -139,31 +140,13 @@ export const InputWithModelSelector: StoryObj = {
   },
 };
 
+/** Queued-message chip pinned above the textarea while a reply streams. */
 export const QueuedMessage: StoryObj = {
   render: () => {
     const [queued, setQueued] = useState<string | undefined>(
       "Summarize the last 3 deployments and show me any failures",
     );
-    return (
-      <div className="mt-auto bg-on-background rounded-b-2xl">
-        <AgentSidebarInput
-          onSend={(msg) => console.log("Send:", msg)}
-          queuedMessage={queued}
-          onCancelQueued={() => setQueued(undefined)}
-        />
-      </div>
-    );
-  },
-};
-
-export const QueuedMessageWithModelSelector: StoryObj = {
-  render: () => {
-    const [queued, setQueued] = useState<string | undefined>(
-      "Summarize the last 3 deployments",
-    );
-    const [modelId, setModelId] = useState(
-      "anthropic.claude-haiku-4-5-20251001-v1:0",
-    );
+    const [modelId, setModelId] = useState(DEFAULT_MODEL_ID);
     return (
       <div className="mt-auto bg-on-background rounded-b-2xl">
         <AgentSidebarInput
@@ -227,7 +210,7 @@ export const Playground: StoryObj = {
             onAttachFile={() => console.log("attach")}
             onMic={() => console.log("mic")}
             models={mockAgentModels}
-            selectedModelId="anthropic.claude-haiku-4-5-20251001-v1:0"
+            selectedModelId={DEFAULT_MODEL_ID}
           />
         </div>
       </>

--- a/src/components/ui/agent/sidebar/AgentSidebar.test.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebar.test.tsx
@@ -211,6 +211,54 @@ describe("AgentSidebarHeader history rename", () => {
   });
 });
 
+describe("AgentSidebarHeader history delete", () => {
+  const historyData: AgentSidebarHistoryGroup[] = [
+    {
+      label: "Today",
+      items: [{ id: "h-1", title: "My conversation", updatedAt: "2026-06-12T10:00:00Z" }],
+    },
+  ];
+
+  const renderHistory = (props?: {
+    onDelete?: (id: string) => void;
+    onSelect?: (id: string) => void;
+  }) =>
+    render(
+      <AgentSidebarHeader
+        sidebarWidth={400}
+        onToggleCollapse={() => {}}
+        onClose={() => {}}
+        history={historyData}
+        onSelectHistoryItem={props?.onSelect ?? (() => {})}
+        onDeleteConversation={props?.onDelete}
+      />,
+    );
+
+  const openHistory = () => fireEvent.click(screen.getByLabelText("Chat history"));
+
+  it("shows the delete button when onDeleteConversation is provided", () => {
+    renderHistory({ onDelete: () => {} });
+    openHistory();
+    expect(screen.getByLabelText("Delete conversation")).toBeInTheDocument();
+  });
+
+  it("hides the delete button when onDeleteConversation is absent", () => {
+    renderHistory();
+    openHistory();
+    expect(screen.queryByLabelText("Delete conversation")).not.toBeInTheDocument();
+  });
+
+  it("calls onDeleteConversation with the row id, without opening the conversation", () => {
+    const onDelete = vi.fn();
+    const onSelect = vi.fn();
+    renderHistory({ onDelete, onSelect });
+    openHistory();
+    fireEvent.click(screen.getByLabelText("Delete conversation"));
+    expect(onDelete).toHaveBeenCalledWith("h-1");
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});
+
 describe("AgentSidebarInput", () => {
   it("renders textarea", () => {
     render(<AgentSidebarInput />);

--- a/src/components/ui/agent/sidebar/AgentSidebar.test.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebar.test.tsx
@@ -138,11 +138,13 @@ describe("AgentSidebarHeader history rename", () => {
     expect(screen.queryByLabelText("Rename conversation")).not.toBeInTheDocument();
   });
 
-  it("entering edit mode swaps the row to an input", () => {
+  it("entering edit mode swaps the row to an input labeled with the title", () => {
     renderHistory(() => {});
     openHistory();
     fireEvent.click(screen.getByLabelText("Rename conversation"));
-    expect(screen.getByLabelText("Rename conversation")).toBeInstanceOf(HTMLInputElement);
+    expect(screen.getByLabelText("Rename conversation: My conversation")).toBeInstanceOf(
+      HTMLInputElement,
+    );
   });
 
   it("Enter commits the trimmed rename", () => {
@@ -150,7 +152,7 @@ describe("AgentSidebarHeader history rename", () => {
     renderHistory(onRename);
     openHistory();
     fireEvent.click(screen.getByLabelText("Rename conversation"));
-    const input = screen.getByLabelText("Rename conversation");
+    const input = screen.getByLabelText(/^Rename conversation:/);
     fireEvent.change(input, { target: { value: "  New title  " } });
     fireEvent.keyDown(input, { key: "Enter" });
     expect(onRename).toHaveBeenCalledWith("h-1", "New title");
@@ -161,7 +163,7 @@ describe("AgentSidebarHeader history rename", () => {
     renderHistory(onRename);
     openHistory();
     fireEvent.click(screen.getByLabelText("Rename conversation"));
-    fireEvent.keyDown(screen.getByLabelText("Rename conversation"), { key: "Escape" });
+    fireEvent.keyDown(screen.getByLabelText(/^Rename conversation:/), { key: "Escape" });
     expect(onRename).not.toHaveBeenCalled();
     expect(screen.getByText("My conversation")).toBeInTheDocument();
   });
@@ -171,10 +173,24 @@ describe("AgentSidebarHeader history rename", () => {
     renderHistory(onRename);
     openHistory();
     fireEvent.click(screen.getByLabelText("Rename conversation"));
-    const input = screen.getByLabelText("Rename conversation");
+    const input = screen.getByLabelText(/^Rename conversation:/);
     fireEvent.change(input, { target: { value: "   " } });
     fireEvent.keyDown(input, { key: "Enter" });
     expect(onRename).not.toHaveBeenCalled();
+  });
+
+  it("exits edit mode when the dropdown is dismissed while renaming", () => {
+    renderHistory(() => {});
+    openHistory();
+    fireEvent.click(screen.getByLabelText("Rename conversation"));
+    fireEvent.change(screen.getByLabelText(/^Rename conversation:/), {
+      target: { value: "half-typed" },
+    });
+    // Click-outside dismissal while the rename is in progress.
+    fireEvent.mouseDown(document.body);
+    openHistory();
+    expect(screen.getByText("My conversation")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
 
   it("does not open the conversation when entering edit mode", () => {

--- a/src/components/ui/agent/sidebar/AgentSidebar.test.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebar.test.tsx
@@ -319,27 +319,41 @@ describe("AgentSidebarInput", () => {
   });
 });
 
-describe("AgentSidebarInput queued message", () => {
-  it("renders the chip with full text in the title attr", () => {
-    render(<AgentSidebarInput queuedMessage="Summarize the logs" />);
+describe("AgentSidebarInput queued messages", () => {
+  const queue = (...texts: string[]) =>
+    texts.map((text, i) => ({ id: `q-${i + 1}`, text }));
+
+  it("renders each row with full text in the title attr", () => {
+    render(<AgentSidebarInput queuedMessages={queue("Summarize the logs", "List new members")} />);
     expect(screen.getByTitle("Summarize the logs")).toBeInTheDocument();
+    expect(screen.getByTitle("List new members")).toBeInTheDocument();
+    expect(screen.getAllByLabelText("Cancel queued message")).toHaveLength(2);
   });
 
-  it("does not render the chip when queuedMessage is absent", () => {
-    render(<AgentSidebarInput />);
+  it("shows the queued prefix on the first row only", () => {
+    render(<AgentSidebarInput queuedMessages={queue("First", "Second")} />);
+    expect(screen.getAllByText("Queued")).toHaveLength(1);
+  });
+
+  it("does not render rows when the queue is absent or empty", () => {
+    const { rerender } = render(<AgentSidebarInput />);
+    expect(screen.queryByLabelText("Cancel queued message")).not.toBeInTheDocument();
+    rerender(<AgentSidebarInput queuedMessages={[]} />);
     expect(screen.queryByLabelText("Cancel queued message")).not.toBeInTheDocument();
   });
 
-  it("calls onCancelQueued when X is clicked", () => {
+  it("calls onCancelQueued with the clicked row's id", () => {
     const onCancel = vi.fn();
-    render(<AgentSidebarInput queuedMessage="Summarize the logs" onCancelQueued={onCancel} />);
-    fireEvent.click(screen.getByLabelText("Cancel queued message"));
-    expect(onCancel).toHaveBeenCalledOnce();
+    render(
+      <AgentSidebarInput queuedMessages={queue("First", "Second")} onCancelQueued={onCancel} />,
+    );
+    fireEvent.click(screen.getAllByLabelText("Cancel queued message")[1]);
+    expect(onCancel).toHaveBeenCalledExactlyOnceWith("q-2");
   });
 
-  it("keeps the textarea usable while the chip is shown", () => {
+  it("keeps the textarea usable while rows are shown", () => {
     const onSend = vi.fn();
-    render(<AgentSidebarInput queuedMessage="A queued message" onSend={onSend} />);
+    render(<AgentSidebarInput queuedMessages={queue("A queued message")} onSend={onSend} />);
     const textarea = screen.getByLabelText("Message to agent");
     fireEvent.change(textarea, { target: { value: "hello" } });
     fireEvent.keyDown(textarea, { key: "Enter" });
@@ -349,7 +363,7 @@ describe("AgentSidebarInput queued message", () => {
   it("uses custom labels overrides", () => {
     render(
       <AgentSidebarInput
-        queuedMessage="Something"
+        queuedMessages={queue("Something")}
         onCancelQueued={() => {}}
         labels={{ cancelQueuedLabel: "Remove queued", queuedPrefix: "Next up" }}
       />,

--- a/src/components/ui/agent/sidebar/AgentSidebar.test.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebar.test.tsx
@@ -73,6 +73,34 @@ describe("AgentSidebarHeader controlled tabs", () => {
     expect(screen.queryByText("Chat 1")).not.toBeInTheDocument();
   });
 
+  it("collapses tabs into the overflow dropdown when the strip is narrow", () => {
+    // 280 clientWidth − 46 strip padding = 234 available; three 100px tabs
+    // (312 with gaps) don't fit → 1 visible + 2 in the ⋯ dropdown. Before the
+    // padding fix the math compared against the raw 280 and squeezed tabs
+    // inline instead of overflowing.
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      value: 280,
+    });
+    try {
+      renderControlled({
+        tabs: [
+          { id: "a", title: "New chat" },
+          { id: "b", title: "Settings help" },
+          { id: "c", title: "Update display name" },
+        ],
+      });
+      expect(screen.getAllByRole("tab")).toHaveLength(1);
+      expect(screen.getByLabelText("2 more tabs")).toBeInTheDocument();
+      expect(screen.queryByLabelText("New chat")).not.toBeInTheDocument();
+    } finally {
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+        configurable: true,
+        value: 400,
+      });
+    }
+  });
+
   it("calls onNewTab when + is clicked instead of adding an internal tab", () => {
     const onNewTab = vi.fn();
     renderControlled({ onNewTab });

--- a/src/components/ui/agent/sidebar/AgentSidebar.test.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebar.test.tsx
@@ -1,7 +1,8 @@
 import { cleanup, render, screen, fireEvent } from "@testing-library/react";
-import { describe, expect, it, vi, afterEach } from "vitest";
+import { describe, expect, it, vi, afterEach, beforeAll, afterAll } from "vitest";
 import { AgentSidebarHeader } from "./AgentSidebarHeader";
 import { AgentSidebarInput } from "./AgentSidebarInput";
+import type { AgentSidebarHistoryGroup, ChatTab } from "./types";
 
 afterEach(cleanup);
 
@@ -28,6 +29,169 @@ describe("AgentSidebarHeader", () => {
     );
     fireEvent.click(screen.getByLabelText("Close sidebar"));
     expect(onClose).toHaveBeenCalledOnce();
+  });
+});
+
+describe("AgentSidebarHeader controlled tabs", () => {
+  // jsdom reports clientWidth 0, which would collapse the strip to a single
+  // visible tab and swap the + button for the overflow trigger. Report a
+  // real width so both tabs render inline.
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      value: 400,
+    });
+  });
+  afterAll(() => {
+    Reflect.deleteProperty(HTMLElement.prototype, "clientWidth");
+  });
+
+  const makeTabs = (): ChatTab[] => [
+    { id: "a", title: "New chat" },
+    { id: "b", title: "Settings help" },
+  ];
+
+  const renderControlled = (overrides: Partial<Parameters<typeof AgentSidebarHeader>[0]> = {}) =>
+    render(
+      <AgentSidebarHeader
+        sidebarWidth={400}
+        onToggleCollapse={() => {}}
+        onClose={() => {}}
+        tabs={makeTabs()}
+        activeTabId="a"
+        onSelectTab={() => {}}
+        onCloseTab={() => {}}
+        onNewTab={() => {}}
+        {...overrides}
+      />,
+    );
+
+  it("renders supplied tab titles instead of internal labels", () => {
+    renderControlled();
+    expect(screen.getByText("New chat")).toBeInTheDocument();
+    expect(screen.getByText("Settings help")).toBeInTheDocument();
+    expect(screen.queryByText("Chat 1")).not.toBeInTheDocument();
+  });
+
+  it("calls onNewTab when + is clicked instead of adding an internal tab", () => {
+    const onNewTab = vi.fn();
+    renderControlled({ onNewTab });
+    fireEvent.click(screen.getByLabelText("New chat"));
+    expect(onNewTab).toHaveBeenCalledOnce();
+    expect(screen.getAllByRole("tab")).toHaveLength(2);
+  });
+
+  it("calls onSelectTab with the clicked tab id", () => {
+    const onSelectTab = vi.fn();
+    renderControlled({ onSelectTab });
+    fireEvent.click(screen.getByText("Settings help"));
+    expect(onSelectTab).toHaveBeenCalledWith("b");
+  });
+
+  it("calls onCloseTab with the closed tab id", () => {
+    const onCloseTab = vi.fn();
+    renderControlled({ onCloseTab });
+    fireEvent.click(screen.getByLabelText("Close Settings help"));
+    expect(onCloseTab).toHaveBeenCalledWith("b");
+  });
+
+  it("marks the controlled active tab as selected", () => {
+    renderControlled({ activeTabId: "b" });
+    expect(screen.getByRole("tab", { name: /Settings help/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+});
+
+describe("AgentSidebarHeader history rename", () => {
+  const historyData: AgentSidebarHistoryGroup[] = [
+    {
+      label: "Today",
+      items: [{ id: "h-1", title: "My conversation", updatedAt: "2026-06-12T10:00:00Z" }],
+    },
+  ];
+
+  const renderHistory = (onRename?: (id: string, title: string) => void) =>
+    render(
+      <AgentSidebarHeader
+        sidebarWidth={400}
+        onToggleCollapse={() => {}}
+        onClose={() => {}}
+        history={historyData}
+        onSelectHistoryItem={() => {}}
+        onRenameConversation={onRename}
+      />,
+    );
+
+  const openHistory = () => fireEvent.click(screen.getByLabelText("Chat history"));
+
+  it("shows the rename button when onRenameConversation is provided", () => {
+    renderHistory(() => {});
+    openHistory();
+    expect(screen.getByLabelText("Rename conversation")).toBeInTheDocument();
+  });
+
+  it("hides the rename button when onRenameConversation is absent", () => {
+    renderHistory();
+    openHistory();
+    expect(screen.queryByLabelText("Rename conversation")).not.toBeInTheDocument();
+  });
+
+  it("entering edit mode swaps the row to an input", () => {
+    renderHistory(() => {});
+    openHistory();
+    fireEvent.click(screen.getByLabelText("Rename conversation"));
+    expect(screen.getByLabelText("Rename conversation")).toBeInstanceOf(HTMLInputElement);
+  });
+
+  it("Enter commits the trimmed rename", () => {
+    const onRename = vi.fn();
+    renderHistory(onRename);
+    openHistory();
+    fireEvent.click(screen.getByLabelText("Rename conversation"));
+    const input = screen.getByLabelText("Rename conversation");
+    fireEvent.change(input, { target: { value: "  New title  " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onRename).toHaveBeenCalledWith("h-1", "New title");
+  });
+
+  it("Esc cancels without calling onRenameConversation", () => {
+    const onRename = vi.fn();
+    renderHistory(onRename);
+    openHistory();
+    fireEvent.click(screen.getByLabelText("Rename conversation"));
+    fireEvent.keyDown(screen.getByLabelText("Rename conversation"), { key: "Escape" });
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.getByText("My conversation")).toBeInTheDocument();
+  });
+
+  it("does not commit an empty rename", () => {
+    const onRename = vi.fn();
+    renderHistory(onRename);
+    openHistory();
+    fireEvent.click(screen.getByLabelText("Rename conversation"));
+    const input = screen.getByLabelText("Rename conversation");
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onRename).not.toHaveBeenCalled();
+  });
+
+  it("does not open the conversation when entering edit mode", () => {
+    const onSelect = vi.fn();
+    render(
+      <AgentSidebarHeader
+        sidebarWidth={400}
+        onToggleCollapse={() => {}}
+        onClose={() => {}}
+        history={historyData}
+        onSelectHistoryItem={onSelect}
+        onRenameConversation={() => {}}
+      />,
+    );
+    openHistory();
+    fireEvent.click(screen.getByLabelText("Rename conversation"));
+    expect(onSelect).not.toHaveBeenCalled();
   });
 });
 
@@ -60,6 +224,46 @@ describe("AgentSidebarInput", () => {
     render(<AgentSidebarInput onSend={onSend} />);
     fireEvent.click(screen.getByLabelText("Send message"));
     expect(onSend).not.toHaveBeenCalled();
+  });
+});
+
+describe("AgentSidebarInput queued message", () => {
+  it("renders the chip with full text in the title attr", () => {
+    render(<AgentSidebarInput queuedMessage="Summarize the logs" />);
+    expect(screen.getByTitle("Summarize the logs")).toBeInTheDocument();
+  });
+
+  it("does not render the chip when queuedMessage is absent", () => {
+    render(<AgentSidebarInput />);
+    expect(screen.queryByLabelText("Cancel queued message")).not.toBeInTheDocument();
+  });
+
+  it("calls onCancelQueued when X is clicked", () => {
+    const onCancel = vi.fn();
+    render(<AgentSidebarInput queuedMessage="Summarize the logs" onCancelQueued={onCancel} />);
+    fireEvent.click(screen.getByLabelText("Cancel queued message"));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the textarea usable while the chip is shown", () => {
+    const onSend = vi.fn();
+    render(<AgentSidebarInput queuedMessage="A queued message" onSend={onSend} />);
+    const textarea = screen.getByLabelText("Message to agent");
+    fireEvent.change(textarea, { target: { value: "hello" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+    expect(onSend).toHaveBeenCalledWith("hello");
+  });
+
+  it("uses custom labels overrides", () => {
+    render(
+      <AgentSidebarInput
+        queuedMessage="Something"
+        onCancelQueued={() => {}}
+        labels={{ cancelQueuedLabel: "Remove queued", queuedPrefix: "Next up" }}
+      />,
+    );
+    expect(screen.getByLabelText("Remove queued")).toBeInTheDocument();
+    expect(screen.getByText("Next up")).toBeInTheDocument();
   });
 });
 

--- a/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
@@ -434,7 +434,10 @@ export function AgentSidebarHeader({
           width changes snap during a live sidebar drag instead of easing
           through whatever transition class the ancestor chain inherits. */}
       <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-10 pr-1.5 gap-1.5 !transition-none">
-        <div role="tablist" aria-label="Chat sessions" className="flex flex-1 h-full gap-1.5 !transition-none">
+        {/* min-w-0 here too: without it a long tab title inflates the
+            tablist's min-width:auto past the strip's content area and the
+            last tab gets clipped flat by overflow-hidden. */}
+        <div role="tablist" aria-label="Chat sessions" className="flex flex-1 min-w-0 h-full gap-1.5 !transition-none">
           {visibleTabs.map((tab) => {
             const isActive = tab.id === activeTabId;
             return (
@@ -483,19 +486,21 @@ export function AgentSidebarHeader({
         </div>
       </div>
 
-      {/* Actions — z-10 keeps the icons above the active-tab notch overlay
-          (z-[5]); when the active tab is last in the strip its arc overhang
-          otherwise paints over them, dark-on-dark. */}
-      <div ref={overflowRef} className="relative z-10 flex items-center gap-0.5 pr-1 shrink-0">
+      {/* Actions. Each button gets its own relative z-10 so it paints above
+          the active-tab notch overlay (z-[5]) when the active tab is last in
+          the strip — a z on the CONTAINER would instead create one stacking
+          context that traps the ⋯ trigger's z-[51] beneath the header-level
+          overflow dropdown (z-50), hiding the trigger inside its notch. */}
+      <div ref={overflowRef} className="flex items-center gap-0.5 pr-1 shrink-0">
         {overflowTabs.length > 0 ? (
           <div ref={triggerBtnRef} className="relative z-[51]">
             <IconButton icon="more_horiz" variant="text" size="sm" className="text-on-surface" onClick={() => setShowOverflow(!showOverflow)} aria-label={`${overflowTabs.length} more tabs`} />
           </div>
         ) : (
-          <IconButton icon="add" variant="text" size="sm" className="text-on-surface" onClick={handleAddTab} aria-label={labels?.newChatLabel ?? "New chat"} />
+          <IconButton icon="add" variant="text" size="sm" className="relative z-10 text-on-surface" onClick={handleAddTab} aria-label={labels?.newChatLabel ?? "New chat"} />
         )}
-        <IconButton icon={isCollapsed ? "unfold_more" : "unfold_less"} variant="text" size="sm" className="rotate-90 text-on-surface" onClick={onToggleCollapse} aria-label={isCollapsed ? "Expand" : "Collapse"} />
-        <IconButton icon="close" variant="text" size="sm" className="text-on-surface" onClick={onClose} aria-label="Close sidebar" />
+        <IconButton icon={isCollapsed ? "unfold_more" : "unfold_less"} variant="text" size="sm" className="relative z-10 rotate-90 text-on-surface" onClick={onToggleCollapse} aria-label={isCollapsed ? "Expand" : "Collapse"} />
+        <IconButton icon="close" variant="text" size="sm" className="relative z-10 text-on-surface" onClick={onClose} aria-label="Close sidebar" />
       </div>
 
       {/* Overflow dropdown with notch tab connecting to the ... button */}

--- a/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
@@ -1,16 +1,12 @@
 import { useState, useRef, useEffect, useCallback, useLayoutEffect } from "react";
 import { flushSync } from "react-dom";
 import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 import { Icon } from "@/components/ui/media/icon/Icon";
 import { Notch } from "@/components/ui/surfaces/notch/Notch";
 import { useClickOutside } from "@/hooks/useClickOutside";
-import type { AgentSidebarHistoryGroup } from "./types";
-
-interface ChatTab {
-  id: string;
-  title: string;
-}
+import type { AgentSidebarHeaderLabels, AgentSidebarHistoryGroup, ChatTab } from "./types";
 
 export interface AgentSidebarHeaderProps {
   sidebarWidth: number;
@@ -19,6 +15,22 @@ export interface AgentSidebarHeaderProps {
   /** Past conversations grouped by date — shown in the arrow-down dropdown. */
   history?: AgentSidebarHistoryGroup[];
   onSelectHistoryItem?: (id: string) => void;
+  /** Controlled tab list. Provide together with activeTabId/onSelectTab/onCloseTab/onNewTab;
+   *  omit all five to keep the internal uncontrolled tab state. */
+  tabs?: ChatTab[];
+  /** Controlled active tab id. */
+  activeTabId?: string;
+  /** Called when the user clicks a tab. Consumer updates activeTabId. */
+  onSelectTab?: (id: string) => void;
+  /** Called when the user clicks the X on a tab. Consumer removes it from tabs. */
+  onCloseTab?: (id: string) => void;
+  /** Called when the user clicks + or the overflow "New chat" entry. Consumer appends a tab. */
+  onNewTab?: () => void;
+  /** Enables the hover rename affordance on history rows.
+   *  Called with the trimmed title (1-200 chars) when the user commits an inline rename. */
+  onRenameConversation?: (id: string, title: string) => void;
+  /** Label overrides. All have EN defaults. */
+  labels?: AgentSidebarHeaderLabels;
 }
 
 const TAB_WIDTH = 100;
@@ -47,11 +59,41 @@ export function AgentSidebarHeader({
   onClose,
   history,
   onSelectHistoryItem,
+  tabs: propTabs,
+  activeTabId: propActiveTabId,
+  onSelectTab,
+  onCloseTab,
+  onNewTab,
+  onRenameConversation,
+  labels,
 }: AgentSidebarHeaderProps) {
   const isCollapsed = sidebarWidth <= 350;
 
-  const [tabs, setTabs] = useState<ChatTab[]>([{ id: "1", title: "Chat 1" }]);
-  const [activeTabId, setActiveTabId] = useState("1");
+  const isControlled =
+    propTabs !== undefined &&
+    propActiveTabId !== undefined &&
+    onSelectTab !== undefined &&
+    onCloseTab !== undefined &&
+    onNewTab !== undefined;
+
+  if (isDev && !isControlled) {
+    const wired = [propTabs, propActiveTabId, onSelectTab, onCloseTab, onNewTab].filter(
+      (p) => p !== undefined,
+    ).length;
+    if (wired > 0) {
+      console.warn(
+        "[AgentSidebarHeader] Partial controlled-tabs wiring detected — falling back to uncontrolled. Provide all five of: tabs, activeTabId, onSelectTab, onCloseTab, onNewTab.",
+      );
+    }
+  }
+
+  // Internal state — used only in uncontrolled mode.
+  const [internalTabs, setInternalTabs] = useState<ChatTab[]>([{ id: "1", title: "Chat 1" }]);
+  const [internalActiveTabId, setInternalActiveTabId] = useState("1");
+
+  const tabs = isControlled ? propTabs! : internalTabs;
+  const activeTabId = isControlled ? propActiveTabId! : internalActiveTabId;
+
   const [visibleCount, setVisibleCount] = useState(tabs.length);
   const [showOverflow, setShowOverflow] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
@@ -70,6 +112,11 @@ export function AgentSidebarHeader({
   const [ddNotchX, setDdNotchX] = useState(0);
   const histContentRef = useRef<HTMLDivElement>(null);
   const [histContentH, setHistContentH] = useState(0);
+
+  // Inline history-row rename.
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const editInputRef = useRef<HTMLInputElement>(null);
 
   const calculateVisible = useCallback(() => {
     if (!tabsContainerRef.current) return;
@@ -163,19 +210,32 @@ export function AgentSidebarHeader({
   }, [showOverflow, overflowTabs.length]);
 
   const handleAddTab = () => {
+    if (isControlled) {
+      onNewTab!();
+      return;
+    }
     const id = String(nextIdRef.current++);
-    setTabs((prev) => [...prev, { id, title: `Chat ${id}` }]);
-    setActiveTabId(id);
+    setInternalTabs((prev) => [...prev, { id, title: `Chat ${id}` }]);
+    setInternalActiveTabId(id);
   };
 
-  const removeTab = (tabId: string) => {
-    if (tabs.length === 1) return;
-    const idx = tabs.findIndex((t) => t.id === tabId);
-    const newTabs = tabs.filter((t) => t.id !== tabId);
-    setTabs(newTabs);
-    if (tabId === activeTabId) {
+  const handleSelectTab = (id: string) => {
+    if (isControlled) onSelectTab!(id);
+    else setInternalActiveTabId(id);
+  };
+
+  const handleCloseTab = (tabId: string) => {
+    if (isControlled) {
+      onCloseTab!(tabId);
+      return;
+    }
+    if (internalTabs.length === 1) return;
+    const idx = internalTabs.findIndex((t) => t.id === tabId);
+    const newTabs = internalTabs.filter((t) => t.id !== tabId);
+    setInternalTabs(newTabs);
+    if (tabId === internalActiveTabId) {
       const next = newTabs[Math.min(idx, newTabs.length - 1)];
-      if (next) setActiveTabId(next.id);
+      if (next) setInternalActiveTabId(next.id);
     }
   };
 
@@ -206,7 +266,7 @@ export function AgentSidebarHeader({
 
       {/* History */}
       <div ref={historyBtnRef} className="absolute left-0 top-0 z-[51] w-10 h-10 flex justify-center">
-        <IconButton icon="expand_more" variant="text" size="sm" className="m-auto text-on-surface" onClick={() => setShowHistory(!showHistory)} aria-label="Chat history" />
+        <IconButton icon="expand_more" variant="text" size="sm" className="m-auto text-on-surface" onClick={() => setShowHistory(!showHistory)} aria-label={labels?.historyButtonLabel ?? "Chat history"} />
       </div>
 
       {/* History dropdown */}
@@ -238,7 +298,7 @@ export function AgentSidebarHeader({
           >
             {!history || history.length === 0 ? (
               <div className="px-2 py-3 text-xs text-on-surface-variant text-center">
-                No previous conversations
+                {labels?.historyEmpty ?? "No previous conversations"}
               </div>
             ) : (
               history.map((group) => (
@@ -247,26 +307,101 @@ export function AgentSidebarHeader({
                     {group.label}
                   </div>
                   {group.items.map((item) => {
+                    const isEditing = editingId === item.id;
                     const select = () => {
+                      if (isEditing) return;
                       onSelectHistoryItem?.(item.id);
                       setShowHistory(false);
                     };
+                    const startEdit = (e: React.SyntheticEvent) => {
+                      e.stopPropagation();
+                      setEditingId(item.id);
+                      setEditValue(item.title);
+                      // Focus once the input has rendered.
+                      requestAnimationFrame(() => editInputRef.current?.focus());
+                    };
+                    const commitEdit = () => {
+                      const trimmed = editValue.trim();
+                      if (trimmed.length >= 1 && trimmed.length <= 200) {
+                        onRenameConversation?.(item.id, trimmed);
+                      }
+                      setEditingId(null);
+                    };
+                    const cancelEdit = () => setEditingId(null);
                     return (
                       <div
                         key={item.id}
-                        role="button"
-                        tabIndex={0}
+                        role={isEditing ? undefined : "button"}
+                        tabIndex={isEditing ? undefined : 0}
                         className="group/item flex items-center gap-1.5 px-2 py-1 rounded-md cursor-pointer transition-colors text-on-surface hover:bg-on-surface/10"
                         onClick={select}
                         onKeyDown={(e) => {
-                          if (e.key === "Enter" || e.key === " ") {
+                          if (!isEditing && (e.key === "Enter" || e.key === " ")) {
                             e.preventDefault();
                             select();
                           }
                         }}
                       >
-                        <Icon name="chat_bubble_outline" size={14} className="text-on-surface-variant shrink-0" />
-                        <span className="text-sm truncate flex-1">{item.title}</span>
+                        {isEditing ? (
+                          <>
+                            <input
+                              ref={editInputRef}
+                              value={editValue}
+                              onChange={(e) => setEditValue(e.target.value)}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") { e.preventDefault(); commitEdit(); }
+                                if (e.key === "Escape") {
+                                  e.preventDefault();
+                                  // Keep the dropdown's Escape-to-dismiss from also firing.
+                                  e.stopPropagation();
+                                  cancelEdit();
+                                }
+                              }}
+                              onClick={(e) => e.stopPropagation()}
+                              maxLength={200}
+                              className="flex-1 min-w-0 text-sm bg-transparent border-b border-outline focus:outline-none text-on-surface"
+                              aria-label={labels?.renameConversationLabel ?? "Rename conversation"}
+                            />
+                            <div
+                              role="button"
+                              tabIndex={0}
+                              className="w-5 h-5 flex items-center justify-center rounded-full text-on-surface hover:bg-on-surface/10 shrink-0"
+                              onClick={(e) => { e.stopPropagation(); cancelEdit(); }}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter" || e.key === " ") {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  cancelEdit();
+                                }
+                              }}
+                              aria-label={labels?.cancelRenameLabel ?? "Cancel rename"}
+                            >
+                              <Icon name="close" size={12} />
+                            </div>
+                          </>
+                        ) : (
+                          <>
+                            <Icon name="chat_bubble_outline" size={14} className="text-on-surface-variant shrink-0" />
+                            <span className="text-sm truncate flex-1">{item.title}</span>
+                            {onRenameConversation && (
+                              <div
+                                role="button"
+                                tabIndex={0}
+                                className="w-5 h-5 flex items-center justify-center rounded-full text-on-surface hover:bg-on-surface/10 shrink-0 opacity-0 group-hover/item:opacity-70 group-hover/item:hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+                                onClick={startEdit}
+                                onKeyDown={(e) => {
+                                  if (e.key === "Enter" || e.key === " ") {
+                                    e.preventDefault();
+                                    startEdit(e);
+                                  }
+                                }}
+                                aria-label={labels?.renameConversationLabel ?? "Rename conversation"}
+                              >
+                                <Icon name="edit" size={12} />
+                              </div>
+                            )}
+                          </>
+                        )}
                       </div>
                     );
                   })}
@@ -291,8 +426,8 @@ export function AgentSidebarHeader({
                 ref={isActive ? activeTabRef : undefined}
                 aria-selected={isActive}
                 tabIndex={isActive ? 0 : -1}
-                onClick={() => setActiveTabId(tab.id)}
-                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setActiveTabId(tab.id); } }}
+                onClick={() => handleSelectTab(tab.id)}
+                onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleSelectTab(tab.id); } }}
                 className="group relative h-full flex flex-1 !transition-none"
               >
                 <div
@@ -315,7 +450,7 @@ export function AgentSidebarHeader({
                         ? "text-inverse-on-surface hover:bg-inverse-on-surface/20 opacity-70 hover:opacity-100"
                         : "text-on-surface hover:bg-on-surface/10 opacity-0 group-hover:opacity-70 group-hover:hover:opacity-100",
                     )}
-                    onClick={(e) => { e.stopPropagation(); removeTab(tab.id); }}
+                    onClick={(e) => { e.stopPropagation(); handleCloseTab(tab.id); }}
                     aria-label={`Close ${tab.title}`}
                   >
                     <Icon name="close" size={14} />
@@ -334,7 +469,7 @@ export function AgentSidebarHeader({
             <IconButton icon="more_horiz" variant="text" size="sm" className="text-on-surface" onClick={() => setShowOverflow(!showOverflow)} aria-label={`${overflowTabs.length} more tabs`} />
           </div>
         ) : (
-          <IconButton icon="add" variant="text" size="sm" className="text-on-surface" onClick={handleAddTab} aria-label="New chat" />
+          <IconButton icon="add" variant="text" size="sm" className="text-on-surface" onClick={handleAddTab} aria-label={labels?.newChatLabel ?? "New chat"} />
         )}
         <IconButton icon={isCollapsed ? "unfold_more" : "unfold_less"} variant="text" size="sm" className="rotate-90 text-on-surface" onClick={onToggleCollapse} aria-label={isCollapsed ? "Expand" : "Collapse"} />
         <IconButton icon="close" variant="text" size="sm" className="text-on-surface" onClick={onClose} aria-label="Close sidebar" />
@@ -374,7 +509,7 @@ export function AgentSidebarHeader({
                   "w-full px-2 py-1 text-left text-sm rounded-md transition-colors flex items-center gap-1.5",
                   tab.id === activeTabId ? "bg-primary/10 text-primary font-medium" : "text-on-surface hover:bg-on-surface/10",
                 )}
-                onClick={() => { setActiveTabId(tab.id); setShowOverflow(false); }}
+                onClick={() => { handleSelectTab(tab.id); setShowOverflow(false); }}
               >
                 <span className="truncate">{tab.title}</span>
               </button>
@@ -385,7 +520,7 @@ export function AgentSidebarHeader({
               onClick={() => { handleAddTab(); setShowOverflow(false); }}
             >
               <Icon name="add" size={12} />
-              <span>New chat</span>
+              <span>{labels?.newChatLabel ?? "New chat"}</span>
             </button>
           </div>
         </div>

--- a/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
@@ -39,6 +39,7 @@ export interface AgentSidebarHeaderProps {
 const TAB_WIDTH = 100;
 const GAP = 6;
 const ADD_BTN = 40;
+const TABS_PAD = 46; // strip's pl-10 (40) + pr-1.5 (6) — clientWidth includes padding
 
 // Active tab notch (headOnly)
 const TAB_R = 12;
@@ -124,16 +125,19 @@ export function AgentSidebarHeader({
 
   const calculateVisible = useCallback(() => {
     if (!tabsContainerRef.current) return;
-    const container = tabsContainerRef.current.clientWidth;
+    // clientWidth includes the strip's own pl-10 + pr-1.5 padding — subtract
+    // it, or the math overestimates by 46px and tabs squeeze (min-w-0 lets
+    // them shrink) instead of collapsing into the overflow dropdown.
+    const available = tabsContainerRef.current.clientWidth - TABS_PAD;
     const spaceForAll = tabs.length * TAB_WIDTH + (tabs.length - 1) * GAP;
 
-    if (spaceForAll <= container) {
+    if (spaceForAll <= available) {
       setVisibleCount(tabs.length);
       return;
     }
 
-    const available = container - ADD_BTN;
-    const count = Math.floor((available + GAP) / (TAB_WIDTH + GAP));
+    const usable = available - ADD_BTN;
+    const count = Math.floor((usable + GAP) / (TAB_WIDTH + GAP));
     setVisibleCount(Math.max(1, count));
   }, [tabs.length]);
 
@@ -386,25 +390,33 @@ export function AgentSidebarHeader({
                           <>
                             <Icon name="chat_bubble_outline" size={14} className="text-on-surface-variant shrink-0" />
                             <span className="text-sm truncate flex-1">{item.title}</span>
-                            {onRenameConversation && (
-                              <button
-                                type="button"
-                                className="w-5 h-5 flex items-center justify-center rounded-full cursor-pointer text-on-surface hover:bg-on-surface/10 shrink-0 opacity-0 group-hover/item:opacity-70 group-hover/item:hover:opacity-100 focus-visible:opacity-100 transition-opacity"
-                                onClick={startEdit}
-                                aria-label={labels?.renameConversationLabel ?? "Rename conversation"}
-                              >
-                                <Icon name="edit" size={12} />
-                              </button>
-                            )}
-                            {onDeleteConversation && (
-                              <button
-                                type="button"
-                                className="w-5 h-5 flex items-center justify-center rounded-full cursor-pointer text-on-surface hover:bg-error/10 hover:text-error shrink-0 opacity-0 group-hover/item:opacity-70 group-hover/item:hover:opacity-100 focus-visible:opacity-100 transition-opacity"
-                                onClick={(e) => { e.stopPropagation(); onDeleteConversation(item.id); }}
-                                aria-label={labels?.deleteConversationLabel ?? "Delete conversation"}
-                              >
-                                <Icon name="delete" size={12} />
-                              </button>
+                            {/* Idle rows give the title the full width: the action
+                                cluster collapses to w-0 (still focusable — unlike
+                                display:none — so keyboard tab reveals it) and only
+                                takes layout space on hover/focus. */}
+                            {(onRenameConversation || onDeleteConversation) && (
+                              <div className="flex w-0 shrink-0 items-center gap-0.5 overflow-hidden opacity-0 group-hover/item:w-auto group-hover/item:opacity-100 focus-within:w-auto focus-within:opacity-100">
+                                {onRenameConversation && (
+                                  <button
+                                    type="button"
+                                    className="w-5 h-5 flex items-center justify-center rounded-full cursor-pointer text-on-surface opacity-70 hover:opacity-100 hover:bg-on-surface/10 shrink-0"
+                                    onClick={startEdit}
+                                    aria-label={labels?.renameConversationLabel ?? "Rename conversation"}
+                                  >
+                                    <Icon name="edit" size={12} />
+                                  </button>
+                                )}
+                                {onDeleteConversation && (
+                                  <button
+                                    type="button"
+                                    className="w-5 h-5 flex items-center justify-center rounded-full cursor-pointer text-on-surface opacity-70 hover:opacity-100 hover:bg-error/10 hover:text-error shrink-0"
+                                    onClick={(e) => { e.stopPropagation(); onDeleteConversation(item.id); }}
+                                    aria-label={labels?.deleteConversationLabel ?? "Delete conversation"}
+                                  >
+                                    <Icon name="delete" size={12} />
+                                  </button>
+                                )}
+                              </div>
                             )}
                           </>
                         )}
@@ -471,8 +483,10 @@ export function AgentSidebarHeader({
         </div>
       </div>
 
-      {/* Actions */}
-      <div ref={overflowRef} className="flex items-center gap-0.5 pr-1 shrink-0">
+      {/* Actions — z-10 keeps the icons above the active-tab notch overlay
+          (z-[5]); when the active tab is last in the strip its arc overhang
+          otherwise paints over them, dark-on-dark. */}
+      <div ref={overflowRef} className="relative z-10 flex items-center gap-0.5 pr-1 shrink-0">
         {overflowTabs.length > 0 ? (
           <div ref={triggerBtnRef} className="relative z-[51]">
             <IconButton icon="more_horiz" variant="text" size="sm" className="text-on-surface" onClick={() => setShowOverflow(!showOverflow)} aria-label={`${overflowTabs.length} more tabs`} />

--- a/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
@@ -29,6 +29,9 @@ export interface AgentSidebarHeaderProps {
   /** Enables the hover rename affordance on history rows.
    *  Called with the trimmed title (1-200 chars) when the user commits an inline rename. */
   onRenameConversation?: (id: string, title: string) => void;
+  /** Enables the hover delete affordance on history rows. Confirmation (if any)
+   *  is the consumer's responsibility; the kit fires immediately. */
+  onDeleteConversation?: (id: string) => void;
   /** Label overrides. All have EN defaults. */
   labels?: AgentSidebarHeaderLabels;
 }
@@ -65,6 +68,7 @@ export function AgentSidebarHeader({
   onCloseTab,
   onNewTab,
   onRenameConversation,
+  onDeleteConversation,
   labels,
 }: AgentSidebarHeaderProps) {
   const isCollapsed = sidebarWidth <= 350;
@@ -392,6 +396,16 @@ export function AgentSidebarHeader({
                                 <Icon name="edit" size={12} />
                               </button>
                             )}
+                            {onDeleteConversation && (
+                              <button
+                                type="button"
+                                className="w-5 h-5 flex items-center justify-center rounded-full cursor-pointer text-on-surface hover:bg-error/10 hover:text-error shrink-0 opacity-0 group-hover/item:opacity-70 group-hover/item:hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+                                onClick={(e) => { e.stopPropagation(); onDeleteConversation(item.id); }}
+                                aria-label={labels?.deleteConversationLabel ?? "Delete conversation"}
+                              >
+                                <Icon name="delete" size={12} />
+                              </button>
+                            )}
                           </>
                         )}
                       </div>
@@ -420,7 +434,10 @@ export function AgentSidebarHeader({
                 tabIndex={isActive ? 0 : -1}
                 onClick={() => handleSelectTab(tab.id)}
                 onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); handleSelectTab(tab.id); } }}
-                className="group relative h-full flex flex-1 !transition-none"
+                // min-w-0 overrides the flex min-width:auto floor so a long
+                // title shrinks to the strip's allotment and ellipsizes
+                // (the inner box's min-w-[100px]/[80px] is the real floor).
+                className="group relative h-full flex flex-1 min-w-0 !transition-none"
               >
                 <div
                   className={cn(

--- a/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
@@ -165,6 +165,12 @@ export function AgentSidebarHeader({
     enabled: showHistory,
   });
 
+  // Every close path (toggle button, item select, click-outside, Escape)
+  // also exits inline-rename, so reopening never resumes a stale edit.
+  useEffect(() => {
+    if (!showHistory) setEditingId(null);
+  }, [showHistory]);
+
   useLayoutEffect(() => {
     if (!showHistory || !histContentRef.current) return;
     setHistContentH(histContentRef.current.offsetHeight);
@@ -336,7 +342,8 @@ export function AgentSidebarHeader({
                         className="group/item flex items-center gap-1.5 px-2 py-1 rounded-md cursor-pointer transition-colors text-on-surface hover:bg-on-surface/10"
                         onClick={select}
                         onKeyDown={(e) => {
-                          if (!isEditing && (e.key === "Enter" || e.key === " ")) {
+                          // target check: nested rename/cancel buttons handle their own keys.
+                          if (e.target === e.currentTarget && !isEditing && (e.key === "Enter" || e.key === " ")) {
                             e.preventDefault();
                             select();
                           }
@@ -360,45 +367,30 @@ export function AgentSidebarHeader({
                               onClick={(e) => e.stopPropagation()}
                               maxLength={200}
                               className="flex-1 min-w-0 text-sm bg-transparent border-b border-outline focus:outline-none text-on-surface"
-                              aria-label={labels?.renameConversationLabel ?? "Rename conversation"}
+                              aria-label={`${labels?.renameConversationLabel ?? "Rename conversation"}: ${item.title}`}
                             />
-                            <div
-                              role="button"
-                              tabIndex={0}
-                              className="w-5 h-5 flex items-center justify-center rounded-full text-on-surface hover:bg-on-surface/10 shrink-0"
+                            <button
+                              type="button"
+                              className="w-5 h-5 flex items-center justify-center rounded-full cursor-pointer text-on-surface hover:bg-on-surface/10 shrink-0"
                               onClick={(e) => { e.stopPropagation(); cancelEdit(); }}
-                              onKeyDown={(e) => {
-                                if (e.key === "Enter" || e.key === " ") {
-                                  e.preventDefault();
-                                  e.stopPropagation();
-                                  cancelEdit();
-                                }
-                              }}
                               aria-label={labels?.cancelRenameLabel ?? "Cancel rename"}
                             >
                               <Icon name="close" size={12} />
-                            </div>
+                            </button>
                           </>
                         ) : (
                           <>
                             <Icon name="chat_bubble_outline" size={14} className="text-on-surface-variant shrink-0" />
                             <span className="text-sm truncate flex-1">{item.title}</span>
                             {onRenameConversation && (
-                              <div
-                                role="button"
-                                tabIndex={0}
-                                className="w-5 h-5 flex items-center justify-center rounded-full text-on-surface hover:bg-on-surface/10 shrink-0 opacity-0 group-hover/item:opacity-70 group-hover/item:hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+                              <button
+                                type="button"
+                                className="w-5 h-5 flex items-center justify-center rounded-full cursor-pointer text-on-surface hover:bg-on-surface/10 shrink-0 opacity-0 group-hover/item:opacity-70 group-hover/item:hover:opacity-100 focus-visible:opacity-100 transition-opacity"
                                 onClick={startEdit}
-                                onKeyDown={(e) => {
-                                  if (e.key === "Enter" || e.key === " ") {
-                                    e.preventDefault();
-                                    startEdit(e);
-                                  }
-                                }}
                                 aria-label={labels?.renameConversationLabel ?? "Rename conversation"}
                               >
                                 <Icon name="edit" size={12} />
-                              </div>
+                              </button>
                             )}
                           </>
                         )}

--- a/src/components/ui/agent/sidebar/AgentSidebarInput.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebarInput.tsx
@@ -184,7 +184,7 @@ export function AgentSidebarInput({
       </div>
       <div className="flex flex-col w-full border border-outline-variant/30 rounded-xl bg-inverse-on-surface/8 p-1 gap-0.5">
         {queuedMessages && queuedMessages.length > 0 && (
-          <div className="flex flex-col border-b border-outline-variant/20 pb-0.5">
+          <div className="flex flex-col border-b border-outline-variant/20 pb-1">
             {queuedMessages.map((q, i) => (
               <div key={q.id} className="flex items-center gap-1.5 px-2 py-0.5">
                 {/* prefix on the first row only; later rows align under it */}

--- a/src/components/ui/agent/sidebar/AgentSidebarInput.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebarInput.tsx
@@ -11,6 +11,12 @@ import { useMenuKeyNav } from "@/hooks/useMenuKeyNav";
 import { useModelSelection } from "@/hooks/useModelSelection";
 import type { AgentSidebarInputLabels } from "./types";
 
+/** One pending message in the send queue (see queuedMessages). */
+export interface AgentQueuedMessage {
+  id: string;
+  text: string;
+}
+
 export interface AgentSidebarInputModel {
   id: string;
   label: string;
@@ -34,11 +40,12 @@ export interface AgentSidebarInputProps {
   /** Selected model id. Falls back to the first enabled model when omitted. */
   selectedModelId?: string;
   onSelectModel?: (modelId: string) => void;
-  /** When set, renders a cancellable queued-message chip above the textarea.
-   *  Display-only — queueing logic lives in the consumer. */
-  queuedMessage?: string;
-  /** Called when the user clicks the X on the queued-message chip. */
-  onCancelQueued?: () => void;
+  /** Messages waiting to send once the current reply finishes — rendered as
+   *  cancellable rows above the textarea, in send order. Display-only:
+   *  queueing logic lives in the consumer. */
+  queuedMessages?: AgentQueuedMessage[];
+  /** Called with the row's id when its X is clicked. */
+  onCancelQueued?: (id: string) => void;
   /** Label overrides. All have EN defaults. */
   labels?: AgentSidebarInputLabels;
 }
@@ -66,7 +73,7 @@ export function AgentSidebarInput({
   models,
   selectedModelId,
   onSelectModel,
-  queuedMessage,
+  queuedMessages,
   onCancelQueued,
   labels,
 }: AgentSidebarInputProps) {
@@ -175,26 +182,31 @@ export function AgentSidebarInput({
           Tip — ctrl + c to interrupt
         </span>
       </div>
-      <div className="flex flex-col w-full border border-outline-variant/30 rounded-xl bg-inverse-on-surface/8 p-1 pt-1.5 gap-0.5">
-        {queuedMessage && (
-          <div className="flex items-center gap-1.5 px-2 py-1 border-b border-outline-variant/20 mb-0.5">
-            <span className="text-[11px] font-medium text-inverse-on-surface/50 shrink-0">
-              {labels?.queuedPrefix ?? "Queued"}
-            </span>
-            <span
-              className="flex-1 text-xs text-inverse-on-surface/70 truncate"
-              title={queuedMessage}
-            >
-              {queuedMessage}
-            </span>
-            <IconButton
-              icon="close"
-              variant="text"
-              size="sm"
-              className="text-inverse-on-surface/50 hover:text-inverse-on-surface shrink-0 -mr-0.5"
-              onClick={onCancelQueued}
-              aria-label={labels?.cancelQueuedLabel ?? "Cancel queued message"}
-            />
+      <div className="flex flex-col w-full border border-outline-variant/30 rounded-xl bg-inverse-on-surface/8 p-1 gap-0.5">
+        {queuedMessages && queuedMessages.length > 0 && (
+          <div className="flex flex-col border-b border-outline-variant/20 mb-0.5">
+            {queuedMessages.map((q, i) => (
+              <div key={q.id} className="flex items-center gap-1.5 px-2 py-0.5">
+                {/* prefix on the first row only; later rows align under it */}
+                <span className="text-[11px] font-medium text-inverse-on-surface/50 shrink-0 w-11">
+                  {i === 0 ? (labels?.queuedPrefix ?? "Queued") : ""}
+                </span>
+                <span
+                  className="flex-1 text-xs text-inverse-on-surface/70 truncate"
+                  title={q.text}
+                >
+                  {q.text}
+                </span>
+                <button
+                  type="button"
+                  className="w-5 h-5 flex items-center justify-center rounded-full cursor-pointer text-inverse-on-surface/50 hover:text-inverse-on-surface hover:bg-inverse-on-surface/10 shrink-0"
+                  onClick={() => onCancelQueued?.(q.id)}
+                  aria-label={labels?.cancelQueuedLabel ?? "Cancel queued message"}
+                >
+                  <Icon name="close" size={12} />
+                </button>
+              </div>
+            ))}
           </div>
         )}
         <textarea
@@ -204,7 +216,7 @@ export function AgentSidebarInput({
           onKeyDown={handleKeyDown}
           onCompositionStart={onCompositionStart}
           onCompositionEnd={onCompositionEnd}
-          className="w-full text-inverse-on-surface placeholder:text-inverse-on-surface/30 rounded-lg px-2 py-1 resize-none focus:outline-none bg-transparent text-sm"
+          className="w-full text-inverse-on-surface placeholder:text-inverse-on-surface/30 rounded-lg px-2 py-2 resize-none focus:outline-none bg-transparent text-sm"
           placeholder={placeholder}
           aria-label="Message to agent"
           rows={1}

--- a/src/components/ui/agent/sidebar/AgentSidebarInput.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebarInput.tsx
@@ -184,7 +184,7 @@ export function AgentSidebarInput({
       </div>
       <div className="flex flex-col w-full border border-outline-variant/30 rounded-xl bg-inverse-on-surface/8 p-1 gap-0.5">
         {queuedMessages && queuedMessages.length > 0 && (
-          <div className="flex flex-col border-b border-outline-variant/20 mb-1">
+          <div className="flex flex-col border-b border-outline-variant/20 pb-0.5">
             {queuedMessages.map((q, i) => (
               <div key={q.id} className="flex items-center gap-1.5 px-2 py-0.5">
                 {/* prefix on the first row only; later rows align under it */}

--- a/src/components/ui/agent/sidebar/AgentSidebarInput.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebarInput.tsx
@@ -184,7 +184,7 @@ export function AgentSidebarInput({
       </div>
       <div className="flex flex-col w-full border border-outline-variant/30 rounded-xl bg-inverse-on-surface/8 p-1 gap-0.5">
         {queuedMessages && queuedMessages.length > 0 && (
-          <div className="flex flex-col border-b border-outline-variant/20 mb-0.5">
+          <div className="flex flex-col border-b border-outline-variant/20 mb-1">
             {queuedMessages.map((q, i) => (
               <div key={q.id} className="flex items-center gap-1.5 px-2 py-0.5">
                 {/* prefix on the first row only; later rows align under it */}

--- a/src/components/ui/agent/sidebar/AgentSidebarInput.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebarInput.tsx
@@ -9,6 +9,7 @@ import { useComposerSubmit } from "@/hooks/useComposerSubmit";
 import { useClickOutside } from "@/hooks/useClickOutside";
 import { useMenuKeyNav } from "@/hooks/useMenuKeyNav";
 import { useModelSelection } from "@/hooks/useModelSelection";
+import type { AgentSidebarInputLabels } from "./types";
 
 export interface AgentSidebarInputModel {
   id: string;
@@ -33,6 +34,13 @@ export interface AgentSidebarInputProps {
   /** Selected model id. Falls back to the first enabled model when omitted. */
   selectedModelId?: string;
   onSelectModel?: (modelId: string) => void;
+  /** When set, renders a cancellable queued-message chip above the textarea.
+   *  Display-only — queueing logic lives in the consumer. */
+  queuedMessage?: string;
+  /** Called when the user clicks the X on the queued-message chip. */
+  onCancelQueued?: () => void;
+  /** Label overrides. All have EN defaults. */
+  labels?: AgentSidebarInputLabels;
 }
 
 // Model menu geometry — mirrors AgentGreeting's selector, flipped upward:
@@ -58,6 +66,9 @@ export function AgentSidebarInput({
   models,
   selectedModelId,
   onSelectModel,
+  queuedMessage,
+  onCancelQueued,
+  labels,
 }: AgentSidebarInputProps) {
   const [text, setText] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -165,6 +176,27 @@ export function AgentSidebarInput({
         </span>
       </div>
       <div className="flex flex-col w-full border border-outline-variant/30 rounded-xl bg-inverse-on-surface/8 p-1 pt-1.5 gap-0.5">
+        {queuedMessage && (
+          <div className="flex items-center gap-1.5 px-2 py-1 border-b border-outline-variant/20 mb-0.5">
+            <span className="text-[11px] font-medium text-inverse-on-surface/50 shrink-0">
+              {labels?.queuedPrefix ?? "Queued"}
+            </span>
+            <span
+              className="flex-1 text-xs text-inverse-on-surface/70 truncate"
+              title={queuedMessage}
+            >
+              {queuedMessage}
+            </span>
+            <IconButton
+              icon="close"
+              variant="text"
+              size="sm"
+              className="text-inverse-on-surface/50 hover:text-inverse-on-surface shrink-0 -mr-0.5"
+              onClick={onCancelQueued}
+              aria-label={labels?.cancelQueuedLabel ?? "Cancel queued message"}
+            />
+          </div>
+        )}
         <textarea
           ref={textareaRef}
           value={text}

--- a/src/components/ui/agent/sidebar/types.ts
+++ b/src/components/ui/agent/sidebar/types.ts
@@ -22,7 +22,8 @@ export interface AgentSidebarHeaderLabels {
   historyButtonLabel?: string;
   /** Shown when history is empty. Default: "No previous conversations" */
   historyEmpty?: string;
-  /** aria-label on the rename icon button + rename input in a history row. Default: "Rename conversation" */
+  /** aria-label on the rename icon button in a history row; the rename input
+   *  uses it as a prefix ("<label>: <title>"). Default: "Rename conversation" */
   renameConversationLabel?: string;
   /** aria-label on the cancel-rename button. Default: "Cancel rename" */
   cancelRenameLabel?: string;

--- a/src/components/ui/agent/sidebar/types.ts
+++ b/src/components/ui/agent/sidebar/types.ts
@@ -9,3 +9,31 @@ export interface AgentSidebarHistoryGroup {
   label: string;
   items: AgentSidebarHistoryItem[];
 }
+
+/** A single tab in the agent sidebar header. */
+export interface ChatTab {
+  id: string;
+  title: string;
+}
+
+/** Label overrides for AgentSidebarHeader. All have EN defaults. */
+export interface AgentSidebarHeaderLabels {
+  /** aria-label on the history expand button. Default: "Chat history" */
+  historyButtonLabel?: string;
+  /** Shown when history is empty. Default: "No previous conversations" */
+  historyEmpty?: string;
+  /** aria-label on the rename icon button + rename input in a history row. Default: "Rename conversation" */
+  renameConversationLabel?: string;
+  /** aria-label on the cancel-rename button. Default: "Cancel rename" */
+  cancelRenameLabel?: string;
+  /** aria-label on the + button and text of the overflow new-chat entry. Default: "New chat" */
+  newChatLabel?: string;
+}
+
+/** Label overrides for AgentSidebarInput. All have EN defaults. */
+export interface AgentSidebarInputLabels {
+  /** aria-label on the queued-message cancel button. Default: "Cancel queued message" */
+  cancelQueuedLabel?: string;
+  /** Prefix text in the queued-message chip. Default: "Queued" */
+  queuedPrefix?: string;
+}

--- a/src/components/ui/agent/sidebar/types.ts
+++ b/src/components/ui/agent/sidebar/types.ts
@@ -27,6 +27,8 @@ export interface AgentSidebarHeaderLabels {
   renameConversationLabel?: string;
   /** aria-label on the cancel-rename button. Default: "Cancel rename" */
   cancelRenameLabel?: string;
+  /** aria-label on the delete icon button in a history row. Default: "Delete conversation" */
+  deleteConversationLabel?: string;
   /** aria-label on the + button and text of the overflow new-chat entry. Default: "New chat" */
   newChatLabel?: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export {
   AgentSidebarInput,
   type AgentSidebarInputProps,
   type AgentSidebarInputModel,
+  type AgentQueuedMessage,
 } from "./components/ui/agent/sidebar/AgentSidebarInput";
 export {
   AgentGreeting,

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,9 @@ export {
 export {
   type AgentSidebarHistoryGroup,
   type AgentSidebarHistoryItem,
+  type ChatTab,
+  type AgentSidebarHeaderLabels,
+  type AgentSidebarInputLabels,
 } from "./components/ui/agent/sidebar/types";
 
 // --- ui/blocks (NotchGrid tile primitives) ---


### PR DESCRIPTION
## Summary
Kit-side API surface for the agent-sidebar UX wave (web-applications wiring lands in a later unit). No version bump — a rollup release PR follows.

- **Controlled tabs**: `AgentSidebarHeader` accepts optional `tabs: ChatTab[]`, `activeTabId`, `onSelectTab`, `onCloseTab`, `onNewTab`. Fully controlled when all five are wired (so consumers can show conversation titles and open history clicks as new tabs); the existing uncontrolled behavior is untouched when they're omitted. Partial wiring logs a dev-mode warning and falls back to uncontrolled. `ChatTab` is promoted from a private interface to `sidebar/types.ts` and exported.
- **History rename**: opt-in via `onRenameConversation(id, title)` — a hover edit icon on each history row swaps the title for an inline input. Enter commits (trimmed, 1–200 chars), Esc cancels. Row click still fires `onSelectHistoryItem`.
- **Queued-message slot**: `AgentSidebarInput` accepts `queuedMessage` + `onCancelQueued` and renders a display-only single-line chip pinned above the textarea inside the composer card — truncated text with the full message in the `title` attr and an X button to cancel. Textarea stays fully usable. Queueing logic lives in the consumer.
- **Labels**: all new built-in strings go through `labels` props with EN defaults (`AgentSidebarHeaderLabels`, `AgentSidebarInputLabels`), including aria-labels for the edit/cancel buttons. Pre-existing strings (history button, empty state, new-chat) are also overridable.
- Stories for each behavior; new types exported from `src/index.ts`.

Backward compatible: all new props optional, existing consumers compile unchanged, all pre-existing tests pass unmodified.

## Test plan
- `pnpm typecheck` — green
- `pnpm test` — 636/636 (65 files), incl. 20 new cases: controlled tab titles/select/close/new + aria-selected, rename show/hide/edit/commit/trim/empty-reject/Esc-cancel/no-open-on-edit, queued chip render/absent/cancel/title-attr/textarea-usable/label-overrides
- `pnpm build` — green
- Stories: `ControlledTabs` (history click opens a new tab), `HistoryRename`, `QueuedMessage`, `QueuedMessageWithModelSelector`

## Decisions
- **Esc bubbling fix**: Escape inside the rename input would also hit `useClickOutside`'s document-level keydown and close the whole history dropdown — the input's Escape handler now calls `stopPropagation()` so first Esc cancels the edit, second Esc closes the dropdown.
- **Chip placement**: inside the composer card border (above the textarea), not above the outer wrapper — chip + textarea + action row share one card, per the architect blueprint.
- **Uncontrolled default tab label** stays `"Chat 1"` for backward compat; "New chat" titles come from the consumer/backend in controlled mode.
- **jsdom tab-width**: controlled-tab tests mock `HTMLElement.prototype.clientWidth` (jsdom reports 0, which collapses the strip to one visible tab) — same pattern as Dialog.test.tsx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)