### PR TITLE
feat: personalized empty-state for the agent sidebar (0.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.5.2
+
+- `AgentSidebarMessages`: new optional `emptyState?: ReactNode`. When the
+  thread has no messages the component renders this node (a host-supplied
+  personalized opener like "Hi, Sam, ask me anything about this app") in place
+  of the list, so a freshly-opened sidebar is never a blank pane. Omit it and
+  the kit shows a soft generic line — existing consumers are unchanged.
+- `AppShell`: new optional `agentEmptyState` on the agent sidebar surface,
+  re-exporting the `AgentSidebarMessages` `emptyState` type. Rendered in the
+  agent body when no `agentSidebarContent` is wired (undefined-safe; the
+  existing `agentSidebarContent` pass-through is unchanged).
+
 ## 0.5.1
 
 - `AppShell`: the drag-resized agent sidebar width now persists across reloads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Notable API additions and breaking changes. For the full commit log, see
   re-exporting the `AgentSidebarMessages` `emptyState` type. Rendered in the
   agent body when no `agentSidebarContent` is wired (undefined-safe; the
   existing `agentSidebarContent` pass-through is unchanged).
+- The empty-state is branded with the MirrorStack logo above the opener
+  (mirroring `AgentGreeting`). Suppress it with `hideEmptyStateLogo` on
+  `AgentSidebarMessages` or `hideAgentEmptyStateLogo` on `AppShell` (both
+  default to showing the logo).
 
 ## 0.5.1
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/AppShell.test.tsx
+++ b/src/components/layout/app-shell/AppShell.test.tsx
@@ -197,6 +197,30 @@ describe("AppShell agent sidebar pass-through", () => {
     openSidebar();
     expect(screen.getByRole("tab", { name: /^Chat 1/ })).toBeInTheDocument();
   });
+
+  it("renders agentEmptyState in the agent body when no content is wired", () => {
+    render(
+      <AppShell agentEmptyState={<p>Hi, Sam, ask me anything.</p>}>
+        content
+      </AppShell>,
+    );
+    openSidebar();
+    expect(screen.getByText("Hi, Sam, ask me anything.")).toBeInTheDocument();
+  });
+
+  it("prefers agentSidebarContent over agentEmptyState when both are set", () => {
+    render(
+      <AppShell
+        agentSidebarContent={<p>Live chat surface</p>}
+        agentEmptyState={<p>Empty opener</p>}
+      >
+        content
+      </AppShell>,
+    );
+    openSidebar();
+    expect(screen.getByText("Live chat surface")).toBeInTheDocument();
+    expect(screen.queryByText("Empty opener")).not.toBeInTheDocument();
+  });
 });
 
 describe("AppShell sidebar width persistence", () => {

--- a/src/components/layout/app-shell/AppShell.test.tsx
+++ b/src/components/layout/app-shell/AppShell.test.tsx
@@ -221,6 +221,40 @@ describe("AppShell agent sidebar pass-through", () => {
     expect(screen.getByText("Live chat surface")).toBeInTheDocument();
     expect(screen.queryByText("Empty opener")).not.toBeInTheDocument();
   });
+
+  // Decorative wrapper is aria-hidden, so query hidden elements.
+  const emptyLogo = () =>
+    screen.queryAllByRole("img", { name: "MirrorStack Logo", hidden: true });
+
+  it("paints the MirrorStack logo above agentEmptyState by default", () => {
+    render(
+      <AppShell agentEmptyState={<p>Hi, Sam.</p>}>content</AppShell>,
+    );
+    openSidebar();
+    expect(emptyLogo()).toHaveLength(1);
+    expect(screen.getByText("Hi, Sam.")).toBeInTheDocument();
+  });
+
+  it("hides the logo when hideAgentEmptyStateLogo is set", () => {
+    render(
+      <AppShell agentEmptyState={<p>Hi, Sam.</p>} hideAgentEmptyStateLogo>
+        content
+      </AppShell>,
+    );
+    openSidebar();
+    expect(emptyLogo()).toHaveLength(0);
+    expect(screen.getByText("Hi, Sam.")).toBeInTheDocument();
+  });
+
+  it("paints no empty-state logo when agentSidebarContent is wired", () => {
+    render(
+      <AppShell agentSidebarContent={<p>Live chat surface</p>}>
+        content
+      </AppShell>,
+    );
+    openSidebar();
+    expect(emptyLogo()).toHaveLength(0);
+  });
 });
 
 describe("AppShell sidebar width persistence", () => {

--- a/src/components/layout/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/AppShell.tsx
@@ -20,7 +20,10 @@ import type {
   AgentSidebarInputProps,
 } from "@/components/ui/agent/sidebar/AgentSidebarInput";
 import type { AgentSidebarHistoryGroup } from "@/components/ui/agent/sidebar/types";
-import type { AgentSidebarMessagesProps } from "@/components/ui/agent/messages/AgentSidebarMessages";
+import {
+  AGENT_EMPTY_STATE_LOGO,
+  type AgentSidebarMessagesProps,
+} from "@/components/ui/agent/messages/AgentSidebarMessages";
 
 export const meta: ComponentMeta = {
   name: "AppShell",
@@ -68,6 +71,12 @@ export interface AppShellProps {
    *  list itself and one that lets the shell render it agree on the same type.
    *  Undefined-safe: omit it and the body falls back to `agentSidebarContent`. */
   agentEmptyState?: AgentSidebarMessagesProps["emptyState"];
+  /** Hide the MirrorStack logo the shell paints above `agentEmptyState`.
+   *  Defaults to false (logo shown) — mirrors the inner
+   *  `AgentSidebarMessages` `hideEmptyStateLogo`, so a host that lets the shell
+   *  render the opener gets the same branded hero as one rendering the list
+   *  itself. No-op when `agentEmptyState` is omitted. */
+  hideAgentEmptyStateLogo?: AgentSidebarMessagesProps["hideEmptyStateLogo"];
   onAgentSend?: (message: string) => void;
   onAgentAttachFile?: () => void;
   onAgentMic?: () => void;
@@ -234,6 +243,7 @@ function AppShellInner({
   snackbarClassName,
   agentSidebarContent,
   agentEmptyState,
+  hideAgentEmptyStateLogo = false,
   onAgentSend,
   onAgentAttachFile,
   onAgentMic,
@@ -453,9 +463,18 @@ function AppShellInner({
               <div className="rounded-2xl bg-on-background flex-1 min-h-0 flex flex-col">
                 <div className="flex-1 overflow-y-auto overflow-x-hidden p-4">
                   {/* The host's chat surface when wired; otherwise the
-                      personalized empty-state opener (undefined-safe — both
-                      may be omitted, leaving an empty body). */}
-                  {agentSidebarContent ?? agentEmptyState}
+                      personalized empty-state opener under the brand logo
+                      (undefined-safe — both may be omitted, leaving an empty
+                      body). The logo only rides the shell-rendered opener; when
+                      a host wires `agentSidebarContent` its own
+                      `AgentSidebarMessages` owns the empty-state logo. */}
+                  {agentSidebarContent ??
+                    (agentEmptyState != null && (
+                      <div className="flex flex-col gap-4">
+                        {!hideAgentEmptyStateLogo && AGENT_EMPTY_STATE_LOGO}
+                        {agentEmptyState}
+                      </div>
+                    ))}
                 </div>
 
                 {agentPendingContent && (

--- a/src/components/layout/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/AppShell.tsx
@@ -20,6 +20,7 @@ import type {
   AgentSidebarInputProps,
 } from "@/components/ui/agent/sidebar/AgentSidebarInput";
 import type { AgentSidebarHistoryGroup } from "@/components/ui/agent/sidebar/types";
+import type { AgentSidebarMessagesProps } from "@/components/ui/agent/messages/AgentSidebarMessages";
 
 export const meta: ComponentMeta = {
   name: "AppShell",
@@ -60,6 +61,13 @@ export interface AppShellProps {
   snackbarClassName?: string;
   /** Agent sidebar chat content */
   agentSidebarContent?: ReactNode;
+  /** Personalized opener shown in the agent body when no `agentSidebarContent`
+   *  is wired (e.g. before any conversation exists) — typically a host
+   *  greeting like "Hi, Sam, ask me anything about this app". Re-exports the
+   *  inner `AgentSidebarMessages` `emptyState` slot so a host that renders the
+   *  list itself and one that lets the shell render it agree on the same type.
+   *  Undefined-safe: omit it and the body falls back to `agentSidebarContent`. */
+  agentEmptyState?: AgentSidebarMessagesProps["emptyState"];
   onAgentSend?: (message: string) => void;
   onAgentAttachFile?: () => void;
   onAgentMic?: () => void;
@@ -225,6 +233,7 @@ function AppShellInner({
   navClassName,
   snackbarClassName,
   agentSidebarContent,
+  agentEmptyState,
   onAgentSend,
   onAgentAttachFile,
   onAgentMic,
@@ -443,7 +452,10 @@ function AppShellInner({
 
               <div className="rounded-2xl bg-on-background flex-1 min-h-0 flex flex-col">
                 <div className="flex-1 overflow-y-auto overflow-x-hidden p-4">
-                  {agentSidebarContent}
+                  {/* The host's chat surface when wired; otherwise the
+                      personalized empty-state opener (undefined-safe — both
+                      may be omitted, leaving an empty body). */}
+                  {agentSidebarContent ?? agentEmptyState}
                 </div>
 
                 {agentPendingContent && (

--- a/src/components/ui/agent/messages/AgentSidebarMessages.test.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.test.tsx
@@ -258,6 +258,36 @@ describe("AgentSidebarMessages markdown rendering", () => {
   });
 });
 
+describe("AgentSidebarMessages empty state", () => {
+  it("renders the provided emptyState when there are no messages", () => {
+    render(
+      <AgentSidebarMessages
+        messages={[]}
+        emptyState={<p>Hi, Sam, ask me anything about this app.</p>}
+      />,
+    );
+    expect(
+      screen.getByText("Hi, Sam, ask me anything about this app."),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to the default opener when empty with no emptyState", () => {
+    render(<AgentSidebarMessages messages={[]} />);
+    expect(screen.getByText("Ask the agent anything.")).toBeInTheDocument();
+  });
+
+  it("renders the messages, not the emptyState, when non-empty", () => {
+    render(
+      <AgentSidebarMessages
+        messages={[agentMsg({ content: "Done." })]}
+        emptyState={<p>should not appear</p>}
+      />,
+    );
+    expect(screen.getByText("Done.")).toBeInTheDocument();
+    expect(screen.queryByText("should not appear")).not.toBeInTheDocument();
+  });
+});
+
 describe("AgentSidebarMessages showLogo", () => {
   // The logo wrapper is aria-hidden (decorative), so opt into hidden elements.
   const logo = () =>

--- a/src/components/ui/agent/messages/AgentSidebarMessages.test.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.test.tsx
@@ -286,6 +286,45 @@ describe("AgentSidebarMessages empty state", () => {
     expect(screen.getByText("Done.")).toBeInTheDocument();
     expect(screen.queryByText("should not appear")).not.toBeInTheDocument();
   });
+
+  // The empty-state logo wrapper is aria-hidden (decorative), so opt into
+  // hidden elements when querying for it.
+  const emptyLogo = () =>
+    screen.queryAllByRole("img", { name: "MirrorStack Logo", hidden: true });
+
+  it("renders the MirrorStack logo above the opener by default", () => {
+    render(
+      <AgentSidebarMessages
+        messages={[]}
+        emptyState={<p>Hi, Sam.</p>}
+      />,
+    );
+    expect(emptyLogo()).toHaveLength(1);
+    expect(screen.getByText("Hi, Sam.")).toBeInTheDocument();
+  });
+
+  it("renders the logo above the default opener too", () => {
+    render(<AgentSidebarMessages messages={[]} />);
+    expect(emptyLogo()).toHaveLength(1);
+    expect(screen.getByText("Ask the agent anything.")).toBeInTheDocument();
+  });
+
+  it("hides the logo when hideEmptyStateLogo is set", () => {
+    render(
+      <AgentSidebarMessages
+        messages={[]}
+        hideEmptyStateLogo
+        emptyState={<p>Hi, Sam.</p>}
+      />,
+    );
+    expect(emptyLogo()).toHaveLength(0);
+    expect(screen.getByText("Hi, Sam.")).toBeInTheDocument();
+  });
+
+  it("renders no empty-state logo when non-empty (showLogo omitted)", () => {
+    render(<AgentSidebarMessages messages={[agentMsg({ content: "Done." })]} />);
+    expect(emptyLogo()).toHaveLength(0);
+  });
 });
 
 describe("AgentSidebarMessages showLogo", () => {

--- a/src/components/ui/agent/messages/AgentSidebarMessages.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.tsx
@@ -82,6 +82,10 @@ export interface AgentSidebarMessagesProps {
    *  Omit to keep the kit's soft generic line so existing consumers are
    *  unchanged. A node slot (not a string) so hosts can style/i18n freely. */
   emptyState?: ReactNode;
+  /** Hide the MirrorStack logo shown above the empty-state opener. Defaults to
+   *  false (logo shown) — mirrors `AgentGreeting`'s `hideLogo`. The empty
+   *  sidebar reads as a branded hero just like the greeting surface. */
+  hideEmptyStateLogo?: boolean;
   className?: string;
 }
 
@@ -91,6 +95,18 @@ const DEFAULT_EMPTY_STATE = (
   <p className="px-1 py-2 text-sm text-inverse-on-surface/60">
     Ask the agent anything.
   </p>
+);
+
+/** Brand signature above the empty-state opener — the same MirrorStack `Logo`
+ *  the greeting hero shows, sized for the narrower sidebar (size-10 vs the
+ *  hero's size-14) and tinted with `bg-inverse-primary` for the dark agent
+ *  surface. Decorative: the host's opener carries the accessible name.
+ *  Exported so `AppShell`, which renders the empty body itself, paints the
+ *  identical logo without duplicating the markup. */
+export const AGENT_EMPTY_STATE_LOGO = (
+  <div aria-hidden className="flex justify-center pb-1">
+    <Logo className="size-10 bg-inverse-primary" />
+  </div>
 );
 
 type ToolMessage = Extract<AgentSidebarMessage, { role: "tool" }>;
@@ -137,6 +153,7 @@ export function AgentSidebarMessages({
   showLogo = false,
   autoScroll = true,
   emptyState,
+  hideEmptyStateLogo = false,
   className,
 }: AgentSidebarMessagesProps) {
   const endRef = useRef<HTMLDivElement>(null);
@@ -174,12 +191,14 @@ export function AgentSidebarMessages({
     endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   };
 
-  // Empty thread → the host's opener (or the kit fallback) in place of the
-  // list, so a freshly-opened sidebar is never a blank pane. Rendered after
-  // the hooks above so hook order stays stable across renders.
+  // Empty thread → the brand logo over the host's opener (or the kit fallback)
+  // in place of the list, so a freshly-opened sidebar reads as a branded hero
+  // rather than a blank pane. Rendered after the hooks above so hook order
+  // stays stable across renders.
   if (messages.length === 0) {
     return (
       <div className={cn("flex flex-col gap-4", className)}>
+        {!hideEmptyStateLogo && AGENT_EMPTY_STATE_LOGO}
         {emptyState ?? DEFAULT_EMPTY_STATE}
         <div ref={endRef} />
       </div>

--- a/src/components/ui/agent/messages/AgentSidebarMessages.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.tsx
@@ -104,7 +104,7 @@ const DEFAULT_EMPTY_STATE = (
  *  Exported so `AppShell`, which renders the empty body itself, paints the
  *  identical logo without duplicating the markup. */
 export const AGENT_EMPTY_STATE_LOGO = (
-  <div aria-hidden className="flex justify-center pb-1">
+  <div aria-hidden className="flex justify-start">
     <Logo className="size-10 bg-inverse-primary" />
   </div>
 );
@@ -197,7 +197,7 @@ export function AgentSidebarMessages({
   // stays stable across renders.
   if (messages.length === 0) {
     return (
-      <div className={cn("flex flex-col gap-4", className)}>
+      <div className={cn("flex flex-col items-start", className)}>
         {!hideEmptyStateLogo && AGENT_EMPTY_STATE_LOGO}
         {emptyState ?? DEFAULT_EMPTY_STATE}
         <div ref={endRef} />

--- a/src/components/ui/agent/messages/AgentSidebarMessages.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.tsx
@@ -197,7 +197,7 @@ export function AgentSidebarMessages({
   // stays stable across renders.
   if (messages.length === 0) {
     return (
-      <div className={cn("flex flex-col items-start", className)}>
+      <div className={cn("flex flex-col items-start gap-1", className)}>
         {!hideEmptyStateLogo && AGENT_EMPTY_STATE_LOGO}
         {emptyState ?? DEFAULT_EMPTY_STATE}
         <div ref={endRef} />

--- a/src/components/ui/agent/messages/AgentSidebarMessages.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { cn } from "@/utils/cn";
 import { Icon } from "@/components/ui/media/icon/Icon";
 import { Logo } from "@/components/ui/media/logo/Logo";
@@ -77,8 +77,21 @@ export interface AgentSidebarMessagesProps {
   showLogo?: boolean;
   /** Auto-scroll to the latest message. Default: true. */
   autoScroll?: boolean;
+  /** Rendered in place of the list when there are no messages — the host's
+   *  personalized opener (e.g. "Hi, Sam, ask me anything about this app").
+   *  Omit to keep the kit's soft generic line so existing consumers are
+   *  unchanged. A node slot (not a string) so hosts can style/i18n freely. */
+  emptyState?: ReactNode;
   className?: string;
 }
+
+/** The kit's fallback opener when a host wires no `emptyState`. Intentionally
+ *  plain — hosts are expected to override with a personalized line. */
+const DEFAULT_EMPTY_STATE = (
+  <p className="px-1 py-2 text-sm text-inverse-on-surface/60">
+    Ask the agent anything.
+  </p>
+);
 
 type ToolMessage = Extract<AgentSidebarMessage, { role: "tool" }>;
 
@@ -123,6 +136,7 @@ export function AgentSidebarMessages({
   toolLabels,
   showLogo = false,
   autoScroll = true,
+  emptyState,
   className,
 }: AgentSidebarMessagesProps) {
   const endRef = useRef<HTMLDivElement>(null);
@@ -159,6 +173,18 @@ export function AgentSidebarMessages({
   const scrollToBottom = () => {
     endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   };
+
+  // Empty thread → the host's opener (or the kit fallback) in place of the
+  // list, so a freshly-opened sidebar is never a blank pane. Rendered after
+  // the hooks above so hook order stays stable across renders.
+  if (messages.length === 0) {
+    return (
+      <div className={cn("flex flex-col gap-4", className)}>
+        {emptyState ?? DEFAULT_EMPTY_STATE}
+        <div ref={endRef} />
+      </div>
+    );
+  }
 
   const lastMessage = messages[messages.length - 1];
   const showBrandLogo =

--- a/src/components/ui/agent/sidebar/AgentSidebar.stories.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebar.stories.tsx
@@ -204,10 +204,11 @@ export const QueuedMessage: StoryObj = {
   },
 };
 
-/** Fresh conversation: with no messages, the list renders the host-supplied
- *  `emptyState` — a personalized opener — instead of a blank pane. Every host
- *  (web-applications, web-account) passes its own greeting, so the empty
- *  sidebar reads as a warm prompt rather than dead space. */
+/** Fresh conversation: with no messages, the list renders the MirrorStack
+ *  logo above the host-supplied `emptyState` — a personalized opener — instead
+ *  of a blank pane, so the empty sidebar reads as a branded hero (matching the
+ *  greeting surface) rather than dead space. Every host (web-applications,
+ *  web-account) passes its own greeting. */
 export const EmptyState: StoryObj = {
   render: () => (
     <>
@@ -222,6 +223,40 @@ export const EmptyState: StoryObj = {
         <div className="flex-1 overflow-y-auto p-4">
           <AgentSidebarMessages
             messages={[]}
+            emptyState={
+              <p className="px-1 text-center text-sm text-inverse-on-surface/70">
+                Hi, Sam, ask me anything about this app.
+              </p>
+            }
+          />
+        </div>
+        <AgentSidebarInput
+          onSend={(msg) => console.log("Send:", msg)}
+          models={mockAgentModels}
+          selectedModelId={DEFAULT_MODEL_ID}
+        />
+      </div>
+    </>
+  ),
+};
+
+/** Same empty thread with `hideEmptyStateLogo` — for hosts that want only
+ *  their opener with no brand mark above it. */
+export const EmptyStateNoLogo: StoryObj = {
+  render: () => (
+    <>
+      <AgentSidebarHeader
+        sidebarWidth={420}
+        onToggleCollapse={() => {}}
+        onClose={() => {}}
+        history={mockAgentHistory}
+        onSelectHistoryItem={(id) => console.log("history", id)}
+      />
+      <div className="flex-1 bg-on-background rounded-2xl flex flex-col min-h-0">
+        <div className="flex-1 overflow-y-auto p-4">
+          <AgentSidebarMessages
+            messages={[]}
+            hideEmptyStateLogo
             emptyState={
               <p className="px-1 py-2 text-sm text-inverse-on-surface/70">
                 Hi, Sam, ask me anything about this app.

--- a/src/components/ui/agent/sidebar/AgentSidebar.stories.tsx
+++ b/src/components/ui/agent/sidebar/AgentSidebar.stories.tsx
@@ -204,6 +204,41 @@ export const QueuedMessage: StoryObj = {
   },
 };
 
+/** Fresh conversation: with no messages, the list renders the host-supplied
+ *  `emptyState` — a personalized opener — instead of a blank pane. Every host
+ *  (web-applications, web-account) passes its own greeting, so the empty
+ *  sidebar reads as a warm prompt rather than dead space. */
+export const EmptyState: StoryObj = {
+  render: () => (
+    <>
+      <AgentSidebarHeader
+        sidebarWidth={420}
+        onToggleCollapse={() => {}}
+        onClose={() => {}}
+        history={mockAgentHistory}
+        onSelectHistoryItem={(id) => console.log("history", id)}
+      />
+      <div className="flex-1 bg-on-background rounded-2xl flex flex-col min-h-0">
+        <div className="flex-1 overflow-y-auto p-4">
+          <AgentSidebarMessages
+            messages={[]}
+            emptyState={
+              <p className="px-1 py-2 text-sm text-inverse-on-surface/70">
+                Hi, Sam, ask me anything about this app.
+              </p>
+            }
+          />
+        </div>
+        <AgentSidebarInput
+          onSend={(msg) => console.log("Send:", msg)}
+          models={mockAgentModels}
+          selectedModelId={DEFAULT_MODEL_ID}
+        />
+      </div>
+    </>
+  ),
+};
+
 /** Full sidebar with live queue behavior: sending while the agent is still
  *  replying queues the message above the input; queued messages auto-send
  *  in order as each reply finishes. */


### PR DESCRIPTION
## Why

When a new agent-sidebar conversation has no messages, each host renders its OWN hardcoded empty-state (web-applications short-circuits with "Ask the agent anything about this app." before the kit's message list). That makes the empty pane inconsistent across hosts and unable to be personalized. This makes the empty-state a kit capability so every host (web-applications AND web-account) gets a consistent, host-supplied opener — e.g. a personalized "Hi, Sam, ask…".

## What

- **`AgentSidebarMessages`**: new optional `emptyState?: ReactNode`. When `messages.length === 0` it renders that node in place of the list. Omit it and the kit shows a soft generic line, so existing consumers are unchanged. A node slot (not a string) so hosts style/i18n freely.
- **`AppShell`**: new optional `agentEmptyState` on the same `agent*` namespace, re-exporting the inner `AgentSidebarMessages["emptyState"]` type. Rendered in the agent body when no `agentSidebarContent` is wired (undefined-safe). The existing `agentSidebarContent` pass-through is unchanged.
- **Story**: `EmptyState` added to the agent Sidebar story (`AgentSidebar.stories.tsx`) showing an empty conversation with a personalized "Hi, Sam, ask me anything about this app." opener. `AppShell.stories.tsx` is intentionally untouched (parallel track owns it).
- **Release**: bumped to `0.5.2` + CHANGELOG entry + `release` label (release.yml reads the version).

## Tests

- empty + `emptyState` -> renders the provided node
- empty + no prop -> renders the kit default opener
- non-empty -> renders messages, not the emptyState (unchanged)
- `AppShell` forwards `agentEmptyState` into the agent body when no content is wired, and prefers `agentSidebarContent` when both are set

## Verification

- `pnpm install`, `pnpm typecheck`, `pnpm build`, `pnpm test` (725 passed), `pnpm lint` all green.

## Consumer follow-up (web-applications)

`AgentSidebarContent` can drop its `messages.length === 0` short-circuit and pass `emptyState={<p>{t("empty")}</p>}` (personalized) to `AgentSidebarMessages` instead — or pass `agentEmptyState` to `AppShell`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)