### PR TITLE
feat: forward agent sidebar tab/rename/queue APIs through AppShell

### DIFF
--- a/src/components/layout/app-shell/AppShell.stories.tsx
+++ b/src/components/layout/app-shell/AppShell.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { AppShell } from "./AppShell";
 import { NavigationRail } from "@/components/ui/navigation/navigation-rail/NavigationRail";
@@ -10,7 +10,9 @@ import { NavDrawer, type NavDrawerItem } from "@/components/ui/navigation/nav-dr
 import { Avatar } from "@/components/ui/media/avatar/Avatar";
 import { Button } from "@/components/ui/actions/button/Button";
 import { useSnackbar } from "@/context/snackbar/SnackbarProvider";
-import { mockAgentModels } from "@/components/ui/agent/sidebar/mock-data";
+import { mockAgentHistory, mockAgentModels } from "@/components/ui/agent/sidebar/mock-data";
+import type { AgentQueuedMessage } from "@/components/ui/agent/sidebar/AgentSidebarInput";
+import type { AgentSidebarHistoryGroup, ChatTab } from "@/components/ui/agent/sidebar/types";
 
 const meta: Meta<typeof AppShell> = {
   title: "Layout/AppShell",
@@ -326,6 +328,76 @@ export const SnackbarWithScrollableContent: Story = {
       <SnackbarScrollableDemoContent />
     </AppShell>
   ),
+};
+
+/** The full sidebar pass-through surface, driven end-to-end through AppShell:
+ *  controlled tabs (select / close / new — history rows open as new tabs),
+ *  inline rename + delete on history rows, and cancellable queued-message
+ *  chips above the input. Open the agent sidebar with the floating button. */
+function ControlledAgentSidebarDemo() {
+  const [tabs, setTabs] = useState<ChatTab[]>([
+    { id: "conv-1", title: "New chat" },
+    { id: "conv-2", title: "Update display name" },
+  ]);
+  const [activeTabId, setActiveTabId] = useState("conv-1");
+  const [history, setHistory] = useState<AgentSidebarHistoryGroup[]>(mockAgentHistory);
+  const [queued, setQueued] = useState<AgentQueuedMessage[]>([
+    { id: "q-1", text: "Summarize the last 3 deployments and show me any failures" },
+    { id: "q-2", text: "Then list members who joined this week" },
+  ]);
+  const nextIdRef = useRef(3);
+
+  const openTab = (title: string) => {
+    const tab = { id: `conv-${nextIdRef.current++}`, title };
+    setTabs((prev) => [...prev, tab]);
+    setActiveTabId(tab.id);
+  };
+
+  return (
+    <AppShell
+      navigation={<DemoRail />}
+      appSwitcher={appSwitcher}
+      {...agentProps}
+      agentHistory={history}
+      onSelectAgentHistoryItem={(id) => {
+        const item = history.flatMap((g) => g.items).find((i) => i.id === id);
+        openTab(item?.title ?? "New chat");
+      }}
+      agentTabs={tabs}
+      activeAgentTabId={activeTabId}
+      onSelectAgentTab={setActiveTabId}
+      onCloseAgentTab={(id) => {
+        const next = tabs.filter((t) => t.id !== id);
+        if (!next.length) return;
+        setTabs(next);
+        if (activeTabId === id) setActiveTabId(next[next.length - 1].id);
+      }}
+      onNewAgentTab={() => openTab("New chat")}
+      onRenameAgentConversation={(id, title) => {
+        setHistory((prev) =>
+          prev.map((g) => ({
+            ...g,
+            items: g.items.map((item) => (item.id === id ? { ...item, title } : item)),
+          })),
+        );
+      }}
+      onDeleteAgentConversation={(id) => {
+        setHistory((prev) =>
+          prev
+            .map((g) => ({ ...g, items: g.items.filter((item) => item.id !== id) }))
+            .filter((g) => g.items.length > 0),
+        );
+      }}
+      agentQueuedMessages={queued}
+      onCancelAgentQueued={(id) => setQueued((q) => q.filter((m) => m.id !== id))}
+    >
+      <DemoContent />
+    </AppShell>
+  );
+}
+
+export const ControlledAgentSidebar: Story = {
+  render: () => <ControlledAgentSidebarDemo />,
 };
 
 export const Playground: Story = {

--- a/src/components/layout/app-shell/AppShell.test.tsx
+++ b/src/components/layout/app-shell/AppShell.test.tsx
@@ -1,5 +1,5 @@
 import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
-import { describe, expect, it, afterEach } from "vitest";
+import { describe, expect, it, vi, afterEach, beforeAll, afterAll } from "vitest";
 import { AppShell } from "./AppShell";
 
 afterEach(cleanup);
@@ -70,5 +70,103 @@ describe("AppShell mobile navigation", () => {
     fireEvent.click(screen.getByLabelText("Open navigation"));
     fireEvent.keyDown(document, { key: "Escape" });
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});
+
+describe("AppShell agent sidebar pass-through", () => {
+  // jsdom reports clientWidth 0, which would collapse the tab strip to a
+  // single visible tab. Report a real width so both tabs render inline.
+  beforeAll(() => {
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      value: 400,
+    });
+  });
+  afterAll(() => {
+    Reflect.deleteProperty(HTMLElement.prototype, "clientWidth");
+  });
+
+  const openSidebar = () => fireEvent.click(screen.getByLabelText("Open agent"));
+
+  it("forwards controlled tabs to the agent header", () => {
+    const onSelectTab = vi.fn();
+    const onCloseTab = vi.fn();
+    render(
+      <AppShell
+        agentTabs={[
+          { id: "t1", title: "First chat" },
+          { id: "t2", title: "Second chat" },
+        ]}
+        activeAgentTabId="t1"
+        onSelectAgentTab={onSelectTab}
+        onCloseAgentTab={onCloseTab}
+        onNewAgentTab={() => {}}
+      >
+        content
+      </AppShell>,
+    );
+    openSidebar();
+
+    // Name regexes: a tab's accessible name folds in its close button's label.
+    const second = screen.getByRole("tab", { name: /^Second chat/ });
+    expect(screen.getByRole("tab", { name: /^First chat/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    fireEvent.click(second);
+    expect(onSelectTab).toHaveBeenCalledWith("t2");
+
+    fireEvent.click(screen.getByLabelText("Close Second chat"));
+    expect(onCloseTab).toHaveBeenCalledWith("t2");
+  });
+
+  it("forwards rename/delete handlers to the history rows", () => {
+    const onRename = vi.fn();
+    const onDelete = vi.fn();
+    render(
+      <AppShell
+        agentHistory={[
+          { label: "Today", items: [{ id: "h1", title: "Old title", updatedAt: "2026-06-12T00:00:00Z" }] },
+        ]}
+        onRenameAgentConversation={onRename}
+        onDeleteAgentConversation={onDelete}
+      >
+        content
+      </AppShell>,
+    );
+    openSidebar();
+    fireEvent.click(screen.getByLabelText("Chat history"));
+
+    fireEvent.click(screen.getByLabelText("Rename conversation"));
+    const input = screen.getByLabelText("Rename conversation: Old title");
+    fireEvent.change(input, { target: { value: "New title" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onRename).toHaveBeenCalledWith("h1", "New title");
+
+    fireEvent.click(screen.getByLabelText("Delete conversation"));
+    expect(onDelete).toHaveBeenCalledWith("h1");
+  });
+
+  it("forwards queued messages to the agent input", () => {
+    const onCancel = vi.fn();
+    render(
+      <AppShell
+        agentQueuedMessages={[{ id: "q1", text: "Queued question" }]}
+        onCancelAgentQueued={onCancel}
+      >
+        content
+      </AppShell>,
+    );
+    openSidebar();
+
+    expect(screen.getByText("Queued question")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Cancel queued message"));
+    expect(onCancel).toHaveBeenCalledWith("q1");
+  });
+
+  it("keeps the uncontrolled tab fallback when no tab props are wired", () => {
+    render(<AppShell>content</AppShell>);
+    openSidebar();
+    expect(screen.getByRole("tab", { name: /^Chat 1/ })).toBeInTheDocument();
   });
 });

--- a/src/components/layout/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/AppShell.tsx
@@ -9,8 +9,12 @@ import {
   useSnackbarVisible,
 } from "@/context/snackbar/SnackbarProvider";
 import { AgentSidebarHeader } from "@/components/ui/agent/sidebar/AgentSidebarHeader";
+import type { AgentSidebarHeaderProps } from "@/components/ui/agent/sidebar/AgentSidebarHeader";
 import { AgentSidebarInput } from "@/components/ui/agent/sidebar/AgentSidebarInput";
-import type { AgentSidebarInputModel } from "@/components/ui/agent/sidebar/AgentSidebarInput";
+import type {
+  AgentSidebarInputModel,
+  AgentSidebarInputProps,
+} from "@/components/ui/agent/sidebar/AgentSidebarInput";
 import type { AgentSidebarHistoryGroup } from "@/components/ui/agent/sidebar/types";
 
 export const meta: ComponentMeta = {
@@ -58,6 +62,30 @@ export interface AppShellProps {
   /** Past conversations grouped by date — shown in the agent header history dropdown. */
   agentHistory?: AgentSidebarHistoryGroup[];
   onSelectAgentHistoryItem?: (id: string) => void;
+  /** Controlled tab list for the agent header. Provide together with
+   *  activeAgentTabId/onSelectAgentTab/onCloseAgentTab/onNewAgentTab; omit all
+   *  five to keep the header's internal uncontrolled tab state. */
+  agentTabs?: AgentSidebarHeaderProps["tabs"];
+  /** Controlled active agent tab id. */
+  activeAgentTabId?: AgentSidebarHeaderProps["activeTabId"];
+  /** Called when the user clicks an agent tab. Consumer updates activeAgentTabId. */
+  onSelectAgentTab?: AgentSidebarHeaderProps["onSelectTab"];
+  /** Called when the user clicks the X on an agent tab. Consumer removes it from agentTabs. */
+  onCloseAgentTab?: AgentSidebarHeaderProps["onCloseTab"];
+  /** Called when the user clicks + or the overflow "New chat" entry. Consumer appends a tab. */
+  onNewAgentTab?: AgentSidebarHeaderProps["onNewTab"];
+  /** Enables the hover rename affordance on agent history rows.
+   *  Called with the trimmed title (1-200 chars) when the user commits an inline rename. */
+  onRenameAgentConversation?: AgentSidebarHeaderProps["onRenameConversation"];
+  /** Enables the hover delete affordance on agent history rows. Confirmation
+   *  (if any) is the consumer's responsibility; the kit fires immediately. */
+  onDeleteAgentConversation?: AgentSidebarHeaderProps["onDeleteConversation"];
+  /** Messages waiting to send once the current reply finishes — rendered as
+   *  cancellable rows above the agent input, in send order. Display-only:
+   *  queueing logic lives in the consumer. */
+  agentQueuedMessages?: AgentSidebarInputProps["queuedMessages"];
+  /** Called with the queued row's id when its X is clicked. */
+  onCancelAgentQueued?: AgentSidebarInputProps["onCancelQueued"];
   /** Slot pinned directly above the agent input — used for messages the user
    *  sent while the agent was still responding (queued input). Stays in view
    *  with the input even when the messages list scrolls. */
@@ -182,6 +210,15 @@ function AppShellInner({
   onAgentMic,
   agentHistory,
   onSelectAgentHistoryItem,
+  agentTabs,
+  activeAgentTabId,
+  onSelectAgentTab,
+  onCloseAgentTab,
+  onNewAgentTab,
+  onRenameAgentConversation,
+  onDeleteAgentConversation,
+  agentQueuedMessages,
+  onCancelAgentQueued,
   agentPendingContent,
   agentModels,
   selectedAgentModelId,
@@ -360,6 +397,13 @@ function AppShellInner({
                 onClose={handleClose}
                 history={agentHistory}
                 onSelectHistoryItem={onSelectAgentHistoryItem}
+                tabs={agentTabs}
+                activeTabId={activeAgentTabId}
+                onSelectTab={onSelectAgentTab}
+                onCloseTab={onCloseAgentTab}
+                onNewTab={onNewAgentTab}
+                onRenameConversation={onRenameAgentConversation}
+                onDeleteConversation={onDeleteAgentConversation}
               />
 
               <div className="rounded-2xl bg-on-background flex-1 min-h-0 flex flex-col">
@@ -380,6 +424,8 @@ function AppShellInner({
                   models={agentModels}
                   selectedModelId={selectedAgentModelId}
                   onSelectModel={onSelectAgentModel}
+                  queuedMessages={agentQueuedMessages}
+                  onCancelQueued={onCancelAgentQueued}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary
Kit #279/#280 added the controlled-tabs API, history rename/delete, and queued-message props to the inner sidebar components (`AgentSidebarHeader`, `AgentSidebarInput`) — but `AppShell` never forwarded them. Since web-applications (and soon web-account) mount the agent sidebar exclusively through `AppShell`, none of that surface was reachable, blocking the tabs+rename half of webapps #59/#60.

This PR forwards the full surface through `AppShell`, grouped on the existing `agent*` prop namespace:

| AppShell prop | Forwards to |
| --- | --- |
| `agentTabs` / `activeAgentTabId` / `onSelectAgentTab` / `onCloseAgentTab` / `onNewAgentTab` | `AgentSidebarHeader` controlled tabs |
| `onRenameAgentConversation` / `onDeleteAgentConversation` | history row affordances |
| `agentQueuedMessages` / `onCancelAgentQueued` | `AgentSidebarInput` queued chips |

## Design notes
- **Zero breaking change** — every new prop is optional and undefined-safe. Omitting them keeps the header's internal uncontrolled tab state, hides the rename/delete affordances, and renders no queued chips (today's behavior). Existing AppShell consumers compile unchanged.
- **No new shapes** — prop types are taken verbatim from the inner components via indexed access (`AgentSidebarHeaderProps["tabs"]`, `AgentSidebarInputProps["queuedMessages"]`, …), so AppShell can never drift from the inner contracts. All referenced types (`ChatTab`, `AgentQueuedMessage`, …) were already exported from the barrel — export surface unchanged.
- **No version bump** — rides the 0.4.12 rollup release per kit release conventions.

## Test plan
- New Storybook story `Layout/AppShell → ControlledAgentSidebar` drives controlled tabs (select/close/new + history-opens-as-tab), inline rename + delete, and cancellable queued chips end-to-end through AppShell.
- New tests in `AppShell.test.tsx`: controlled-tab forwarding (select/close callbacks + aria-selected), rename/delete handler forwarding through the history dropdown, queued-message forwarding + cancel, and the uncontrolled fallback when nothing is wired.
- `pnpm typecheck` ✅ · `pnpm build` ✅ · `pnpm test` ✅ (670 tests, 66 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)