### PR TITLE
test(agent): lock streamed-reply markdown constructs (headings/lists/code/links/bold)

### DIFF
--- a/src/components/ui/agent/messages/AgentSidebarMessages.stories.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.stories.tsx
@@ -54,13 +54,14 @@ export const AgentMarkdown: StoryObj = {
   render: () => <AgentSidebarAgentMessage content={markdownReply} />,
 };
 
-/** Mid-stream markdown — note the unterminated code fence renders calmly
- *  as a code block until the closing fence arrives. */
+/** Mid-stream markdown with every construct a real reply carries — heading,
+ *  bold, list, inline code, link — and an unterminated code fence that
+ *  renders calmly as a code block until the closing fence arrives. */
 export const AgentMarkdownStreaming: StoryObj = {
   render: () => (
     <AgentSidebarAgentMessage
       content={
-        "Here's what I found so far:\n\n- Username **alice2** is available\n- Dark mode is `off`\n\n```bash\nmirrorstack account au"
+        "## Checking availability\n\nHere's what I found so far:\n\n- Username **alice2** is available\n- Dark mode is `off` — see the [appearance docs](https://docs.mirrorstack.ai/appearance)\n\n```bash\nmirrorstack account au"
       }
       streaming
     />

--- a/src/components/ui/agent/messages/AgentSidebarMessages.test.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.test.tsx
@@ -220,6 +220,42 @@ describe("AgentSidebarMessages markdown rendering", () => {
       "mirrorstack au",
     );
   });
+
+  // Regression lock for the 2026-06-12 report: every construct a real
+  // streamed reply carries must render as markup, not raw text, while the
+  // message is still streaming.
+  it("renders headings, lists, code, links and bold in a streamed-style reply", () => {
+    const streamed = [
+      "## Audit summary",
+      "",
+      "Changed **username** to `alice2`:",
+      "",
+      "- [audit log](https://docs.mirrorstack.ai/audit)",
+      "- dark mode enabled",
+      "",
+      "```bash",
+      "mirrorstack account au", // fence still open mid-stream
+    ].join("\n");
+    const { container } = render(
+      <AgentSidebarMessages messages={[agentMsg({ content: streamed, streaming: true })]} />,
+    );
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "Audit summary",
+    );
+    expect(screen.getByText("username").tagName).toBe("STRONG");
+    expect(screen.getByText("alice2").tagName).toBe("CODE");
+    expect(screen.getByRole("link", { name: "audit log" })).toHaveAttribute(
+      "href",
+      "https://docs.mirrorstack.ai/audit",
+    );
+    expect(container.querySelectorAll("ul > li")).toHaveLength(2);
+    expect(container.querySelector("pre > code")).toHaveTextContent(
+      "mirrorstack account au",
+    );
+    // None of the raw sigils leak through as literal text.
+    expect(container.textContent).not.toContain("**");
+    expect(container.textContent).not.toContain("## ");
+  });
 });
 
 describe("AgentSidebarMessages showLogo", () => {


### PR DESCRIPTION
## Why

User report 2026-06-12: the agent sidebar in web-applications still shows raw `**bold**`, list markers and code fences.

**Diagnosis (no kit code defect):** the markdown renderer (#283) on main is correct — but it merged *after* the v0.4.11 release, so the latest published kit (0.4.11, what web-applications resolves) still renders `{content}` as a plain text node. The fix ships with the 0.4.12 rollup; the app bumps its floor in mirrorstack-ai/web-applications#61.

What the kit *was* missing is a regression lock: the only streaming markdown test covered an unterminated fence, and the streaming story carried no heading or link.

## Changes

- **Test:** a streamed-style reply carrying heading + bold + list + inline code + link + open fence must render real markup (H2/STRONG/CODE/A/UL/PRE) with no raw `**`/`## ` sigils leaking as text.
- **Story:** `AgentMarkdownStreaming` now carries the full construct set.

No version bump — rides the 0.4.12 rollup release (this PR is listed in its merge order).

## Verification

- `pnpm typecheck` green
- `pnpm test` 671/671 green (66 files)
- `pnpm build` green

Companion: mirrorstack-ai/web-applications#61 (kit floor bump to ^0.4.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)