### PR TITLE
feat: persist agent sidebar width across reloads (0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.5.1
+
+- `AppShell`: the drag-resized agent sidebar width now persists across reloads.
+  The chosen width is saved to `localStorage` (key `ms.agentSidebar.width`) on
+  resize and restored on reopen — closing/collapsing no longer forgets the size.
+  SSR-safe (read in an effect after mount, default on the server pass);
+  rehydrated values are clamped to the drag bounds and corrupt/out-of-range
+  values are ignored. No host changes required — every `AppShell` consumer
+  inherits it.
+- `SidebarProvider`: new optional `persistKey` / `minOpenWidth` / `maxOpenWidth`
+  props and a `lastOpenWidth` context value to drive the persisted reopen size.
+  New `SIDEBAR_WIDTH_STORAGE_KEY` export.
+
 ## 0.5.0
 
 Agent sidebar surface reachable through `AppShell`, headless agent-chat hooks,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/AppShell.stories.tsx
+++ b/src/components/layout/app-shell/AppShell.stories.tsx
@@ -411,3 +411,16 @@ export const Playground: Story = {
     </AppShell>
   ),
 };
+
+// The agent sidebar's drag-resized width persists to localStorage
+// (`ms.agentSidebar.width`). To verify: open the sidebar (floating robot
+// button), drag the left edge to resize, then reload this story — the sidebar
+// reopens at the width you chose, not the default. Closing/collapsing keeps the
+// remembered size. Use the toolbar to clear localStorage if you want to reset.
+export const PersistedSidebarWidth: Story = {
+  render: () => (
+    <AppShell navigation={<DemoRail />} appSwitcher={appSwitcher} {...agentProps}>
+      <DemoContent />
+    </AppShell>
+  ),
+};

--- a/src/components/layout/app-shell/AppShell.test.tsx
+++ b/src/components/layout/app-shell/AppShell.test.tsx
@@ -198,3 +198,29 @@ describe("AppShell agent sidebar pass-through", () => {
     expect(screen.getByRole("tab", { name: /^Chat 1/ })).toBeInTheDocument();
   });
 });
+
+describe("AppShell sidebar width persistence", () => {
+  afterEach(() => localStorage.clear());
+
+  it("reopens to the persisted width after reload (clamped to the viewport)", () => {
+    // Simulate a prior session that drag-resized to 500px. jsdom's
+    // window.innerWidth is 1024, so 500 is well within [350, 1004].
+    localStorage.setItem("ms.agentSidebar.width", "500");
+
+    render(<AppShell>content</AppShell>);
+    // Sidebar starts closed (toggle button shown), not auto-opened.
+    fireEvent.click(screen.getByLabelText("Open agent"));
+
+    // The agent inner panel width reflects the rehydrated 500, not the 350
+    // floor — the persisted size survived the "reload".
+    expect(document.querySelector('[style*="width: 500px"]')).not.toBeNull();
+  });
+
+  it("ignores a corrupt persisted value and uses the default reopen behavior", () => {
+    localStorage.setItem("ms.agentSidebar.width", "garbage");
+    render(<AppShell>content</AppShell>);
+    fireEvent.click(screen.getByLabelText("Open agent"));
+    // No 500px panel — reopen fell back to the 50%-of-viewport default.
+    expect(document.querySelector('[style*="width: 500px"]')).toBeNull();
+  });
+});

--- a/src/components/layout/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/AppShell.tsx
@@ -2,7 +2,11 @@ import { useState, useRef, useEffect, type ReactNode } from "react";
 import { cn } from "@/utils/cn";
 import type { ComponentMeta } from "@/types/component-meta";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
