### PR TITLE
feat(agent): unify AgentSidebarState (tab-objects + width) — 0.5.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/hooks/agent-chat/useAgentTabs.test.ts
+++ b/src/hooks/agent-chat/useAgentTabs.test.ts
@@ -5,11 +5,26 @@ import {
   isDraftTab,
   useAgentTabs,
   type AgentSidebarState,
+  type AgentSidebarTab,
   type AgentTabsPersistence,
 } from "./useAgentTabs";
 
+// Wire tabs are objects (matches api-client-shared AgentSidebarState): id +
+// conversationId both hold the conversation id (the kit tracks no separate
+// server tab-row id), title is the cached strip label, order is the strip
+// position. Tests assert on conversation ids — `tab()` keeps them terse.
+const tab = (conversationId: string, order: number, title = ""): AgentSidebarTab => ({
+  id: conversationId,
+  conversationId,
+  title,
+  order,
+});
+
+/** A persisted record from a list of conversation ids (strip order). */
+const tabsOf = (...ids: string[]): AgentSidebarTab[] => ids.map((id, i) => tab(id, i));
+
 function state(over: Partial<AgentSidebarState> = {}): AgentSidebarState {
-  return { open: true, activeTabId: "c-2", tabs: ["c-1", "c-2"], ...over };
+  return { open: true, activeTabId: "c-2", tabs: tabsOf("c-1", "c-2"), width: 0, ...over };
 }
 
 function fakePersistence(initial: AgentSidebarState = state()) {
@@ -55,7 +70,7 @@ describe("useAgentTabs", () => {
   });
 
   it("hydrate drops ids the host can't resolve (deleted conversations heal silently)", async () => {
-    const { persistence } = fakePersistence(state({ tabs: ["gone", "c-1"], activeTabId: "gone" }));
+    const { persistence } = fakePersistence(state({ tabs: tabsOf("gone", "c-1"), activeTabId: "gone" }));
     const resolveTabs = vi.fn().mockResolvedValue(["c-1"]);
     const { result } = renderHook(() => useAgentTabs(persistence, { resolveTabs }));
 
@@ -103,7 +118,8 @@ describe("useAgentTabs", () => {
     expect(put).toHaveBeenCalledWith({
       open: false,
       activeTabId: "c-1",
-      tabs: ["c-3", "c-1", "c-2"],
+      tabs: tabsOf("c-3", "c-1", "c-2"),
+      width: 0,
     });
   });
 
@@ -119,7 +135,7 @@ describe("useAgentTabs", () => {
     expect(result.current.activeTabId).toBe("c-1");
     await advance(1100);
     expect(put).toHaveBeenCalledTimes(1);
-    expect(put).toHaveBeenCalledWith({ open: true, activeTabId: "c-1", tabs: ["c-1"] });
+    expect(put).toHaveBeenCalledWith({ open: true, activeTabId: "c-1", tabs: tabsOf("c-1"), width: 0 });
   });
 
   it("refetches on focus and adopts the remote state, keeping local drafts", async () => {
@@ -138,7 +154,7 @@ describe("useAgentTabs", () => {
     await advance(1100);
 
     // Another host closed c-2 and switched the active tab.
-    remote = state({ tabs: ["c-1"], activeTabId: "c-1" });
+    remote = state({ tabs: tabsOf("c-1"), activeTabId: "c-1" });
     act(() => {
       window.dispatchEvent(new Event("focus"));
     });
@@ -219,7 +235,7 @@ describe("useAgentTabs", () => {
     await advance(1100); // settle the PUT so the refetch isn't skipped
 
     // Another host reordered the conversation tabs.
-    remote = state({ tabs: ["c-2", "c-1"], activeTabId: "c-1" });
+    remote = state({ tabs: tabsOf("c-2", "c-1"), activeTabId: "c-1" });
     act(() => {
       window.dispatchEvent(new Event("focus"));
     });
@@ -241,7 +257,7 @@ describe("useAgentTabs", () => {
     const draftId = result.current.activeTabId;
     await advance(1100);
     expect(put).toHaveBeenCalledTimes(1);
-    expect(put).toHaveBeenCalledWith({ open: true, activeTabId: null, tabs: ["c-1", "c-2"] });
+    expect(put).toHaveBeenCalledWith({ open: true, activeTabId: null, tabs: tabsOf("c-1", "c-2"), width: 0 });
 
     // Closing the draft restores the persisted projection — no second PUT.
     act(() => result.current.closeTab(draftId));
@@ -259,11 +275,12 @@ describe("useAgentTabs", () => {
     expect(put).toHaveBeenLastCalledWith({
       open: true,
       activeTabId: "c-9",
-      tabs: ["c-1", "c-2", "c-9"],
+      tabs: tabsOf("c-1", "c-2", "c-9"),
+      width: 0,
     });
     for (const call of put.mock.calls) {
       const persisted = call[0] as AgentSidebarState;
-      expect(persisted.tabs.some(isDraftTab)).toBe(false);
+      expect(persisted.tabs.some((t) => isDraftTab(t.conversationId))).toBe(false);
       expect(persisted.activeTabId === null || !isDraftTab(persisted.activeTabId)).toBe(true);
     }
   });

--- a/src/hooks/agent-chat/useAgentTabs.ts
+++ b/src/hooks/agent-chat/useAgentTabs.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 /** A single tab in the agent sidebar header strip. Defined here — the data
  *  layer owns the definitions so it never imports from the component layer;
@@ -9,22 +9,45 @@ export interface ChatTab {
 }
 
 // ---- Wire state (mirrors the agent service's /v1/sidebar-state) ----
+//
+// These match @mirrorstack-ai/api-client-shared's AgentSidebarTab /
+// AgentSidebarState 1:1 (field names + types) so a host can wire its
+// getSidebarState/putSidebarState straight into AgentTabsPersistence below
+// with no adapter — the shape IS the contract.
+
+/** One persisted open tab in the cross-host sidebar strip (matches
+ *  api-client-shared `AgentSidebarTab`, camelCase wire). conversationId is the
+ *  OPEN conversation the tab tracks; id is the tab's stable identity (the kit
+ *  mirrors it to conversationId — it tracks no separate server tab-row id);
+ *  title is the cached strip label (the host still derives the live title from
+ *  history and falls back to this); order is the strip position (ascending). */
+export interface AgentSidebarTab {
+  id: string;
+  conversationId: string;
+  title: string;
+  order: number;
+}
 
 /** Persisted sidebar session — ONE row per platform user, shared by every
- *  host (web-account, web-applications, future platforms). Tabs hold
- *  conversation ids only; titles resolve from the conversation list each
- *  host already loads. Local draft tabs are never part of this state. */
+ *  host (web-account, web-applications, future platforms). Matches
+ *  api-client-shared `AgentSidebarState`. tabs hold the OPEN tabs in strip
+ *  order; titles still resolve from the conversation list each host already
+ *  loads (the cached `title` is a fallback). width is the shared open-sidebar
+ *  width (0 = no saved width, host default). Local draft tabs are never part
+ *  of this state. */
 export interface AgentSidebarState {
   open: boolean;
   /** Active tab's conversation id — null when a local draft was active. */
   activeTabId: string | null;
-  /** Open tabs' conversation ids, strip order. */
-  tabs: string[];
+  /** Open tabs in strip order. */
+  tabs: AgentSidebarTab[];
+  /** Shared open-sidebar width (0 = host default). */
+  width: number;
 }
 
 /** Structural persistence surface for the tab strip. The kit stays
  *  backend-agnostic: hosts inject any object with these methods —
- *  api-client-shared's `agent` module satisfies them once its free
+ *  api-client-shared's `agent` module satisfies them directly once its free
  *  functions are bound to the host's service client:
  *
  *    const tabsPersistence: AgentTabsPersistence = {
@@ -49,20 +72,48 @@ export const isDraftTab = (id: string) => id.startsWith(DRAFT_PREFIX);
 const freshDraft = () => `${DRAFT_PREFIX}${crypto.randomUUID()}`;
 
 // ---- Pure strip transitions (the hook's internal state machine) ----
+//
+// The strip is keyed throughout by conversation id (drafts use their draft
+// id as the conversation id) — that single id is the tab's public identity:
+// every host-facing callback (select/close/open/bindDraft) takes it, and the
+// public `tabs` projection maps each tab to it. The kit tracks no separate
+// server tab-row id, so a tab's `id` mirrors its conversationId.
 
 interface StripState {
   open: boolean;
-  tabs: string[];
+  tabs: AgentSidebarTab[];
   activeTabId: string;
+  width: number;
 }
 
-const initialStrip = (open = false): StripState => {
+/** A tab object for a given conversation id at a given strip position. order
+ *  is the position; title defaults empty (the host derives the live title from
+ *  history and only falls back to the cached `title`). */
+const makeTab = (conversationId: string, order: number, title = ""): AgentSidebarTab => ({
+  id: conversationId,
+  conversationId,
+  title,
+  order,
+});
+
+/** Re-stamp `order` to match array position after any insert/remove/move so
+ *  the persisted order is always a dense ascending run. */
+const reindex = (tabs: AgentSidebarTab[]): AgentSidebarTab[] =>
+  tabs.map((tab, i) => (tab.order === i ? tab : { ...tab, order: i }));
+
+const tabIndex = (tabs: AgentSidebarTab[], conversationId: string) =>
+  tabs.findIndex((tab) => tab.conversationId === conversationId);
+
+const hasTab = (tabs: AgentSidebarTab[], conversationId: string) =>
+  tabIndex(tabs, conversationId) !== -1;
+
+const initialStrip = (open = false, width = 0): StripState => {
   const draft = freshDraft();
-  return { open, tabs: [draft], activeTabId: draft };
+  return { open, tabs: [makeTab(draft, 0)], activeTabId: draft, width };
 };
 
 const selectTabState = (s: StripState, id: string): StripState =>
-  s.activeTabId !== id && s.tabs.includes(id) ? { ...s, activeTabId: id } : s;
+  s.activeTabId !== id && hasTab(s.tabs, id) ? { ...s, activeTabId: id } : s;
 
 /** Close ≠ delete: drop the tab from the strip only. Closing the active tab
  *  activates its right neighbor (the tab now at the closed index), or the
@@ -70,104 +121,138 @@ const selectTabState = (s: StripState, id: string): StripState =>
  *  Closing the only tab falls back to a fresh draft from the given factory
  *  (invoked only when actually needed). */
 const closeTabState = (s: StripState, id: string, makeDraft: () => string): StripState => {
-  const index = s.tabs.indexOf(id);
+  const index = tabIndex(s.tabs, id);
   if (index === -1) return s;
-  const next = s.tabs.filter((tab) => tab !== id);
+  const next = reindex(s.tabs.filter((tab) => tab.conversationId !== id));
   if (next.length === 0) {
     const draft = makeDraft();
-    return { ...s, tabs: [draft], activeTabId: draft };
+    return { ...s, tabs: [makeTab(draft, 0)], activeTabId: draft };
   }
   return {
     ...s,
     tabs: next,
-    activeTabId: s.activeTabId === id ? next[Math.min(index, next.length - 1)] : s.activeTabId,
+    activeTabId:
+      s.activeTabId === id ? next[Math.min(index, next.length - 1)].conversationId : s.activeTabId,
   };
 };
 
 const addDraftState = (s: StripState, draft: string): StripState => ({
   ...s,
-  tabs: [...s.tabs, draft],
+  tabs: [...s.tabs, makeTab(draft, s.tabs.length)],
   activeTabId: draft,
 });
 
 /** Open a past conversation as a tab, or refocus its existing tab. */
 const openConversationState = (s: StripState, id: string): StripState =>
-  s.tabs.includes(id)
+  hasTab(s.tabs, id)
     ? selectTabState(s, id)
-    : { ...s, tabs: [...s.tabs, id], activeTabId: id };
+    : { ...s, tabs: [...s.tabs, makeTab(id, s.tabs.length)], activeTabId: id };
 
 const moveTabState = (s: StripState, id: string, toIndex: number): StripState => {
-  const from = s.tabs.indexOf(id);
+  const from = tabIndex(s.tabs, id);
   if (from === -1) return s;
   const to = Math.max(0, Math.min(toIndex, s.tabs.length - 1));
   if (from === to) return s;
   const tabs = [...s.tabs];
-  tabs.splice(from, 1);
-  tabs.splice(to, 0, id);
-  return { ...s, tabs };
+  const [moved] = tabs.splice(from, 1);
+  tabs.splice(to, 0, moved);
+  return { ...s, tabs: reindex(tabs) };
 };
 
 /** First send created the conversation — the draft tab becomes its tab in
  *  place. If the conversation already has a tab (opened from history while
  *  the send was in flight), the draft dissolves into it instead. */
 const bindDraftState = (s: StripState, draftId: string, conversationId: string): StripState => {
-  if (!s.tabs.includes(draftId)) return s;
-  const tabs = s.tabs.includes(conversationId)
-    ? s.tabs.filter((tab) => tab !== draftId)
-    : s.tabs.map((tab) => (tab === draftId ? conversationId : tab));
+  if (!hasTab(s.tabs, draftId)) return s;
+  const tabs = hasTab(s.tabs, conversationId)
+    ? s.tabs.filter((tab) => tab.conversationId !== draftId)
+    : s.tabs.map((tab) =>
+        tab.conversationId === draftId ? { ...tab, id: conversationId, conversationId } : tab,
+      );
   return {
     ...s,
-    tabs,
+    tabs: reindex(tabs),
     activeTabId: s.activeTabId === draftId ? conversationId : s.activeTabId,
   };
 };
 
 // Project the strip onto the wire: drafts are NEVER persisted — reload
 // drops empty drafts by design (the first send creates the conversation
-// and the next debounce persists it).
+// and the next debounce persists it). order is re-stamped to the persisted
+// (draft-stripped) position; width rides along unchanged.
 const toPersisted = (s: StripState): AgentSidebarState => ({
   open: s.open,
   activeTabId: isDraftTab(s.activeTabId) ? null : s.activeTabId,
-  tabs: s.tabs.filter((id) => !isDraftTab(id)),
+  tabs: s.tabs
+    .filter((tab) => !isDraftTab(tab.conversationId))
+    .map((tab, i) => ({ ...tab, order: i })),
+  width: s.width,
 });
 
-const sameIds = (a: readonly string[], b: readonly string[]) =>
-  a.length === b.length && a.every((id, i) => id === b[i]);
+const sameTabs = (a: readonly AgentSidebarTab[], b: readonly AgentSidebarTab[]) =>
+  a.length === b.length &&
+  a.every((tab, i) => {
+    const other = b[i];
+    return (
+      tab.id === other.id &&
+      tab.conversationId === other.conversationId &&
+      tab.title === other.title &&
+      tab.order === other.order
+    );
+  });
 
 const samePersisted = (a: AgentSidebarState, b: AgentSidebarState) =>
-  a.open === b.open && a.activeTabId === b.activeTabId && sameIds(a.tabs, b.tabs);
+  a.open === b.open &&
+  a.activeTabId === b.activeTabId &&
+  a.width === b.width &&
+  sameTabs(a.tabs, b.tabs);
 
 const sameStrip = (a: StripState, b: StripState) =>
-  a.open === b.open && a.activeTabId === b.activeTabId && sameIds(a.tabs, b.tabs);
+  a.open === b.open &&
+  a.activeTabId === b.activeTabId &&
+  a.width === b.width &&
+  sameTabs(a.tabs, b.tabs);
 
 // Reconcile a fetched remote state into the local strip. Hydration replaces
 // the untouched initial placeholder outright; refetches (and hydration after
 // a local mutation) keep local drafts — they exist on this host only, so the
 // server can't know about them. The merge happens in place: surviving
-// conversation tabs adopt the remote (strip) order, drafts keep their
-// interleaved positions, tabs closed elsewhere drop, tabs opened elsewhere
-// append. The locally active tab keeps focus when it survives; otherwise
-// the remote active wins, then the first tab.
-function applyRemote(prev: StripState, remote: AgentSidebarState, ids: string[], keepDrafts: boolean): StripState {
-  const prevTabs = new Set(prev.tabs);
+// conversation tabs adopt the remote (strip) order AND its cached title/order
+// fields, drafts keep their interleaved positions, tabs closed elsewhere
+// drop, tabs opened elsewhere append. The locally active tab keeps focus when
+// it survives; otherwise the remote active wins, then the first tab. width
+// always adopts the remote value (it's the shared per-user value).
+function applyRemote(
+  prev: StripState,
+  remote: AgentSidebarState,
+  ids: string[],
+  keepDrafts: boolean,
+): StripState {
+  const prevIds = new Set(prev.tabs.map((tab) => tab.conversationId));
   const idSet = new Set(ids);
-  const survivors = ids.filter((id) => prevTabs.has(id));
+  // Remote tab objects survivors carry, keyed by conversation id so survivors
+  // adopt the remote cached title (and we re-stamp order below).
+  const remoteById = new Map(remote.tabs.map((tab) => [tab.conversationId, tab]));
+  const survivors = ids.filter((id) => prevIds.has(id));
   let s = 0;
-  const tabs: string[] = [];
+  const tabs: AgentSidebarTab[] = [];
   for (const tab of prev.tabs) {
-    if (isDraftTab(tab)) {
+    if (isDraftTab(tab.conversationId)) {
       if (keepDrafts) tabs.push(tab);
-    } else if (idSet.has(tab)) {
-      tabs.push(survivors[s++]);
+    } else if (idSet.has(tab.conversationId)) {
+      const id = survivors[s++];
+      tabs.push(remoteById.get(id) ?? makeTab(id, 0));
     }
   }
-  for (const id of ids) if (!prevTabs.has(id)) tabs.push(id);
-  if (tabs.length === 0) return initialStrip(remote.open);
+  for (const id of ids) {
+    if (!prevIds.has(id)) tabs.push(remoteById.get(id) ?? makeTab(id, 0));
+  }
+  if (tabs.length === 0) return initialStrip(remote.open, remote.width);
   let activeTabId: string;
-  if (keepDrafts && tabs.includes(prev.activeTabId)) activeTabId = prev.activeTabId;
-  else if (remote.activeTabId && tabs.includes(remote.activeTabId)) activeTabId = remote.activeTabId;
-  else activeTabId = tabs[0];
-  return { open: remote.open, tabs, activeTabId };
+  if (keepDrafts && hasTab(tabs, prev.activeTabId)) activeTabId = prev.activeTabId;
+  else if (remote.activeTabId && hasTab(tabs, remote.activeTabId)) activeTabId = remote.activeTabId;
+  else activeTabId = tabs[0].conversationId;
+  return { open: remote.open, tabs: reindex(tabs), activeTabId, width: remote.width };
 }
 
 // ---- Title derivation (render-time, host-side) ----
@@ -212,8 +297,8 @@ export interface UseAgentTabsResult {
   /** Sidebar open/closed — persisted, shared across hosts. */
   open: boolean;
   setOpen: (open: boolean) => void;
-  /** Open tabs as ids (conversation ids + local draft ids), strip order.
-   *  Map to titled ChatTabs with deriveTabTitles. */
+  /** Open tabs as conversation ids (conversation ids + local draft ids),
+   *  strip order. Map to titled ChatTabs with deriveTabTitles. */
   tabs: string[];
   activeTabId: string;
   /** True once the mount GET settled (or no persistence was injected). */
@@ -242,6 +327,11 @@ export interface UseAgentTabsResult {
  * PUT debounced (trailing, ~1s); the strip refetches on window focus /
  * visibilitychange so concurrent hosts converge — skipped while a local
  * mutation is pending flush so it can't clobber newer local state.
+ *
+ * The persisted record (AgentSidebarState) also carries the shared
+ * open-sidebar `width`; the strip never MANAGES width (a host-side width
+ * persistence owns the read/write — see api-client-shared), but it preserves
+ * the hydrated width through every reducer so a tab PUT never drops it.
  *
  * `persistence` and `resolveTabs` are read through refs — their identities
  * may change per render without retriggering fetches.
@@ -342,7 +432,9 @@ export function useAgentTabs(
       const remote = await p.get();
       if (fetchSeq.current !== seq || pendingRef.current) return;
       // Defensive: the wire never carries drafts, but never trust it to.
-      let ids = remote.tabs.filter((id) => !isDraftTab(id));
+      let ids = remote.tabs
+        .map((tab) => tab.conversationId)
+        .filter((id) => !isDraftTab(id));
       if (resolveTabsRef.current && ids.length > 0) {
         try {
           ids = await resolveTabsRef.current(ids);
@@ -429,10 +521,16 @@ export function useAgentTabs(
     [mutate],
   );
 
+  // Public strip is the conversation ids in order — hosts map these to titled
+  // ChatTabs (deriveTabTitles) and key everything off this single id, never
+  // the internal AgentSidebarTab objects. Memoized so identity is stable
+  // until the strip actually changes.
+  const tabs = useMemo(() => strip.tabs.map((tab) => tab.conversationId), [strip.tabs]);
+
   return {
     open: strip.open,
     setOpen,
-    tabs: strip.tabs,
+    tabs,
     activeTabId: strip.activeTabId,
     hydrated,
     selectTab,

--- a/src/index.ts
+++ b/src/index.ts
@@ -502,6 +502,7 @@ export {
   useAgentTabs,
   isDraftTab,
   deriveTabTitles,
+  type AgentSidebarTab,
   type AgentSidebarState,
   type AgentTabsPersistence,
   type UseAgentTabsOptions,


### PR DESCRIPTION
## What

Aligns `useAgentTabs`'s `AgentSidebarState` to the unified cross-host wire shape.

0.5.3 (A3) added the `SidebarWidthPersistence` prop to `AppShell` but left `useAgentTabs`'s `AgentSidebarState` at the OLD `{ open, activeTabId, tabs: string[] }` shape. This PR aligns it to the unified record:

```ts
interface AgentSidebarTab { id: string; conversationId: string; title: string; order: number }
interface AgentSidebarState { open: boolean; activeTabId: string | null; tabs: AgentSidebarTab[]; width: number }
```

This matches `@mirrorstack-ai/api-client-shared@2.0.0` / api-platform A1 1:1 (field names + types), so a host wires its `getSidebarState`/`putSidebarState` straight into `AgentTabsPersistence` with **no adapter** — the shape IS the contract.

## Why

The host PRs (web-applications #71, web-account #54) typecheck against the unified `AgentSidebarState`. Before this, the kit's exported type still said `tabs: string[]` with no `width`, so the hosts would fail to typecheck. With this aligned, the hosts pass by bumping to `^0.5.4` with **NO host code change**.

## Details

- Internal strip state-machine reworked to carry `AgentSidebarTab` objects + `width`; the public `tabs` projection still exposes conversation ids (hosts key everything off the single id via `deriveTabTitles`). The strip never *manages* width — a host-side width persistence owns read/write — but it preserves the hydrated `width` through every reducer so a tab PUT never drops it.
- `order` is re-stamped to dense ascending after every insert/remove/move and on persist (drafts stripped); `width` (0 = host default) rides along unchanged.
- `applyRemote` survivors now adopt the remote cached `title`/`order`; `width` always adopts the remote value (shared per-user).
- Exports new `AgentSidebarTab` type from `src/index.ts`.
- Bumps to **0.5.4**.

## Verification

- `pnpm exec tsc --noEmit` — green
- `vitest run src/hooks/agent-chat/useAgentTabs.test.ts` — 14/14 pass (tests updated to the tab-object + width shape)

Merging tags **v0.5.4** and publishes (release label).

Generated with Claude Code (https://claude.com/claude-code)