### PR TITLE
fix(agent-sidebar): keep active-tab notch curl off the header action icons

### DIFF
--- a/src/components/ui/agent/sidebar/AgentSidebar.stories.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebar.stories.tsx
@@ -86,6 +86,45 @@ export const ControlledTabs: StoryObj = {
   },
 };
 
+/** Regression: ACTIVE tab is the LAST tab in the strip, right next to the
+ *  header action icons. Tabs are flex-1, so the active tab's right edge sits
+ *  flush at the strip's content edge and its notch overlay flares TAB_IR
+ *  (12px) past it — the strip's pr-3 must absorb that curl so the dark
+ *  on-background fill never paints under the + / collapse / close icons. */
+export const ActiveLastTab: StoryObj = {
+  render: () => {
+    const [tabs, setTabs] = useState<ChatTab[]>([
+      { id: "conv-1", title: "New chat" },
+      { id: "conv-2", title: "Deploy checklist" },
+    ]);
+    const [activeTabId, setActiveTabId] = useState("conv-2");
+    const nextIdRef = useRef(3);
+    return (
+      <div className="bg-surface-container">
+        <AgentSidebarHeader
+          sidebarWidth={420}
+          onToggleCollapse={() => {}}
+          onClose={() => {}}
+          tabs={tabs}
+          activeTabId={activeTabId}
+          onSelectTab={setActiveTabId}
+          onCloseTab={(id) => {
+            const next = tabs.filter((t) => t.id !== id);
+            if (!next.length) return;
+            setTabs(next);
+            if (activeTabId === id) setActiveTabId(next[next.length - 1].id);
+          }}
+          onNewTab={() => {
+            const tab = { id: `conv-${nextIdRef.current++}`, title: "New chat" };
+            setTabs((prev) => [...prev, tab]);
+            setActiveTabId(tab.id);
+          }}
+        />
+      </div>
+    );
+  },
+};
+
 /** History row actions: hover edit (inline rename) + hover delete. */
 export const History: StoryObj = {
   render: () => {

--- a/src/components/ui/agent/sidebar/AgentSidebar.test.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebar.test.tsx
@@ -74,7 +74,7 @@ describe("AgentSidebarHeader controlled tabs", () => {
   });
 
   it("collapses tabs into the overflow dropdown when the strip is narrow", () => {
-    // 280 clientWidth − 46 strip padding = 234 available; three 100px tabs
+    // 280 clientWidth − 52 strip padding = 228 available; three 100px tabs
     // (312 with gaps) don't fit → 1 visible + 2 in the ⋯ dropdown. Before the
     // padding fix the math compared against the raw 280 and squeezed tabs
     // inline instead of overflowing.

--- a/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
@@ -39,7 +39,7 @@ export interface AgentSidebarHeaderProps {
 const TAB_WIDTH = 100;
 const GAP = 6;
 const ADD_BTN = 40;
-const TABS_PAD = 46; // strip's pl-10 (40) + pr-1.5 (6) — clientWidth includes padding
+const TABS_PAD = 52; // strip's pl-10 (40) + pr-3 (12) — clientWidth includes padding
 
 // Active tab notch (headOnly)
 const TAB_R = 12;
@@ -125,8 +125,8 @@ export function AgentSidebarHeader({
 
   const calculateVisible = useCallback(() => {
     if (!tabsContainerRef.current) return;
-    // clientWidth includes the strip's own pl-10 + pr-1.5 padding — subtract
-    // it, or the math overestimates by 46px and tabs squeeze (min-w-0 lets
+    // clientWidth includes the strip's own pl-10 + pr-3 padding — subtract
+    // it, or the math overestimates by 52px and tabs squeeze (min-w-0 lets
     // them shrink) instead of collapsing into the overflow dropdown.
     const available = tabsContainerRef.current.clientWidth - TABS_PAD;
     const spaceForAll = tabs.length * TAB_WIDTH + (tabs.length - 1) * GAP;
@@ -272,6 +272,10 @@ export function AgentSidebarHeader({
           inverseRadius={TAB_IR}
           fill="var(--color-on-background)"
           stroke="none"
+          // The default strokeWidth (1) pads the SVG half a pixel past the
+          // shape on each side — with no stroke that pad is pure overhang,
+          // so zero it and keep the overlay exactly tabWidth + 2×TAB_IR wide.
+          strokeWidth={0}
           headOnly
           className="absolute z-[5] !transition-none"
           style={{ left: activeTabRect.left - TAB_IR, top: 0 }}
@@ -432,8 +436,14 @@ export function AgentSidebarHeader({
 
       {/* Tabs — !transition-none on the tab + its inner box so flex-1
           width changes snap during a live sidebar drag instead of easing
-          through whatever transition class the ancestor chain inherits. */}
-      <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-10 pr-1.5 gap-1.5 !transition-none">
+          through whatever transition class the ancestor chain inherits.
+          pr-3 (12px) reserves the active-tab notch's trailing inverse-radius
+          curl (TAB_IR): tabs are flex-1, so when the active tab is LAST its
+          right edge sits flush at the strip's content edge and the curl
+          bleeds TAB_IR past it — anything less than 12px of padding paints
+          the dark curl under the header action icons. (pl-10 covers the
+          leading curl.) Keep TABS_PAD in sync. */}
+      <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-10 pr-3 gap-1.5 !transition-none">
         {/* min-w-0 here too: without it a long tab title inflates the
             tablist's min-width:auto past the strip's content area and the
             last tab gets clipped flat by overflow-hidden. */}

--- a/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebarHeader.tsx
@@ -39,11 +39,13 @@ export interface AgentSidebarHeaderProps {
 const TAB_WIDTH = 100;
 const GAP = 6;
 const ADD_BTN = 40;
-const TABS_PAD = 52; // strip's pl-10 (40) + pr-3 (12) — clientWidth includes padding
 
 // Active tab notch (headOnly)
 const TAB_R = 12;
 const TAB_IR = 12;
+// strip's pl-10 (40px history-btn clearance) + pr-3 (TAB_IR curl clearance)
+// clientWidth includes the strip's own padding, so subtract both sides.
+const TABS_PAD = 40 + TAB_IR;
 const HEADER_H = 40;
 
 // History dropdown
@@ -126,7 +128,7 @@ export function AgentSidebarHeader({
   const calculateVisible = useCallback(() => {
     if (!tabsContainerRef.current) return;
     // clientWidth includes the strip's own pl-10 + pr-3 padding — subtract
-    // it, or the math overestimates by 52px and tabs squeeze (min-w-0 lets
+    // TABS_PAD, or the math overestimates and tabs squeeze (min-w-0 lets
     // them shrink) instead of collapsing into the overflow dropdown.
     const available = tabsContainerRef.current.clientWidth - TABS_PAD;
     const spaceForAll = tabs.length * TAB_WIDTH + (tabs.length - 1) * GAP;
@@ -437,12 +439,12 @@ export function AgentSidebarHeader({
       {/* Tabs — !transition-none on the tab + its inner box so flex-1
           width changes snap during a live sidebar drag instead of easing
           through whatever transition class the ancestor chain inherits.
-          pr-3 (12px) reserves the active-tab notch's trailing inverse-radius
-          curl (TAB_IR): tabs are flex-1, so when the active tab is LAST its
-          right edge sits flush at the strip's content edge and the curl
-          bleeds TAB_IR past it — anything less than 12px of padding paints
-          the dark curl under the header action icons. (pl-10 covers the
-          leading curl.) Keep TABS_PAD in sync. */}
+          pr-3 (TAB_IR = 12px) reserves the active-tab notch's trailing
+          inverse-radius curl: when the active tab is LAST its right edge
+          sits flush at the strip's content edge and the curl bleeds TAB_IR
+          past it — anything less paints the dark curl under the action
+          icons. (pl-10 covers the leading curl.) TABS_PAD is derived from
+          TAB_IR so they stay in sync automatically. */}
       <div ref={tabsContainerRef} className="flex-1 flex h-full overflow-hidden pl-10 pr-3 gap-1.5 !transition-none">
         {/* min-w-0 here too: without it a long tab title inflates the
             tablist's min-width:auto past the strip's content area and the


### PR DESCRIPTION
## What / Why

Pre-existing bug shipped with 0.4.10's agent sidebar: when the **active tab is the last tab** in the header strip, the dark active-tab notch overlay visually clips into the header action icons (+ / ⋯ / collapse / close).

## Diagnosis (before redesigning)

The active-tab overlay is a `headOnly` Notch: the tab silhouette plus a `TAB_IR` (12px) inverse-radius curl flaring out on **each** side, anchored at `left: activeTabRect.left - TAB_IR`. The strip reserved 40px on the left (`pl-10`, fits the leading curl) but only **6px** on the right (`pr-1.5`). Tabs are `flex-1`, so when the active tab is last its right edge sits flush at the strip's content edge — the trailing curl bled ~6.5px past the strip and painted the `on-background` fill under the bottom-left corner of the first action icon. (#280 already z-orders the icons above the overlay; the dark fill behind/around the glyph was the remaining defect.) Concrete defect class: **width math**, not z-index.

Verified with a real Storybook render (static build + screenshot): with `pr-1.5` the curl reaches under the + button's edge; with the fix it ends inside the strip padding, clear of the icons.

## Fix (minimal)

- Strip `pr-1.5` → `pr-3` so the right padding absorbs the full 12px curl; `TABS_PAD` 46 → 52 keeps the overflow-collapse math in sync (the narrow-strip test still collapses 3 tabs → 1 visible + 2 in ⋯).
- `strokeWidth={0}` on the overlay Notch — stroke is `none`, so the default `strokeWidth=1` SVG pad was a half-pixel of pure overhang.
- New `ActiveLastTab` story: controlled tabs with the last tab active, right next to the header actions — the regression render.

No version bump (per the kit's rollup-release flow).

## Test plan

- `pnpm typecheck` ✅
- `pnpm test` ✅ (658 tests, 66 files)
- `pnpm build` ✅
- `pnpm build-storybook` + screenshot of `UI/Agent/Sidebar → ActiveLastTab`: curl ends clear of the + icon; DOM-restoring `pr-1.5` in the same render reproduces the overlap.

Serves the KIT-OVERLAY track of the multi-repo wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)