-import { SidebarProvider, useSidebarWidth } from "@/context/sidebar/SidebarProvider";
+import {
+  SidebarProvider,
+  useSidebarWidth,
+  SIDEBAR_WIDTH_STORAGE_KEY,
+} from "@/context/sidebar/SidebarProvider";
 import {
   SnackbarProvider,
   SnackbarOutlet,
@@ -106,7 +110,15 @@ export interface AppShellProps {
 
 export function AppShell(props: AppShellProps) {
   return (
-    <SidebarProvider defaultWidth={0}>
+    // Start closed (0); persist the drag-resized OPEN width so it survives
+    // reload. minOpenWidth matches the resize floor below; the provider clamps
+    // a rehydrated value to [MIN_WIDTH, viewport] and ignores corrupt/oversized
+    // stored values.
+    <SidebarProvider
+      defaultWidth={0}
+      persistKey={SIDEBAR_WIDTH_STORAGE_KEY}
+      minOpenWidth={MIN_WIDTH}
+    >
       <SnackbarProvider>
         <AppShellInner {...props} />
       </SnackbarProvider>
@@ -235,7 +247,7 @@ function AppShellInner({
   agentInputPlaceholder,
   agentInputLabels,
 }: AppShellProps) {
-  const { sidebarWidth, setSidebarWidth } = useSidebarWidth();
+  const { sidebarWidth, setSidebarWidth, lastOpenWidth } = useSidebarWidth();
   const [isResizing, setIsResizing] = useState(false);
   const [windowWidth, setWindowWidth] = useState(() =>
     typeof window === "undefined" ? 0 : window.innerWidth,
@@ -301,9 +313,20 @@ function AppShellInner({
   // Keep dragWidthRef in sync when sidebar opens
   useEffect(() => { dragWidthRef.current = sidebarWidth; }, [sidebarWidth]);
 
+  // Reopen to the user's remembered (persisted) width, clamped to the live
+  // viewport. Falls back to half the viewport when no wider width was ever
+  // recorded (lastOpenWidth still at the MIN_WIDTH floor).
+  const reopenWidth = () => {
+    const remembered =
+      lastOpenWidth > MIN_WIDTH
+        ? lastOpenWidth
+        : (windowWidth || 1000) * 0.5;
+    return Math.min(Math.max(remembered, MIN_WIDTH), maxWidthRef.current);
+  };
+
   const handleToggleCollapse = () => {
     if (sidebarWidth <= MIN_WIDTH) {
-      setSidebarWidth(Math.min((windowWidth || 1000) * 0.5, maxWidthRef.current));
+      setSidebarWidth(reopenWidth());
     } else {
       setSidebarWidth(MIN_WIDTH);
     }
@@ -454,7 +477,7 @@ function AppShellInner({
           variant="tonal"
           size="md"
           className="fixed top-2 right-2 z-50"
-          onClick={() => setSidebarWidth(MIN_WIDTH)}
+          onClick={() => setSidebarWidth(reopenWidth())}
           aria-label="Open agent"
         />
       )}

--- a/src/context/sidebar/SidebarProvider.test.tsx
+++ b/src/context/sidebar/SidebarProvider.test.tsx
@@ -1,15 +1,25 @@
 import { cleanup, render, screen, fireEvent, act } from "@testing-library/react";
-import { describe, expect, it, afterEach } from "vitest";
-import { SidebarProvider, useSidebarWidth } from "./SidebarProvider";
+import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
+import {
+  SidebarProvider,
+  useSidebarWidth,
+  SIDEBAR_WIDTH_STORAGE_KEY,
+} from "./SidebarProvider";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
 
 function TestConsumer() {
-  const { sidebarWidth, setSidebarWidth } = useSidebarWidth();
+  const { sidebarWidth, setSidebarWidth, lastOpenWidth } = useSidebarWidth();
   return (
     <div>
       <span data-testid="width">{sidebarWidth}</span>
+      <span data-testid="last-open">{lastOpenWidth}</span>
       <button onClick={() => setSidebarWidth(500)}>Resize</button>
+      <button onClick={() => setSidebarWidth(0)}>Close</button>
     </div>
   );
 }
@@ -49,5 +59,147 @@ describe("SidebarProvider", () => {
     expect(() => render(<TestConsumer />)).toThrow(
       "useSidebarWidth must be used within a SidebarProvider",
     );
+  });
+});
+
+describe("SidebarProvider persistence", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("does not read localStorage at module load (SSR-safe — value applied after mount)", () => {
+    // A pre-existing stored value must NOT bleed into the first render: the
+    // default stands on the SSR/first pass, the stored value applies in an
+    // effect. Guards against hydration mismatch.
+    localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, "500");
+    const getItem = vi.spyOn(Storage.prototype, "getItem");
+
+    render(
+      <SidebarProvider
+        defaultWidth={0}
+        persistKey={SIDEBAR_WIDTH_STORAGE_KEY}
+        maxOpenWidth={2000}
+      >
+        <TestConsumer />
+      </SidebarProvider>,
+    );
+
+    // The width state still reflects the default on the committed render — the
+    // sidebar doesn't auto-open from a persisted width.
+    expect(screen.getByTestId("width").textContent).toBe("0");
+    // After mount, lastOpenWidth carries the rehydrated value for reopen.
+    expect(screen.getByTestId("last-open").textContent).toBe("500");
+    getItem.mockRestore();
+  });
+
+  it("persists a resize and exposes it as lastOpenWidth", () => {
+    render(
+      <SidebarProvider
+        defaultWidth={0}
+        persistKey={SIDEBAR_WIDTH_STORAGE_KEY}
+        maxOpenWidth={2000}
+      >
+        <TestConsumer />
+      </SidebarProvider>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText("Resize"));
+    });
+    expect(localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)).toBe("500");
+    expect(screen.getByTestId("last-open").textContent).toBe("500");
+  });
+
+  it("a close (width 0) does not erase the persisted open width", () => {
+    render(
+      <SidebarProvider
+        defaultWidth={0}
+        persistKey={SIDEBAR_WIDTH_STORAGE_KEY}
+        maxOpenWidth={2000}
+      >
+        <TestConsumer />
+      </SidebarProvider>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText("Resize"));
+    });
+    act(() => {
+      fireEvent.click(screen.getByText("Close"));
+    });
+    expect(screen.getByTestId("width").textContent).toBe("0");
+    // lastOpenWidth and the stored value both survive the close.
+    expect(screen.getByTestId("last-open").textContent).toBe("500");
+    expect(localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)).toBe("500");
+  });
+
+  it("rehydrates a valid stored width", () => {
+    localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, "480");
+    render(
+      <SidebarProvider
+        defaultWidth={0}
+        persistKey={SIDEBAR_WIDTH_STORAGE_KEY}
+        maxOpenWidth={2000}
+      >
+        <TestConsumer />
+      </SidebarProvider>,
+    );
+    expect(screen.getByTestId("last-open").textContent).toBe("480");
+  });
+
+  it("ignores an out-of-range stored width (above max), falling back to default", () => {
+    localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, "5000");
+    render(
+      <SidebarProvider
+        defaultWidth={0}
+        persistKey={SIDEBAR_WIDTH_STORAGE_KEY}
+        minOpenWidth={350}
+        maxOpenWidth={2000}
+      >
+        <TestConsumer />
+      </SidebarProvider>,
+    );
+    expect(screen.getByTestId("last-open").textContent).toBe("0");
+  });
+
+  it("ignores an out-of-range stored width (below min), falling back to default", () => {
+    localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, "100");
+    render(
+      <SidebarProvider
+        defaultWidth={0}
+        persistKey={SIDEBAR_WIDTH_STORAGE_KEY}
+        minOpenWidth={350}
+        maxOpenWidth={2000}
+      >
+        <TestConsumer />
+      </SidebarProvider>,
+    );
+    expect(screen.getByTestId("last-open").textContent).toBe("0");
+  });
+
+  it("ignores a corrupt stored value, falling back to default", () => {
+    localStorage.setItem(SIDEBAR_WIDTH_STORAGE_KEY, "not-a-number");
+    render(
+      <SidebarProvider
+        defaultWidth={0}
+        persistKey={SIDEBAR_WIDTH_STORAGE_KEY}
+        maxOpenWidth={2000}
+      >
+        <TestConsumer />
+      </SidebarProvider>,
+    );
+    expect(screen.getByTestId("last-open").textContent).toBe("0");
+  });
+
+  it("does not persist when persistKey is omitted", () => {
+    render(
+      <SidebarProvider defaultWidth={0}>
+        <TestConsumer />
+      </SidebarProvider>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText("Resize"));
+    });
+    expect(localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)).toBeNull();
+    // In-memory state still updates.
+    expect(screen.getByTestId("last-open").textContent).toBe("500");
   });
 });

