### PR TITLE
feat: useAgentTabs — cross-platform persisted agent tab strip

### DIFF
--- a/src/components/ui/agent/sidebar/types.ts
+++ b/src/components/ui/agent/sidebar/types.ts
@@ -3,16 +3,13 @@ import type {
   ConversationHistoryItem,
 } from "@/hooks/agent-chat/history";
 
-/** Sidebar-facing aliases of the hooks-layer history shapes — the data
- *  layer owns the definitions so it never imports from components. */
+/** Sidebar-facing aliases of the hooks-layer shapes — the data layer owns
+ *  the definitions so it never imports from components. */
 export type AgentSidebarHistoryItem = ConversationHistoryItem;
 export type AgentSidebarHistoryGroup = ConversationHistoryGroup;
 
 /** A single tab in the agent sidebar header. */
-export interface ChatTab {
-  id: string;
-  title: string;
-}
+export type { ChatTab } from "@/hooks/agent-chat/useAgentTabs";
 
 /** Label overrides for AgentSidebarHeader. All have EN defaults. */
 export interface AgentSidebarHeaderLabels {

--- a/src/hooks/agent-chat/useAgentTabs.test.ts
+++ b/src/hooks/agent-chat/useAgentTabs.test.ts
@@ -161,13 +161,73 @@ describe("useAgentTabs", () => {
     });
     await flush();
 
-    // The GET fired but its (stale) result was discarded — local state wins
-    // and the debounce later PUTs it.
-    expect(get).toHaveBeenCalledTimes(2);
+    // No GET fires beyond hydration — local state wins and the debounce
+    // later PUTs it.
+    expect(get).toHaveBeenCalledTimes(1);
     expect(result.current.activeTabId).toBe("c-1");
     await advance(1100);
     expect(put).toHaveBeenCalledTimes(1);
     expect(put).toHaveBeenCalledWith(state({ activeTabId: "c-1" }));
+  });
+
+  it("a failed PUT keeps local state authoritative: focus refetch can't clobber it, the next mutation re-PUTs", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { persistence, get, put } = fakePersistence();
+    put.mockRejectedValueOnce(new Error("boom"));
+    const { result } = renderHook(() => useAgentTabs(persistence));
+    await flush();
+
+    act(() => result.current.selectTab("c-1"));
+    await advance(1100);
+    expect(put).toHaveBeenCalledTimes(1);
+
+    // The mutation never reached the server — a focus refetch must not
+    // replace it with the stale remote state.
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await flush();
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(result.current.activeTabId).toBe("c-1");
+
+    // The next mutation re-PUTs the full state; once synced, refetches
+    // resume.
+    act(() => result.current.setOpen(false));
+    await advance(1100);
+    expect(put).toHaveBeenCalledTimes(2);
+    expect(put).toHaveBeenLastCalledWith(state({ open: false, activeTabId: "c-1" }));
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await flush();
+    expect(get).toHaveBeenCalledTimes(2);
+    errorSpy.mockRestore();
+  });
+
+  it("refetch keeps an interleaved draft in place while adopting remote order", async () => {
+    let remote = state();
+    const get = vi.fn().mockImplementation(async () => remote);
+    const put = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useAgentTabs({ get, put }));
+    await flush();
+
+    // Insert a draft BETWEEN the two conversation tabs.
+    act(() => result.current.newTab());
+    const draftId = result.current.activeTabId;
+    act(() => result.current.moveTab(draftId, 1));
+    expect(result.current.tabs).toEqual(["c-1", draftId, "c-2"]);
+    await advance(1100); // settle the PUT so the refetch isn't skipped
+
+    // Another host reordered the conversation tabs.
+    remote = state({ tabs: ["c-2", "c-1"], activeTabId: "c-1" });
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await flush();
+
+    // The draft stays at strip position 1; survivors adopt remote order.
+    expect(result.current.tabs).toEqual(["c-2", draftId, "c-1"]);
+    expect(result.current.activeTabId).toBe(draftId);
   });
 
   it("never persists draft tabs: draft-only changes don't PUT, bindDraft persists the real id", async () => {

--- a/src/hooks/agent-chat/useAgentTabs.test.ts
+++ b/src/hooks/agent-chat/useAgentTabs.test.ts
@@ -1,0 +1,266 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  deriveTabTitles,
+  isDraftTab,
+  useAgentTabs,
+  type AgentSidebarState,
+  type AgentTabsPersistence,
+} from "./useAgentTabs";
+
+function state(over: Partial<AgentSidebarState> = {}): AgentSidebarState {
+  return { open: true, activeTabId: "c-2", tabs: ["c-1", "c-2"], ...over };
+}
+
+function fakePersistence(initial: AgentSidebarState = state()) {
+  const get = vi.fn().mockImplementation(async () => initial);
+  const put = vi.fn().mockResolvedValue(undefined);
+  const persistence: AgentTabsPersistence = { get, put };
+  return { persistence, get, put };
+}
+
+const flush = () => act(async () => {});
+const advance = (ms: number) =>
+  act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useAgentTabs", () => {
+  it("hydrates on mount: tabs, active tab, and open flag restored; the initial draft placeholder is replaced", async () => {
+    const { persistence, get, put } = fakePersistence(state());
+    const { result } = renderHook(() => useAgentTabs(persistence));
+
+    // Pre-hydration: a single local draft, closed.
+    expect(result.current.tabs).toHaveLength(1);
+    expect(isDraftTab(result.current.tabs[0])).toBe(true);
+    expect(result.current.hydrated).toBe(false);
+
+    await flush();
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(result.current.hydrated).toBe(true);
+    expect(result.current.tabs).toEqual(["c-1", "c-2"]);
+    expect(result.current.activeTabId).toBe("c-2");
+    expect(result.current.open).toBe(true);
+    // Hydration is not a mutation — nothing to PUT.
+    await advance(5000);
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it("hydrate drops ids the host can't resolve (deleted conversations heal silently)", async () => {
+    const { persistence } = fakePersistence(state({ tabs: ["gone", "c-1"], activeTabId: "gone" }));
+    const resolveTabs = vi.fn().mockResolvedValue(["c-1"]);
+    const { result } = renderHook(() => useAgentTabs(persistence, { resolveTabs }));
+
+    await flush();
+
+    expect(resolveTabs).toHaveBeenCalledWith(["gone", "c-1"]);
+    expect(result.current.tabs).toEqual(["c-1"]);
+    // The persisted active didn't survive — focus falls to the first tab.
+    expect(result.current.activeTabId).toBe("c-1");
+  });
+
+  it("hydrating an empty session keeps the fresh draft strip", async () => {
+    const { persistence, put } = fakePersistence(state({ open: false, tabs: [], activeTabId: null }));
+    const { result } = renderHook(() => useAgentTabs(persistence));
+
+    await flush();
+
+    expect(result.current.hydrated).toBe(true);
+    expect(result.current.tabs).toHaveLength(1);
+    expect(isDraftTab(result.current.tabs[0])).toBe(true);
+    await advance(5000);
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it("debounces mutations into ONE trailing PUT carrying the final state", async () => {
+    const { persistence, put } = fakePersistence();
+    const { result } = renderHook(() => useAgentTabs(persistence));
+    await flush();
+
+    act(() => {
+      result.current.openConversation("c-3");
+      result.current.moveTab("c-3", 0);
+      result.current.selectTab("c-1");
+    });
+    // Inside the window: nothing flushed yet.
+    await advance(900);
+    expect(put).not.toHaveBeenCalled();
+    // A late mutation re-arms the trailing edge.
+    act(() => result.current.setOpen(false));
+    await advance(900);
+    expect(put).not.toHaveBeenCalled();
+
+    await advance(200);
+    expect(put).toHaveBeenCalledTimes(1);
+    expect(put).toHaveBeenCalledWith({
+      open: false,
+      activeTabId: "c-1",
+      tabs: ["c-3", "c-1", "c-2"],
+    });
+  });
+
+  it("closing a tab persists the removal (close ≠ delete, gone after reload)", async () => {
+    const { persistence, put } = fakePersistence();
+    const { result } = renderHook(() => useAgentTabs(persistence));
+    await flush();
+
+    act(() => result.current.closeTab("c-2"));
+
+    // Active tab closed → left neighbor takes focus (rightmost closed).
+    expect(result.current.tabs).toEqual(["c-1"]);
+    expect(result.current.activeTabId).toBe("c-1");
+    await advance(1100);
+    expect(put).toHaveBeenCalledTimes(1);
+    expect(put).toHaveBeenCalledWith({ open: true, activeTabId: "c-1", tabs: ["c-1"] });
+  });
+
+  it("refetches on focus and adopts the remote state, keeping local drafts", async () => {
+    let remote = state();
+    const get = vi.fn().mockImplementation(async () => remote);
+    const put = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useAgentTabs({ get, put }));
+    await flush();
+
+    // A local draft exists on this host only — refetch must not drop it.
+    act(() => result.current.newTab());
+    const draftId = result.current.activeTabId;
+    expect(isDraftTab(draftId)).toBe(true);
+    // Focusing the draft nulls the persisted active — settle that PUT so
+    // no flush is pending when the window refocuses.
+    await advance(1100);
+
+    // Another host closed c-2 and switched the active tab.
+    remote = state({ tabs: ["c-1"], activeTabId: "c-1" });
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await flush();
+
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(result.current.tabs).toEqual(["c-1", draftId]);
+    // The locally active tab survived — focus stays put.
+    expect(result.current.activeTabId).toBe(draftId);
+  });
+
+  it("skips the focus refetch while a local mutation is pending flush", async () => {
+    const { persistence, get, put } = fakePersistence();
+    const { result } = renderHook(() => useAgentTabs(persistence));
+    await flush();
+
+    act(() => result.current.selectTab("c-1"));
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+    await flush();
+
+    // The GET fired but its (stale) result was discarded — local state wins
+    // and the debounce later PUTs it.
+    expect(get).toHaveBeenCalledTimes(2);
+    expect(result.current.activeTabId).toBe("c-1");
+    await advance(1100);
+    expect(put).toHaveBeenCalledTimes(1);
+    expect(put).toHaveBeenCalledWith(state({ activeTabId: "c-1" }));
+  });
+
+  it("never persists draft tabs: draft-only changes don't PUT, bindDraft persists the real id", async () => {
+    const { persistence, put } = fakePersistence();
+    const { result } = renderHook(() => useAgentTabs(persistence));
+    await flush();
+
+    // Opening (then focusing) a draft tab flips the persisted active to
+    // null — that PUT must carry conversation ids only.
+    act(() => result.current.newTab());
+    const draftId = result.current.activeTabId;
+    await advance(1100);
+    expect(put).toHaveBeenCalledTimes(1);
+    expect(put).toHaveBeenCalledWith({ open: true, activeTabId: null, tabs: ["c-1", "c-2"] });
+
+    // Closing the draft restores the persisted projection — no second PUT.
+    act(() => result.current.closeTab(draftId));
+    act(() => result.current.newTab());
+    const secondDraft = result.current.activeTabId;
+    await advance(1100);
+    expect(put).toHaveBeenCalledTimes(1);
+
+    // First send created the conversation: the draft rebinds and persists.
+    act(() => result.current.bindDraft(secondDraft, "c-9"));
+    expect(result.current.tabs).toEqual(["c-1", "c-2", "c-9"]);
+    expect(result.current.activeTabId).toBe("c-9");
+    await advance(1100);
+    expect(put).toHaveBeenCalledTimes(2);
+    expect(put).toHaveBeenLastCalledWith({
+      open: true,
+      activeTabId: "c-9",
+      tabs: ["c-1", "c-2", "c-9"],
+    });
+    for (const call of put.mock.calls) {
+      const persisted = call[0] as AgentSidebarState;
+      expect(persisted.tabs.some(isDraftTab)).toBe(false);
+      expect(persisted.activeTabId === null || !isDraftTab(persisted.activeTabId)).toBe(true);
+    }
+  });
+
+  it("runs local-only without persistence (stories/mocks): hydrated immediately, strip still works", async () => {
+    const { result } = renderHook(() => useAgentTabs(null));
+    await flush();
+
+    expect(result.current.hydrated).toBe(true);
+    act(() => result.current.openConversation("c-1"));
+    expect(result.current.tabs).toContain("c-1");
+  });
+
+  it("gates on enabled: no GET until the session is ready", async () => {
+    const { persistence, get } = fakePersistence();
+    const { result, rerender } = renderHook(
+      ({ enabled }) => useAgentTabs(persistence, { enabled }),
+      { initialProps: { enabled: false } },
+    );
+    await flush();
+    expect(get).not.toHaveBeenCalled();
+    expect(result.current.hydrated).toBe(false);
+
+    rerender({ enabled: true });
+    await flush();
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(result.current.tabs).toEqual(["c-1", "c-2"]);
+  });
+
+  it("flushes a pending mutation on unmount", async () => {
+    const { persistence, put } = fakePersistence();
+    const { result, unmount } = renderHook(() => useAgentTabs(persistence));
+    await flush();
+
+    act(() => result.current.selectTab("c-1"));
+    unmount();
+
+    // The cleanup fires the PUT synchronously — the debounce window must
+    // not swallow the last mutation on navigation.
+    expect(put).toHaveBeenCalledTimes(1);
+    expect(put).toHaveBeenCalledWith(state({ activeTabId: "c-1" }));
+  });
+});
+
+describe("deriveTabTitles", () => {
+  it("maps ids to history titles, drafts and unknown ids fall back to the draft title", () => {
+    const history = [
+      { items: [{ id: "c-1", title: "Billing question" }] },
+      { items: [{ id: "c-2", title: "Deploy help" }] },
+    ];
+    expect(deriveTabTitles(["c-2", "draft-x", "c-7"], history, "New chat")).toEqual([
+      { id: "c-2", title: "Deploy help" },
+      { id: "draft-x", title: "New chat" },
+      { id: "c-7", title: "New chat" },
+    ]);
+    expect(deriveTabTitles(["c-1"], undefined, "New chat")).toEqual([
+      { id: "c-1", title: "New chat" },
+    ]);
+  });
+});

--- a/src/hooks/agent-chat/useAgentTabs.ts
+++ b/src/hooks/agent-chat/useAgentTabs.ts
@@ -1,0 +1,421 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ChatTab } from "@/components/ui/agent/sidebar/types";
+
+// ---- Wire state (mirrors the agent service's /v1/sidebar-state) ----
+
+/** Persisted sidebar session — ONE row per platform user, shared by every
+ *  host (web-account, web-applications, future platforms). Tabs hold
+ *  conversation ids only; titles resolve from the conversation list each
+ *  host already loads. Local draft tabs are never part of this state. */
+export interface AgentSidebarState {
+  open: boolean;
+  /** Active tab's conversation id — null when a local draft was active. */
+  activeTabId: string | null;
+  /** Open tabs' conversation ids, strip order. */
+  tabs: string[];
+}
+
+/** Structural persistence surface for the tab strip. The kit stays
+ *  backend-agnostic: hosts inject any object with these methods —
+ *  api-client-shared's `agent` module satisfies them once its free
+ *  functions are bound to the host's service client:
+ *
+ *    const tabsPersistence: AgentTabsPersistence = {
+ *      get: () => getSidebarState(agentApi),
+ *      put: (state) => putSidebarState(agentApi, state),
+ *    };
+ *
+ *  PUTs are full replace, last-write-wins — v1 is a single user's own UI
+ *  state, so there is no version field to carry. */
+export interface AgentTabsPersistence {
+  get(): Promise<AgentSidebarState>;
+  put(state: AgentSidebarState): Promise<void>;
+}
+
+// ---- Draft tabs ----
+
+// A tab with no conversation yet — created locally, persisted never. The
+// host's chat layer lazy-creates the conversation on the first send, then
+// rebinds the tab through bindDraft so the next debounce persists it.
+const DRAFT_PREFIX = "draft-";
+export const isDraftTab = (id: string) => id.startsWith(DRAFT_PREFIX);
+const freshDraft = () => `${DRAFT_PREFIX}${crypto.randomUUID()}`;
+
+// ---- Pure strip transitions (the hook's internal state machine) ----
+
+interface StripState {
+  open: boolean;
+  tabs: string[];
+  activeTabId: string;
+}
+
+const initialStrip = (open = false): StripState => {
+  const draft = freshDraft();
+  return { open, tabs: [draft], activeTabId: draft };
+};
+
+const selectTabState = (s: StripState, id: string): StripState =>
+  s.activeTabId !== id && s.tabs.includes(id) ? { ...s, activeTabId: id } : s;
+
+/** Close ≠ delete: drop the tab from the strip only. Closing the active tab
+ *  activates its right neighbor (the tab now at the closed index), or the
+ *  left one when the rightmost tab closes — browser tab-strip behavior.
+ *  Closing the only tab falls back to the given fresh draft. The draft is
+ *  created by the caller so this updater stays pure. */
+const closeTabState = (s: StripState, id: string, draft: string): StripState => {
+  const index = s.tabs.indexOf(id);
+  if (index === -1) return s;
+  const next = s.tabs.filter((tab) => tab !== id);
+  if (next.length === 0) return { ...s, tabs: [draft], activeTabId: draft };
+  return {
+    ...s,
+    tabs: next,
+    activeTabId: s.activeTabId === id ? next[Math.min(index, next.length - 1)] : s.activeTabId,
+  };
+};
+
+const addDraftState = (s: StripState, draft: string): StripState => ({
+  ...s,
+  tabs: [...s.tabs, draft],
+  activeTabId: draft,
+});
+
+/** Open a past conversation as a tab, or refocus its existing tab. */
+const openConversationState = (s: StripState, id: string): StripState =>
+  s.tabs.includes(id)
+    ? selectTabState(s, id)
+    : { ...s, tabs: [...s.tabs, id], activeTabId: id };
+
+const moveTabState = (s: StripState, id: string, toIndex: number): StripState => {
+  const from = s.tabs.indexOf(id);
+  if (from === -1) return s;
+  const to = Math.max(0, Math.min(toIndex, s.tabs.length - 1));
+  if (from === to) return s;
+  const tabs = [...s.tabs];
+  tabs.splice(from, 1);
+  tabs.splice(to, 0, id);
+  return { ...s, tabs };
+};
+
+/** First send created the conversation — the draft tab becomes its tab in
+ *  place. If the conversation already has a tab (opened from history while
+ *  the send was in flight), the draft dissolves into it instead. */
+const bindDraftState = (s: StripState, draftId: string, conversationId: string): StripState => {
+  if (!s.tabs.includes(draftId)) return s;
+  const tabs = s.tabs.includes(conversationId)
+    ? s.tabs.filter((tab) => tab !== draftId)
+    : s.tabs.map((tab) => (tab === draftId ? conversationId : tab));
+  return {
+    ...s,
+    tabs,
+    activeTabId: s.activeTabId === draftId ? conversationId : s.activeTabId,
+  };
+};
+
+// Project the strip onto the wire: drafts are NEVER persisted — reload
+// drops empty drafts by design (the first send creates the conversation
+// and the next debounce persists it).
+const toPersisted = (s: StripState): AgentSidebarState => ({
+  open: s.open,
+  activeTabId: isDraftTab(s.activeTabId) ? null : s.activeTabId,
+  tabs: s.tabs.filter((id) => !isDraftTab(id)),
+});
+
+const sameIds = (a: readonly string[], b: readonly string[]) =>
+  a.length === b.length && a.every((id, i) => id === b[i]);
+
+const samePersisted = (a: AgentSidebarState, b: AgentSidebarState) =>
+  a.open === b.open && a.activeTabId === b.activeTabId && sameIds(a.tabs, b.tabs);
+
+const sameStrip = (a: StripState, b: StripState) =>
+  a.open === b.open && a.activeTabId === b.activeTabId && sameIds(a.tabs, b.tabs);
+
+// Reconcile a fetched remote state into the local strip. Hydration replaces
+// the untouched initial placeholder outright; refetches (and hydration after
+// a local mutation) keep local drafts — they exist on this host only, so the
+// server can't know about them. The locally active tab keeps focus when it
+// survives; otherwise the remote active wins, then the first tab.
+function applyRemote(prev: StripState, remote: AgentSidebarState, ids: string[], keepDrafts: boolean): StripState {
+  const drafts = keepDrafts ? prev.tabs.filter(isDraftTab) : [];
+  const tabs = [...ids, ...drafts];
+  if (tabs.length === 0) return initialStrip(remote.open);
+  let activeTabId: string;
+  if (keepDrafts && tabs.includes(prev.activeTabId)) activeTabId = prev.activeTabId;
+  else if (remote.activeTabId && tabs.includes(remote.activeTabId)) activeTabId = remote.activeTabId;
+  else activeTabId = tabs[0];
+  return { open: remote.open, tabs, activeTabId };
+}
+
+// ---- Title derivation (render-time, host-side) ----
+
+/** Resolve tab titles from the host's history groups so renames (optimistic,
+ *  with rollback) and server auto-titles flow into the strip for free.
+ *  Drafts (and tabs whose conversation hasn't hit history yet) fall back to
+ *  the localized `draftTitle`. */
+export const deriveTabTitles = (
+  ids: readonly string[],
+  history: ReadonlyArray<{ items: ReadonlyArray<{ id: string; title: string }> }> | undefined,
+  draftTitle: string,
+): ChatTab[] => {
+  const titles = new Map<string, string>();
+  for (const group of history ?? []) {
+    for (const item of group.items) titles.set(item.id, item.title);
+  }
+  return ids.map((id) => ({ id, title: titles.get(id) ?? draftTitle }));
+};
+
+// ---- The hook ----
+
+const DEFAULT_DEBOUNCE_MS = 1000;
+
+export interface UseAgentTabsOptions {
+  /** Gate hydration and persistence (e.g. on the session being ready).
+   *  Default true. The strip works local-only while disabled. */
+  enabled?: boolean;
+  /**
+   * Drop hydrated ids the host can't resolve (deleted conversations heal
+   * silently): given the fetched conversation ids, return the subset that
+   * still resolve. Resolve against an UNFILTERED source — the strip is
+   * global per user, a tab may hold a conversation from another scope.
+   * Errors keep all ids (don't drop tabs on a transient failure).
+   */
+  resolveTabs?: (ids: string[]) => string[] | Promise<string[]>;
+  /** Trailing debounce for PUTs. Default 1000ms. */
+  debounceMs?: number;
+}
+
+export interface UseAgentTabsResult {
+  /** Sidebar open/closed — persisted, shared across hosts. */
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  /** Open tabs as ids (conversation ids + local draft ids), strip order.
+   *  Map to titled ChatTabs with deriveTabTitles. */
+  tabs: string[];
+  activeTabId: string;
+  /** True once the mount GET settled (or no persistence was injected). */
+  hydrated: boolean;
+  selectTab: (id: string) => void;
+  /** Close ≠ delete: removes the tab from the strip everywhere — the
+   *  conversation stays in history. */
+  closeTab: (id: string) => void;
+  /** Open a fresh draft tab (no conversation until the first send). */
+  newTab: () => void;
+  /** Open a past conversation as a tab, or refocus its existing tab. */
+  openConversation: (id: string) => void;
+  /** Reorder: move a tab to the given strip index (clamped). */
+  moveTab: (id: string, toIndex: number) => void;
+  /** Rebind a draft tab to its lazily-created conversation so the strip
+   *  (and the next debounce) carries the real id. */
+  bindDraft: (draftId: string, conversationId: string) => void;
+}
+
+/**
+ * Cross-platform agent tab strip: open tabs + active tab + sidebar open
+ * flag, hydrated from and persisted to the agent service so every host
+ * shows the same strip. Backend-agnostic — the transport is injected
+ * (`persistence`, structural; null runs the strip local-only, e.g. in
+ * stories). Mutations (select/close/open/reorder tab, sidebar open/close)
+ * PUT debounced (trailing, ~1s); the strip refetches on window focus /
+ * visibilitychange so concurrent hosts converge — skipped while a local
+ * mutation is pending flush so it can't clobber newer local state.
+ *
+ * `persistence` and `resolveTabs` are read through refs — their identities
+ * may change per render without retriggering fetches.
+ */
+export function useAgentTabs(
+  persistence: AgentTabsPersistence | null,
+  options: UseAgentTabsOptions = {},
+): UseAgentTabsResult {
+  const { enabled = true, debounceMs = DEFAULT_DEBOUNCE_MS } = options;
+
+  // Injected collaborators ride refs so unstable identities (inline object
+  // literals at the call site) don't churn effects or callbacks.
+  const persistenceRef = useRef(persistence);
+  persistenceRef.current = persistence;
+  const resolveTabsRef = useRef(options.resolveTabs);
+  resolveTabsRef.current = options.resolveTabs;
+  const enabledRef = useRef(enabled);
+  enabledRef.current = enabled;
+  const debounceMsRef = useRef(debounceMs);
+  debounceMsRef.current = debounceMs;
+
+  const [strip, setStrip] = useState<StripState>(initialStrip);
+  const [hydrated, setHydrated] = useState(false);
+
+  // The strip rides a ref alongside state: mutations read/write it
+  // synchronously (so back-to-back mutations in one tick compose) and the
+  // trailing flush PUTs the latest value, not a stale closure.
+  const stripRef = useRef(strip);
+  // What the server is known to hold — set on hydrate/refetch and after a
+  // successful PUT. Draft-only churn projects onto the same wire state, so
+  // comparing against this skips redundant writes entirely.
+  const lastPersistedRef = useRef<AgentSidebarState>(toPersisted(strip));
+  // Set once any local mutation happened — hydration then keeps local
+  // drafts instead of replacing the untouched initial placeholder.
+  const touchedRef = useRef(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // True from the first unflushed mutation until its PUT settles. While
+  // pending, fetched states are discarded (local wins; the flush PUTs it).
+  const pendingRef = useRef(false);
+  // Guards stale GET responses racing a newer fetch.
+  const fetchSeq = useRef(0);
+
+  const schedulePut = useCallback(() => {
+    if (!persistenceRef.current || !enabledRef.current) return;
+    pendingRef.current = true;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      const p = persistenceRef.current;
+      const payload = toPersisted(stripRef.current);
+      // Mutations may have circled back to the persisted state (e.g. a
+      // draft opened then closed) — nothing to write.
+      if (!p || samePersisted(payload, lastPersistedRef.current)) {
+        pendingRef.current = false;
+        return;
+      }
+      p.put(payload)
+        .then(() => {
+          lastPersistedRef.current = payload;
+        })
+        .catch((err) => {
+          // LWW: drop it — the next mutation re-PUTs the full state.
+          console.error("agent: sidebar state put failed", err);
+        })
+        .finally(() => {
+          // A newer mutation may have re-armed the timer mid-flight.
+          if (!timerRef.current) pendingRef.current = false;
+        });
+    }, debounceMsRef.current);
+  }, []);
+
+  const mutate = useCallback(
+    (updater: (s: StripState) => StripState) => {
+      const prev = stripRef.current;
+      const next = updater(prev);
+      if (next === prev) return;
+      touchedRef.current = true;
+      stripRef.current = next;
+      setStrip(next);
+      // Draft-only changes don't reach the wire — PUT only when the
+      // persisted projection actually moved off the server's state.
+      if (!samePersisted(toPersisted(next), lastPersistedRef.current)) schedulePut();
+    },
+    [schedulePut],
+  );
+
+  const reconcile = useCallback(async (mode: "hydrate" | "refetch") => {
+    const p = persistenceRef.current;
+    if (!p) {
+      if (mode === "hydrate") setHydrated(true);
+      return;
+    }
+    const seq = ++fetchSeq.current;
+    try {
+      const remote = await p.get();
+      if (fetchSeq.current !== seq || pendingRef.current) return;
+      // Defensive: the wire never carries drafts, but never trust it to.
+      let ids = remote.tabs.filter((id) => !isDraftTab(id));
+      if (resolveTabsRef.current && ids.length > 0) {
+        try {
+          ids = await resolveTabsRef.current(ids);
+        } catch (err) {
+          console.error("agent: resolve tabs failed", err);
+        }
+        if (fetchSeq.current !== seq || pendingRef.current) return;
+      }
+      const prev = stripRef.current;
+      const next = applyRemote(prev, remote, ids, mode === "refetch" || touchedRef.current);
+      // Healed drops stay silent (no write-back) — the next real mutation
+      // PUTs the full healed state anyway.
+      lastPersistedRef.current = toPersisted(next);
+      if (!sameStrip(prev, next)) {
+        stripRef.current = next;
+        setStrip(next);
+      }
+    } catch (err) {
+      console.error("agent: sidebar state get failed", err);
+    } finally {
+      if (mode === "hydrate" && fetchSeq.current === seq) setHydrated(true);
+    }
+  }, []);
+
+  // ---- Hydrate on mount (requirement 1: reload restores the strip) ----
+  useEffect(() => {
+    if (!enabled) return;
+    void reconcile("hydrate");
+  }, [enabled, reconcile]);
+
+  // ---- Converge concurrent hosts on focus/visibility (requirement 4) ----
+  useEffect(() => {
+    if (!enabled) return;
+    const onVisible = () => {
+      if (document.visibilityState === "visible") void reconcile("refetch");
+    };
+    window.addEventListener("focus", onVisible);
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      window.removeEventListener("focus", onVisible);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [enabled, reconcile]);
+
+  // Best-effort flush on unmount so a mutation inside the debounce window
+  // isn't lost on navigation.
+  useEffect(
+    () => () => {
+      if (!timerRef.current) return;
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+      pendingRef.current = false;
+      const payload = toPersisted(stripRef.current);
+      if (samePersisted(payload, lastPersistedRef.current)) return;
+      persistenceRef.current?.put(payload).catch(() => {});
+    },
+    [],
+  );
+
+  const setOpen = useCallback(
+    (open: boolean) => mutate((s) => (s.open === open ? s : { ...s, open })),
+    [mutate],
+  );
+  const selectTab = useCallback((id: string) => mutate((s) => selectTabState(s, id)), [mutate]);
+  const closeTab = useCallback(
+    (id: string) => {
+      const draft = freshDraft();
+      mutate((s) => closeTabState(s, id, draft));
+    },
+    [mutate],
+  );
+  const newTab = useCallback(() => {
+    const draft = freshDraft();
+    mutate((s) => addDraftState(s, draft));
+  }, [mutate]);
+  const openConversation = useCallback(
+    (id: string) => mutate((s) => openConversationState(s, id)),
+    [mutate],
+  );
+  const moveTab = useCallback(
+    (id: string, toIndex: number) => mutate((s) => moveTabState(s, id, toIndex)),
+    [mutate],
+  );
+  const bindDraft = useCallback(
+    (draftId: string, conversationId: string) =>
+      mutate((s) => bindDraftState(s, draftId, conversationId)),
+    [mutate],
+  );
+
+  return {
+    open: strip.open,
+    setOpen,
+    tabs: strip.tabs,
+    activeTabId: strip.activeTabId,
+    hydrated,
+    selectTab,
+    closeTab,
+    newTab,
+    openConversation,
+    moveTab,
+    bindDraft,
+  };
+}

--- a/src/hooks/agent-chat/useAgentTabs.ts
+++ b/src/hooks/agent-chat/useAgentTabs.ts
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { ChatTab } from "@/components/ui/agent/sidebar/types";
+
+/** A single tab in the agent sidebar header strip. Defined here — the data
+ *  layer owns the definitions so it never imports from the component layer;
+ *  `sidebar/types.ts` re-exports it for component consumers. */
+export interface ChatTab {
+  id: string;
+  title: string;
+}
 
 // ---- Wire state (mirrors the agent service's /v1/sidebar-state) ----
 
@@ -60,13 +67,16 @@ const selectTabState = (s: StripState, id: string): StripState =>
 /** Close ≠ delete: drop the tab from the strip only. Closing the active tab
  *  activates its right neighbor (the tab now at the closed index), or the
  *  left one when the rightmost tab closes — browser tab-strip behavior.
- *  Closing the only tab falls back to the given fresh draft. The draft is
- *  created by the caller so this updater stays pure. */
-const closeTabState = (s: StripState, id: string, draft: string): StripState => {
+ *  Closing the only tab falls back to a fresh draft from the given factory
+ *  (invoked only when actually needed). */
+const closeTabState = (s: StripState, id: string, makeDraft: () => string): StripState => {
   const index = s.tabs.indexOf(id);
   if (index === -1) return s;
   const next = s.tabs.filter((tab) => tab !== id);
-  if (next.length === 0) return { ...s, tabs: [draft], activeTabId: draft };
+  if (next.length === 0) {
+    const draft = makeDraft();
+    return { ...s, tabs: [draft], activeTabId: draft };
+  }
   return {
     ...s,
     tabs: next,
@@ -133,11 +143,25 @@ const sameStrip = (a: StripState, b: StripState) =>
 // Reconcile a fetched remote state into the local strip. Hydration replaces
 // the untouched initial placeholder outright; refetches (and hydration after
 // a local mutation) keep local drafts — they exist on this host only, so the
-// server can't know about them. The locally active tab keeps focus when it
-// survives; otherwise the remote active wins, then the first tab.
+// server can't know about them. The merge happens in place: surviving
+// conversation tabs adopt the remote (strip) order, drafts keep their
+// interleaved positions, tabs closed elsewhere drop, tabs opened elsewhere
+// append. The locally active tab keeps focus when it survives; otherwise
+// the remote active wins, then the first tab.
 function applyRemote(prev: StripState, remote: AgentSidebarState, ids: string[], keepDrafts: boolean): StripState {
-  const drafts = keepDrafts ? prev.tabs.filter(isDraftTab) : [];
-  const tabs = [...ids, ...drafts];
+  const prevTabs = new Set(prev.tabs);
+  const idSet = new Set(ids);
+  const survivors = ids.filter((id) => prevTabs.has(id));
+  let s = 0;
+  const tabs: string[] = [];
+  for (const tab of prev.tabs) {
+    if (isDraftTab(tab)) {
+      if (keepDrafts) tabs.push(tab);
+    } else if (idSet.has(tab)) {
+      tabs.push(survivors[s++]);
+    }
+  }
+  for (const id of ids) if (!prevTabs.has(id)) tabs.push(id);
   if (tabs.length === 0) return initialStrip(remote.open);
   let activeTabId: string;
   if (keepDrafts && tabs.includes(prev.activeTabId)) activeTabId = prev.activeTabId;
@@ -277,14 +301,14 @@ export function useAgentTabs(
       p.put(payload)
         .then(() => {
           lastPersistedRef.current = payload;
-        })
-        .catch((err) => {
-          // LWW: drop it — the next mutation re-PUTs the full state.
-          console.error("agent: sidebar state put failed", err);
-        })
-        .finally(() => {
           // A newer mutation may have re-armed the timer mid-flight.
           if (!timerRef.current) pendingRef.current = false;
+        })
+        .catch((err) => {
+          // Stay pending: the local state is still unsynced, so focus
+          // refetches keep being skipped and can't clobber it with the
+          // stale server state. The next mutation re-PUTs the full state.
+          console.error("agent: sidebar state put failed", err);
         });
     }, debounceMsRef.current);
   }, []);
@@ -305,6 +329,9 @@ export function useAgentTabs(
   );
 
   const reconcile = useCallback(async (mode: "hydrate" | "refetch") => {
+    // An unflushed local mutation always wins over a fetched state — skip
+    // the round-trip entirely, the flush will PUT the local state.
+    if (mode === "refetch" && pendingRef.current) return;
     const p = persistenceRef.current;
     if (!p) {
       if (mode === "hydrate") setHydrated(true);
@@ -381,10 +408,7 @@ export function useAgentTabs(
   );
   const selectTab = useCallback((id: string) => mutate((s) => selectTabState(s, id)), [mutate]);
   const closeTab = useCallback(
-    (id: string) => {
-      const draft = freshDraft();
-      mutate((s) => closeTabState(s, id, draft));
-    },
+    (id: string) => mutate((s) => closeTabState(s, id, freshDraft)),
     [mutate],
   );
   const newTab = useCallback(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -496,6 +496,15 @@ export {
   type ConversationHistoryItem,
   type RecencyLabels,
 } from "./hooks/agent-chat/history";
+export {
+  useAgentTabs,
+  isDraftTab,
+  deriveTabTitles,
+  type AgentSidebarState,
+  type AgentTabsPersistence,
+  type UseAgentTabsOptions,
+  type UseAgentTabsResult,
+} from "./hooks/agent-chat/useAgentTabs";
 export type {
   AgentApiMessage,
   AgentChatClient,


### PR DESCRIPTION
> [!WARNING]
> **STACKED on #288** (`feat/agent-chat-hooks`) — merge #288 first, then retarget this PR to `main`. Merging as-is merges into the stack base, not main.

Implements the kit tier of [08-sidebar-cross-platform-session.md](https://github.com/mirrorstack-ai/mirrorstack-docs) (spec sections "Behavior mapping" + "Code placement"): the agent sidebar tab strip becomes kit-owned state, hydrated from and persisted to the agent service so every platform host (web-account, web-applications, future hosts) shows the same strip.

## What's in it

**`useAgentTabs(persistence, opts)`** — `src/hooks/agent-chat/useAgentTabs.ts`

- **Structural persistence injection**: `AgentTabsPersistence = { get(): Promise<AgentSidebarState>; put(state): Promise<void> }` over the wire shape `{ open, activeTabId, tabs: string[] }`. api-client-shared's upcoming `getSidebarState`/`putSidebarState` bind to it; the kit imports nothing from it. `null` runs the strip local-only (stories/mocks).
- **Hydrate on mount** (req 1/2): tabs + active tab + open flag restored; `opts.resolveTabs` drops ids the host can't resolve, so deleted conversations heal silently.
- **Debounced persistence** (~1s trailing, `opts.debounceMs`): one PUT coalesces tab select/close/open/reorder and sidebar open/close; redundant writes (projection unchanged vs server state) are skipped; best-effort flush on unmount.
- **Focus/visibilitychange refetch** (req 4): concurrent hosts converge; skipped while a local mutation is pending flush so it can't clobber newer local state; local drafts survive refetch.
- **Draft tabs are NEVER persisted**: the persisted projection strips `draft-*` ids and nulls a draft active tab; `bindDraft(draftId, conversationId)` rebinds after the first send creates the conversation, and the next debounce persists the real id.
- **Ported pure transitions** from web-applications #63's `src/lib/agent-tabs.ts` (select/close-with-neighbor-focus/add-draft/open-conversation + `deriveTabTitles`, plus `moveTab` reorder) — hosts delete their copies. Tabs expose as **ids**; hosts map titles via the exported `deriveTabTitles(ids, history, draftTitle)`.

## API

```ts
useAgentTabs(persistence: AgentTabsPersistence | null, opts?: {
  enabled?: boolean;                                        // gate on session ready
  resolveTabs?: (ids: string[]) => string[] | Promise<string[]>;
  debounceMs?: number;                                      // default 1000
}): {
  open, setOpen, tabs /* ids */, activeTabId, hydrated,
  selectTab, closeTab, newTab, openConversation, moveTab, bindDraft,
}
```

Also exported: `isDraftTab`, `deriveTabTitles`, `AgentSidebarState`, `AgentTabsPersistence`.

## Versioning

**No version bump** — rides the next rollup release after 0.4.12 (per the batch-release convention), unless you want to fold it into 0.4.12.

## Verification

- `pnpm typecheck` clean
- `pnpm test`: 69 files / 704 tests green, incl. 12 new (hydrate restore, resolveTabs drop, empty-session, debounce coalescing w/ fake timers, close persists removal, focus refetch + draft survival, pending-flush refetch skip, draft exclusion + bindDraft, local-only mode, enabled gate, unmount flush, deriveTabTitles)
- `eslint` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)