### PR TITLE
feat: forward agent sidebar label/i18n props through AppShell

### DIFF
--- a/src/components/layout/app-shell/AppShell.stories.tsx
+++ b/src/components/layout/app-shell/AppShell.stories.tsx
@@ -332,8 +332,9 @@ export const SnackbarWithScrollableContent: Story = {
 
 /** The full sidebar pass-through surface, driven end-to-end through AppShell:
  *  controlled tabs (select / close / new — history rows open as new tabs),
- *  inline rename + delete on history rows, and cancellable queued-message
- *  chips above the input. Open the agent sidebar with the floating button. */
+ *  inline rename + delete on history rows, cancellable queued-message
+ *  chips above the input, and label/placeholder overrides (i18n) for the
+ *  header and input. Open the agent sidebar with the floating button. */
 function ControlledAgentSidebarDemo() {
   const [tabs, setTabs] = useState<ChatTab[]>([
     { id: "conv-1", title: "New chat" },
@@ -390,6 +391,9 @@ function ControlledAgentSidebarDemo() {
       }}
       agentQueuedMessages={queued}
       onCancelAgentQueued={(id) => setQueued((q) => q.filter((m) => m.id !== id))}
+      agentHeaderLabels={{ newChatLabel: "New conversation" }}
+      agentInputLabels={{ queuedPrefix: "Up next" }}
+      agentInputPlaceholder="Ask the agent anything…"
     >
       <DemoContent />
     </AppShell>

--- a/src/components/layout/app-shell/AppShell.test.tsx
+++ b/src/components/layout/app-shell/AppShell.test.tsx
@@ -164,6 +164,34 @@ describe("AppShell agent sidebar pass-through", () => {
     expect(onCancel).toHaveBeenCalledWith("q1");
   });
 
+  it("forwards label overrides and placeholder to the header and input", () => {
+    render(
+      <AppShell
+        agentHeaderLabels={{ historyButtonLabel: "歷史紀錄", newChatLabel: "新對話" }}
+        agentInputLabels={{ queuedPrefix: "排隊中", cancelQueuedLabel: "取消排隊訊息" }}
+        agentInputPlaceholder="輸入訊息…"
+        agentQueuedMessages={[{ id: "q1", text: "Queued question" }]}
+      >
+        content
+      </AppShell>,
+    );
+    openSidebar();
+
+    expect(screen.getByLabelText("歷史紀錄")).toBeInTheDocument();
+    expect(screen.getByLabelText("新對話")).toBeInTheDocument();
+    expect(screen.getByText("排隊中")).toBeInTheDocument();
+    expect(screen.getByLabelText("取消排隊訊息")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("輸入訊息…")).toBeInTheDocument();
+  });
+
+  it("keeps the EN label defaults when no label props are wired", () => {
+    render(<AppShell>content</AppShell>);
+    openSidebar();
+    expect(screen.getByLabelText("Chat history")).toBeInTheDocument();
+    expect(screen.getByLabelText("New chat")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Type a message...")).toBeInTheDocument();
+  });
+
   it("keeps the uncontrolled tab fallback when no tab props are wired", () => {
     render(<AppShell>content</AppShell>);
     openSidebar();

--- a/src/components/layout/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/AppShell.tsx
@@ -80,6 +80,9 @@ export interface AppShellProps {
   /** Enables the hover delete affordance on agent history rows. Confirmation
    *  (if any) is the consumer's responsibility; the kit fires immediately. */
   onDeleteAgentConversation?: AgentSidebarHeaderProps["onDeleteConversation"];
+  /** Label overrides for the agent header (history, rename, new-chat strings).
+   *  All have EN defaults. */
+  agentHeaderLabels?: AgentSidebarHeaderProps["labels"];
   /** Messages waiting to send once the current reply finishes — rendered as
    *  cancellable rows above the agent input, in send order. Display-only:
    *  queueing logic lives in the consumer. */
@@ -94,6 +97,11 @@ export interface AppShellProps {
   agentModels?: AgentSidebarInputModel[];
   selectedAgentModelId?: string;
   onSelectAgentModel?: (id: string) => void;
+  /** Placeholder for the agent input textarea. Default: "Type a message..." */
+  agentInputPlaceholder?: AgentSidebarInputProps["placeholder"];
+  /** Label overrides for the agent input (queued-message strings).
+   *  All have EN defaults. */
+  agentInputLabels?: AgentSidebarInputProps["labels"];
 }
 
 export function AppShell(props: AppShellProps) {
@@ -217,12 +225,15 @@ function AppShellInner({
   onNewAgentTab,
   onRenameAgentConversation,
   onDeleteAgentConversation,
+  agentHeaderLabels,
   agentQueuedMessages,
   onCancelAgentQueued,
   agentPendingContent,
   agentModels,
   selectedAgentModelId,
   onSelectAgentModel,
+  agentInputPlaceholder,
+  agentInputLabels,
 }: AppShellProps) {
   const { sidebarWidth, setSidebarWidth } = useSidebarWidth();
   const [isResizing, setIsResizing] = useState(false);
@@ -404,6 +415,7 @@ function AppShellInner({
                 onNewTab={onNewAgentTab}
                 onRenameConversation={onRenameAgentConversation}
                 onDeleteConversation={onDeleteAgentConversation}
+                labels={agentHeaderLabels}
               />
 
               <div className="rounded-2xl bg-on-background flex-1 min-h-0 flex flex-col">
@@ -421,11 +433,13 @@ function AppShellInner({
                   onSend={onAgentSend}
                   onAttachFile={onAgentAttachFile}
                   onMic={onAgentMic}
+                  placeholder={agentInputPlaceholder}
                   models={agentModels}
                   selectedModelId={selectedAgentModelId}
                   onSelectModel={onSelectAgentModel}
                   queuedMessages={agentQueuedMessages}
                   onCancelQueued={onCancelAgentQueued}
+                  labels={agentInputLabels}
                 />
               </div>
             </div>


### PR DESCRIPTION
## Summary

Follow-up to #285's review: AppShell's agent pass-through forwarded tabs/rename/queued but not the label/i18n props the inner sidebar components already accept — so consumers using AppShell could not localize the sidebar.

## Diagnosis — props the inner components accept that AppShell missed

- **`AgentSidebarHeader.labels`** (`AgentSidebarHeaderLabels`): `historyButtonLabel`, `historyEmpty`, `renameConversationLabel`, `cancelRenameLabel`, `deleteConversationLabel`, `newChatLabel`
- **`AgentSidebarInput.labels`** (`AgentSidebarInputLabels`): `cancelQueuedLabel`, `queuedPrefix`
- **`AgentSidebarInput.placeholder`** (EN default "Type a message...") — the remaining i18n-bearing string prop on the input

## Changes

New optional AppShell props, same pattern as the existing `agent*` pass-through (typed off the inner components' props, undefined-safe — inner EN defaults apply when omitted):

- `agentHeaderLabels?: AgentSidebarHeaderProps["labels"]`
- `agentInputLabels?: AgentSidebarInputProps["labels"]`
- `agentInputPlaceholder?: AgentSidebarInputProps["placeholder"]`

`AgentSidebarHeaderLabels` / `AgentSidebarInputLabels` were already re-exported from `src/index.ts` — no export changes needed. No version bump (rollup release convention).

Also extends the existing `ControlledAgentSidebar` story and pass-through tests minimally (override forwarding + EN-defaults-when-unset).

Note (out of scope): the inner components still hardcode some strings that are not in their `labels` surface (e.g. the input's "Tip — ctrl + c to interrupt", "Attach file"/"Voice input"/"Send message" aria-labels, header "Expand"/"Collapse"/"Close sidebar"). Forwarding can only cover what the inner props expose; widening that surface is a separate change.

## Verification

- `pnpm typecheck` green
- `pnpm build` green
- `pnpm test` green — 66 files, 672 tests passed (includes 2 new AppShell tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)