--- a/src/context/sidebar/SidebarProvider.test.tsx
+++ b/src/context/sidebar/SidebarProvider.test.tsx
@@ -20,6 +20,7 @@ function TestConsumer() {
       <span data-testid="last-open">{lastOpenWidth}</span>
       <button onClick={() => setSidebarWidth(500)}>Resize</button>
       <button onClick={() => setSidebarWidth(0)}>Close</button>
+      <button onClick={() => setSidebarWidth(350)}>Collapse</button>
     </div>
   );
 }
@@ -127,6 +128,35 @@ describe("SidebarProvider persistence", () => {
     });
     expect(screen.getByTestId("width").textContent).toBe("0");
     // lastOpenWidth and the stored value both survive the close.
+    expect(screen.getByTestId("last-open").textContent).toBe("500");
+    expect(localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)).toBe("500");
+  });
+
+  it("a collapse (width === minOpenWidth) does not erase the persisted open width", () => {
+    // AppShell collapses by setting the width to the floor (MIN_WIDTH ===
+    // minOpenWidth). That floor value is the collapsed state, not a real open
+    // width, so it must NOT overwrite the remembered drag size — otherwise
+    // reopen falls back to the default and the user's chosen size is lost.
+    render(
+      <SidebarProvider
+        defaultWidth={0}
+        persistKey={SIDEBAR_WIDTH_STORAGE_KEY}
+        minOpenWidth={350}
+        maxOpenWidth={2000}
+      >
+        <TestConsumer />
+      </SidebarProvider>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText("Resize"));
+    });
+    act(() => {
+      fireEvent.click(screen.getByText("Collapse"));
+    });
+    // The live width follows the collapse to the floor.
+    expect(screen.getByTestId("width").textContent).toBe("350");
+    // But the remembered open width (in memory AND storage) still holds the
+    // user's dragged 500 — the collapse did not clobber it.
     expect(screen.getByTestId("last-open").textContent).toBe("500");
     expect(localStorage.getItem(SIDEBAR_WIDTH_STORAGE_KEY)).toBe("500");
   });

