### PR TITLE
fix: remove gap-1 from agent sidebar empty state

### DIFF
--- a/src/components/ui/agent/messages/AgentSidebarMessages.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.tsx
@@ -197,7 +197,7 @@ export function AgentSidebarMessages({
   // stays stable across renders.
   if (messages.length === 0) {
     return (
-      <div className={cn("flex flex-col items-start gap-1", className)}>
+      <div className={cn("flex flex-col items-start", className)}>
         {!hideEmptyStateLogo && AGENT_EMPTY_STATE_LOGO}
         {emptyState ?? DEFAULT_EMPTY_STATE}
         <div ref={endRef} />


### PR DESCRIPTION
## Summary
The empty-state branch of `AgentSidebarMessages` (`src/components/ui/agent/messages/AgentSidebarMessages.tsx`) stacked the agent logo over the greeting using `flex flex-col items-start gap-1`. The greeting paragraph already carries its own `py-2`, so the extra `gap-1` produced a doubled, too-loose separation between the logo and the greeting text. This drops `gap-1` so the vertical spacing comes solely from the greeting's intrinsic padding.

One-line change: `gap-1` removed from the empty-branch container className.

## Design doc
Implements item 1 of `docs-temp/next-wave/12-sidebar-followups.md` — "Remove `gap-1` from the agent empty-state (web-ui-kit)".

## Verification
- `pnpm exec tsc --noEmit` (node_modules symlinked from base): the touched file has zero type errors.
- The only tsc errors reported are in an unrelated, untouched file `src/components/ui/agent/messages/AgentSidebarMessage.tsx` (singular, per-message component) and are pre-existing environment artifacts — `react-markdown` / `remark-gfm` are absent from the base node_modules in this light symlinked install, cascading into TS7031 `_node implicitly any`. Not introduced by this change.

## Release
NO version bump and NO release label on this PR. Pre-1.0 web-ui-kit — this rides the next web-ui-kit rollup release.

## /simplify
A simplify pass was run; the change is already a one-class removal with nothing further to simplify.

Generated with Claude Code (https://claude.com/claude-code)