### PR TITLE
feat: add strokeWidth and opacity props to Sparkline

### DIFF
--- a/src/components/ui/blocks/sparkline/Sparkline.stories.tsx
+++ b/src/components/ui/blocks/sparkline/Sparkline.stories.tsx
@@ -8,6 +8,8 @@ const meta: Meta<typeof Sparkline> = {
   argTypes: {
     data: { control: "object" },
     variant: { control: "inline-radio", options: ["bar", "line", "area"] },
+    strokeWidth: { control: { type: "number", min: 0.5, max: 8, step: 0.5 } },
+    opacity: { control: { type: "number", min: 0, max: 1, step: 0.05 } },
   },
 };
 
@@ -72,6 +74,35 @@ export const Area: Story = {
     <div className="bg-background p-6">
       <div className="h-28 w-64 rounded-2xl border border-outline-variant p-3 text-primary">
         <Sparkline {...args} className="h-full" />
+      </div>
+    </div>
+  ),
+};
+
+/** `strokeWidth` (px, non-scaling) and `opacity` (0–1) tune the line stroke.
+ *  Defaults match the previous hardcoded look (`1.5` / `0.6` line, `0.5` area);
+ *  the area fill keeps its fixed `0.15` opacity regardless. */
+export const StrokeAndOpacity: Story = {
+  args: { variant: "line", strokeWidth: 3, opacity: 1 },
+  render: (args) => (
+    <div className="flex flex-wrap items-start gap-6 bg-background p-6">
+      <div className="space-y-1">
+        <span className="text-xs text-on-surface-variant">Defaults</span>
+        <div className="h-24 w-64 rounded-2xl border border-outline-variant p-3 text-primary">
+          <Sparkline data={LABELLED} variant="line" className="h-full" />
+        </div>
+      </div>
+      <div className="space-y-1">
+        <span className="text-xs text-on-surface-variant">strokeWidth=3, opacity=1</span>
+        <div className="h-24 w-64 rounded-2xl border border-outline-variant p-3 text-primary">
+          <Sparkline {...args} data={LABELLED} className="h-full" />
+        </div>
+      </div>
+      <div className="space-y-1">
+        <span className="text-xs text-on-surface-variant">Area · strokeWidth=2.5, opacity=0.9</span>
+        <div className="h-24 w-64 rounded-2xl border border-outline-variant p-3 text-primary">
+          <Sparkline data={LABELLED} variant="area" strokeWidth={2.5} opacity={0.9} className="h-full" />
+        </div>
       </div>
     </div>
   ),

--- a/src/components/ui/blocks/sparkline/Sparkline.test.tsx
+++ b/src/components/ui/blocks/sparkline/Sparkline.test.tsx
@@ -41,6 +41,29 @@ describe("Sparkline", () => {
     expect(screen.queryByText("Wk 3 · 920")).toBeNull();
   });
 
+  it("defaults the line stroke to width 1.5 / opacity 0.6 (0.5 for area)", () => {
+    const line = render(<Sparkline data={[1, 2, 3]} variant="line" />).container;
+    const stroke = line.querySelector('path[stroke="currentColor"]')!;
+    expect(stroke.getAttribute("stroke-width")).toBe("1.5");
+    expect(stroke.getAttribute("opacity")).toBe("0.6");
+
+    const area = render(<Sparkline data={[1, 2, 3]} variant="area" />).container;
+    expect(
+      area.querySelector('path[stroke="currentColor"]')!.getAttribute("opacity"),
+    ).toBe("0.5");
+  });
+
+  it("applies `strokeWidth` and `opacity` to the line stroke, leaving the area fill alone", () => {
+    const { container } = render(
+      <Sparkline data={[1, 2, 3]} variant="area" strokeWidth={3} opacity={1} />,
+    );
+    const stroke = container.querySelector('path[stroke="currentColor"]')!;
+    expect(stroke.getAttribute("stroke-width")).toBe("3");
+    expect(stroke.getAttribute("opacity")).toBe("1");
+    const fill = container.querySelector('path[fill="currentColor"]')!;
+    expect(fill.getAttribute("opacity")).toBe("0.15");
+  });
+
   it("swaps `barClassName` for `barActiveClassName` on the hovered bar", () => {
     const { container } = render(
       <Sparkline data={[1, 2, 3]} barClassName="bg-rest" barActiveClassName="bg-active" />,

--- a/src/components/ui/blocks/sparkline/Sparkline.tsx
+++ b/src/components/ui/blocks/sparkline/Sparkline.tsx
@@ -30,6 +30,11 @@ export interface SparklineProps {
   barActiveClassName?: string;
   /** Classes for the floating hover chip. Default `"bg-on-surface text-surface"`. Only used by `"bar"` variant. */
   chipClassName?: string;
+  /** Stroke width of the line, in px (non-scaling). Default `1.5`. Only used by `"line"` / `"area"` variants. */
+  strokeWidth?: number;
+  /** Opacity of the line stroke, `0–1`. Defaults to `0.6` for `"line"`, `0.5` for `"area"`.
+   *  The area fill keeps its fixed `0.15` opacity. Only used by `"line"` / `"area"` variants. */
+  opacity?: number;
   className?: string;
 }
 
@@ -61,6 +66,8 @@ export function Sparkline({
   barClassName = "bg-primary/30",
   barActiveClassName,
   chipClassName,
+  strokeWidth = 1.5,
+  opacity,
   className,
 }: SparklineProps) {
   // The chip is portaled to <body> so a clipping/overflow-hidden ancestor
@@ -89,8 +96,8 @@ export function Sparkline({
           d={linePath}
           fill="none"
           stroke="currentColor"
-          strokeWidth="1.5"
-          opacity={variant === "area" ? "0.5" : "0.6"}
+          strokeWidth={strokeWidth}
+          opacity={opacity ?? (variant === "area" ? 0.5 : 0.6)}
           vectorEffect="non-scaling-stroke"
         />
       </svg>


### PR DESCRIPTION
## What / Why

Adds two optional props to `Sparkline` for the `line` / `area` variants (Milestone: TRACK KIT-SPARK):

- `strokeWidth?: number` — line stroke width in px (non-scaling). Default `1.5`, the previously hardcoded value.
- `opacity?: number` — line stroke opacity, 0–1. Defaults to the previously hardcoded `0.6` (line) / `0.5` (area).

Defaults are identical to the old hardcoded values, so all existing renders are pixel-identical. Export surface unchanged — props additions only, **no version bump**.

## Design notes

- **Opacity is scoped to the line stroke.** The area variant's fill keeps its fixed `0.15` opacity: the fill is intentionally a faint trend-weight wash relative to `currentColor`, and tying it to the stroke opacity would make `opacity={1}` produce a heavy solid block instead of a bolder line. Documented in the prop JSDoc and locked in by a test.
- The `bar` variant ignores both props (documented, consistent with how `barClassName` etc. are documented as bar-only).
- New `StrokeAndOpacity` story shows defaults vs `strokeWidth=3 / opacity=1` (line) and a tuned area variant; Storybook number controls added for both props.

## Test plan

- `pnpm typecheck` green
- `pnpm build` green
- `pnpm test` green — 66 files / 660 tests, including 2 new tests: default stroke attrs per variant, and custom `strokeWidth`/`opacity` applied to the stroke while the area fill stays at `0.15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)