### PR TITLE
chore: release 0.4.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary
Rollup release for the merged agent-sidebar wave:
- #279 — AgentSidebarToolCall tool-call message block (+ messages union `role: "tool"`, toolLabels)
- #280 — controlled tabs with titles, history rename + delete, queued-messages slot (`AgentQueuedMessage[]`), tab title ellipsis, overflow-collapse + notch layering fixes

Version bump only — release.yml publishes 0.4.11 on merge (reads the version, doesn't bump it).

## Test plan
- Both source PRs merged green (typecheck / 642 tests / build).
- After merge: verify the release workflow run succeeds and 0.4.11 appears on GitHub Packages before any consumer bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)