### PR TITLE
chore: release 0.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Rollup release 0.5.2 → 0.5.3

Bundles the sidebar-wave `web-ui-kit` changes already merged to `main` since `v0.5.2`. (`release.yml` reads the version from `package.json`, so this PR carries the bump + the `release` label; merging tags `v0.5.3` and publishes.)

### Included
- **#295** — fix: remove `gap-1` from the agent sidebar empty state (visual)
- **#296** — refactor: AppShell sidebar width → injected server-persistence provider (docs 12.4 + 13b)

### ⚠️ Consumer migration (ships in 0.5.3)
`AppShell` no longer persists sidebar width to `localStorage` by default. Hosts must inject `sidebarWidthPersistence` (bound to the per-user `/v1/sidebar-state` record) to keep width persisting. `SIDEBAR_WIDTH_STORAGE_KEY` / `persistKey` are deprecated-but-retained for backward compatibility. Host wiring lands in web-applications (#71) and web-account (#54), which should bump to `^0.5.3` once this publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)