--- a/src/context/sidebar/SidebarProvider.tsx
+++ b/src/context/sidebar/SidebarProvider.tsx
@@ -1,27 +1,136 @@
-import { createContext, useContext, useState, type ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 
 export interface SidebarContextType {
   sidebarWidth: number;
   setSidebarWidth: (width: number) => void;
+  /** Last width the sidebar was opened to — survives close AND reload (when
+   *  `persistKey` is set). Reopen logic should restore this, not the default,
+   *  so the user's chosen size sticks. Falls back to `defaultWidth` until a
+   *  real open width has been recorded. */
+  lastOpenWidth: number;
 }
 
 const SidebarContext = createContext<SidebarContextType | undefined>(undefined);
 
+/** Namespaced default localStorage key for the agent sidebar width. */
+export const SIDEBAR_WIDTH_STORAGE_KEY = "ms.agentSidebar.width";
+
 export interface SidebarProviderProps {
   children: ReactNode;
   defaultWidth?: number;
+  /** localStorage key for persisting the sidebar width across reloads. Omit to
+   *  disable persistence (in-memory only). The stored value is the last
+   *  meaningful OPEN width — closing/collapsing does not erase it, so reopening
+   *  restores the user's chosen size. Width is a per-device cosmetic
+   *  preference, so localStorage is the right home (not server/session state). */
+  persistKey?: string;
+  /** Lower bound for a width considered a real "open" width worth persisting,
+   *  and the floor used to clamp a rehydrated value. Widths below this (e.g. 0
+   *  = closed) are not persisted. Default 350. */
+  minOpenWidth?: number;
+  /** Upper bound used to clamp a rehydrated value, guarding against a stored
+   *  value from a wider viewport. Defaults to the current window width (minus a
+   *  small gutter) on the client, or `Infinity` when unknown. */
+  maxOpenWidth?: number;
+}
+
+/** SSR-safe read of the persisted width. Returns null during SSR, when the key
+ *  is unset, or when the stored value is missing/corrupt/out-of-range — callers
+ *  fall back to the default in those cases. */
+function readPersistedWidth(
+  key: string | undefined,
+  min: number,
+  max: number,
+): number | null {
+  if (!key || typeof window === "undefined") return null;
+  let raw: string | null = null;
+  try {
+    raw = window.localStorage.getItem(key);
+  } catch {
+    // localStorage can throw (private mode, disabled). Treat as no value.
+    return null;
+  }
+  if (raw === null) return null;
+  const value = Number(raw);
+  if (!Number.isFinite(value)) return null;
+  if (value < min || value > max) return null;
+  return value;
 }
 
 export function SidebarProvider({
   children,
   defaultWidth = 350,
+  persistKey,
+  minOpenWidth = 350,
+  maxOpenWidth,
 }: SidebarProviderProps) {
   const [sidebarWidth, setSidebarWidth] = useState(defaultWidth);
+  // Tracked separately from sidebarWidth so a close (width → 0) keeps the last
+  // size for reopen. Seeded from the default; rehydrated from storage on mount.
+  const [lastOpenWidth, setLastOpenWidth] = useState(defaultWidth);
+
+  // Resolve the clamp ceiling: explicit prop wins, else the live viewport,
+  // else unbounded (SSR / non-browser).
+  const resolveMax = useCallback(() => {
+    if (typeof maxOpenWidth === "number") return maxOpenWidth;
+    if (typeof window !== "undefined") return window.innerWidth - 20;
+    return Number.POSITIVE_INFINITY;
+  }, [maxOpenWidth]);
+
+  // Rehydrate after mount only — never during render/SSR — so the server pass
+  // and first client render both use `defaultWidth` (no hydration mismatch).
+  // The persisted width applies one tick later. Clamped to [min, max]; corrupt
+  // or out-of-range values are ignored (default stands).
+  useEffect(() => {
+    const stored = readPersistedWidth(persistKey, minOpenWidth, resolveMax());
+    if (stored !== null) setLastOpenWidth(stored);
+    // Run once on mount. minOpenWidth/persistKey are effectively static per
+    // mount; resolveMax reads live window width at call time.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Persist every meaningful open width; skip closed/collapsed-to-floor states
+  // so a close doesn't wipe the remembered size.
+  const persist = useCallback(
+    (width: number) => {
+      if (!persistKey || typeof window === "undefined") return;
+      if (width < minOpenWidth) return;
+      try {
+        window.localStorage.setItem(persistKey, String(Math.round(width)));
+      } catch {
+        // Storage write failures (quota, disabled) are non-fatal — the live
+        // width still updates, it just won't survive reload.
+      }
+    },
+    [persistKey, minOpenWidth],
+  );
+
+  const handleSetWidth = useCallback(
+    (width: number) => {
+      setSidebarWidth(width);
+      if (width >= minOpenWidth) {
+        setLastOpenWidth(width);
+        persist(width);
+      }
+    },
+    [minOpenWidth, persist],
+  );
+
+  const value = useMemo(
+    () => ({ sidebarWidth, setSidebarWidth: handleSetWidth, lastOpenWidth }),
+    [sidebarWidth, handleSetWidth, lastOpenWidth],
+  );
 
   return (
-    <SidebarContext.Provider value={{ sidebarWidth, setSidebarWidth }}>
-      {children}
-    </SidebarContext.Provider>
+    <SidebarContext.Provider value={value}>{children}</SidebarContext.Provider>
   );
 }
 

--- a/src/context/sidebar/SidebarProvider.tsx
+++ b/src/context/sidebar/SidebarProvider.tsx
@@ -33,8 +33,10 @@ export interface SidebarProviderProps {
    *  preference, so localStorage is the right home (not server/session state). */
   persistKey?: string;
   /** Lower bound for a width considered a real "open" width worth persisting,
-   *  and the floor used to clamp a rehydrated value. Widths below this (e.g. 0
-   *  = closed) are not persisted. Default 350. */
+   *  and the floor used to clamp a rehydrated value. Widths at or below this
+   *  (e.g. 0 = closed, or `minOpenWidth` itself = collapsed-to-floor) are not
+   *  persisted, so a collapse never overwrites the remembered open width.
+   *  Default 350. */
   minOpenWidth?: number;
   /** Upper bound used to clamp a rehydrated value, guarding against a stored
    *  value from a wider viewport. Defaults to the current window width (minus a
@@ -98,11 +100,13 @@ export function SidebarProvider({
   }, []);
 
   // Persist every meaningful open width; skip closed/collapsed-to-floor states
-  // so a close doesn't wipe the remembered size.
+  // so a close OR a collapse (width === minOpenWidth) doesn't wipe the
+  // remembered size. The floor value itself is the collapsed state, not a real
+  // open width, so it must use a strict comparison.
   const persist = useCallback(
     (width: number) => {
       if (!persistKey || typeof window === "undefined") return;
-      if (width < minOpenWidth) return;
+      if (width <= minOpenWidth) return;
       try {
         window.localStorage.setItem(persistKey, String(Math.round(width)));
       } catch {
@@ -116,7 +120,12 @@ export function SidebarProvider({
   const handleSetWidth = useCallback(
     (width: number) => {
       setSidebarWidth(width);
-      if (width >= minOpenWidth) {
+      // Strict `>`: a width of exactly `minOpenWidth` is the collapsed floor
+      // (AppShell collapses by setting the width to MIN_WIDTH), not a real open
+      // width — recording it would erase the user's chosen drag size and make
+      // reopen fall back to the default. Only widths strictly above the floor
+      // count as the remembered open width.
+      if (width > minOpenWidth) {
         setLastOpenWidth(width);
         persist(width);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -462,6 +462,7 @@ export {
 export {
   SidebarProvider,
   useSidebarWidth,
+  SIDEBAR_WIDTH_STORAGE_KEY,
   type SidebarProviderProps,
   type SidebarContextType,
 } from "./context/sidebar/SidebarProvider";


### PR DESCRIPTION
## What

The agent sidebar can be drag-resized, but the chosen width reset to the default on reload because it lived only in in-memory \`SidebarProvider\` state. This persists the resized width so it survives reload.

## How

- **\`SidebarProvider\`** — opt-in \`persistKey\` (plus \`minOpenWidth\` / \`maxOpenWidth\` clamp props). Persists the chosen OPEN width to \`localStorage\` and exposes a new \`lastOpenWidth\` context value, tracked **separately** from the live \`sidebarWidth\` so closing/collapsing doesn't erase the remembered size.
- **SSR-safe (Next.js hosts)** — never touches \`localStorage\` during render. The default applies on the server/first-client pass; the persisted value rehydrates in a post-mount effect, so there's no hydration mismatch and the sidebar does **not** auto-open from a stored width.
- **Robust** — rehydrated values are clamped to \`[minOpenWidth, viewport]\`; corrupt / out-of-range / missing values are ignored (default stands). \`localStorage\` read/write is try/caught (private mode, quota).
- **\`AppShell\`** — wires the namespaced key \`SIDEBAR_WIDTH_STORAGE_KEY\` (\`"ms.agentSidebar.width"\`). Reopen paths (floating toggle button + collapse toggle) now reopen to the persisted width, clamped to the live viewport, falling back to the previous 50%-of-viewport default when no width was ever recorded.
- Self-contained in the kit — every \`AppShell\` host inherits it with no host changes. Width is a per-device cosmetic preference, so \`localStorage\` is the right home (not server/session state).

## Release

Pre-1.0 patch bump to **0.5.1** (\`release\` label added). \`CHANGELOG.md\` "## 0.5.1" entry, version bump, and new \`SIDEBAR_WIDTH_STORAGE_KEY\` export all in this PR — \`release.yml\` reads the version from \`package.json\`.

## Tests / verify

- New \`SidebarProvider\` tests: persist-on-resize, rehydrate valid value, ignore out-of-range (above max / below min) + corrupt values, SSR-safe (no \`localStorage\` read bleeding into first render / no auto-open), close doesn't erase, no-op when \`persistKey\` omitted.
- New \`AppShell\` tests: reopen to persisted width (clamped to viewport); corrupt value falls back to default reopen.
- New Storybook \`PersistedSidebarWidth\` story (resize → reload to verify).
- Fresh \`pnpm install\`; \`pnpm typecheck\` + \`pnpm lint\` + \`pnpm build\` + \`pnpm test\` (719 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)