### PR TITLE
chore: release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.4.12
+
+Agent sidebar surface reachable through `AppShell`, headless agent-chat hooks,
+Markdown replies. **No breaking changes**; all new props/exports are optional.
+
+- `AppShell`: forwards the controlled agent sidebar surface — tabs
+  (`agentTabs` / `activeAgentTabId` / `onSelectAgentTab` / `onCloseAgentTab` /
+  `onNewAgentTab`), history rename/delete (`onRenameAgentConversation` /
+  `onDeleteAgentConversation`), queued chips (`agentQueuedMessages` /
+  `onCancelAgentQueued`). (#285)
+- `AppShell`: forwards the sidebar label/i18n surface — `agentHeaderLabels`,
+  `agentInputLabels`, `agentInputPlaceholder`. (#286)
+- `useAgentChat(client, opts)` / `useQueuedAgentSend(chat, scopeKey)` (new
+  hooks): headless agent-chat state machine (SSE streaming, tool-call rows,
+  replay, history, optimistic rename/feedback) + FIFO send queue. Transport is
+  injected via the new structural `AgentChatClient` type — no
+  api-client-shared dependency. Also exports
+  `groupConversationsByRecency`. (#288)
+- `AgentSidebarReply`: streamed replies render as Markdown (headings, lists,
+  code, links, emphasis) instead of plain text. (#283, regression-locked
+  in #287)
+- `Sparkline`: new `strokeWidth` and `opacity` props. (#282)
+- Fix: active-tab notch curl no longer overlaps the agent sidebar header
+  action icons. (#284)
+
 ## 0.4.9
 
 - `AgentSidebarInput`: new optional `detail` field on `AgentSidebarInputModel` —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
-## 0.4.12
+## 0.5.0
 
 Agent sidebar surface reachable through `AppShell`, headless agent-chat hooks,
-Markdown replies. **No breaking changes**; all new props/exports are optional.
+persisted cross-platform tab strip, Markdown replies. **No breaking changes**;
+all new props/exports are optional. Minor bump (vs the usual pre-1.0 patch) to
+mark the agent-sidebar surface reaching feature completeness.
 
 - `AppShell`: forwards the controlled agent sidebar surface — tabs
   (`agentTabs` / `activeAgentTabId` / `onSelectAgentTab` / `onCloseAgentTab` /
@@ -21,6 +23,11 @@ Markdown replies. **No breaking changes**; all new props/exports are optional.
   injected via the new structural `AgentChatClient` type — no
   api-client-shared dependency. Also exports
   `groupConversationsByRecency`. (#288)
+- `useAgentTabs(persistence, opts)` (new hook): cross-platform persisted agent
+  tab strip — hydrates on mount, debounced last-write-wins persistence on
+  open/close/select/reorder, focus refetch for multi-host convergence; drafts
+  are never persisted. Persistence is injected via a structural interface — no
+  api-client-shared dependency. (#290)
 - `AgentSidebarReply`: streamed replies render as Markdown (headings, lists,
   code, links, emphasis) instead of plain text. (#283, regression-locked
   in #287)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.4.12",
+  "version": "0.5.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary

Rollup release for **0.4.12**: version bump (`0.4.11` → `0.4.12`) + changelog entry. **No other changes** — the `release` label on this PR makes release.yml tag `v0.4.12` and publish to GitHub Packages on merge, reading the version straight from `package.json`.

Pre-1.0 patch-only convention: patch bump even though this release ships new components/hooks.

## Merge order — merge this PR LAST

The rollup publishes **whatever is on main at merge time**. Merge these first:

1. #288 — agent chat hooks (`useAgentChat` / `useQueuedAgentSend` / `AgentChatClient`)
2. #286 — AppShell agent label/i18n pass-through
3. #287 — agent-markdown regression lock (tests + story)
4. **this PR** — version bump + `release` label → publish

## What 0.4.12 ships

Already on main since v0.4.11:
- #285 — AppShell forwards agent sidebar tabs / rename / queued-message APIs
- #283 — agent sidebar replies render as Markdown
- #284 — fix: active-tab notch curl off the header action icons
- #282 — Sparkline `strokeWidth` / `opacity` props

Pending (merge before this PR):
- #288 — agent chat hooks with injected transport client
- #286 — AppShell agent label/i18n pass-through
- #287 — markdown regression lock

No breaking changes; all new props/exports optional.

## Verification

- `pnpm install --frozen-lockfile` clean
- `pnpm typecheck` green
- `pnpm build` green

Downstream: mirrorstack-ai/web-applications#61 bumps its kit floor to `^0.4.12` once this publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
