### PR TITLE
fix(agent): interleave tool calls with response text + tighten tool-call spacing

### DIFF
--- a/src/components/ui/agent/messages/AgentSidebarMessage.test.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessage.test.tsx
@@ -1,0 +1,80 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// react-markdown / remark-gfm pull in an ESM-only chain that the unit env
+// doesn't need for these structural assertions — stub them to passthrough so
+// the test exercises segment ORDER, not markdown parsing (covered elsewhere).
+vi.mock("react-markdown", () => ({
+  default: ({ children }: { children: string }) => <span>{children}</span>,
+}));
+vi.mock("remark-gfm", () => ({ default: () => {} }));
+
+import {
+  AgentSidebarAgentMessage,
+  type AgentMessageSegment,
+} from "./AgentSidebarMessage";
+
+afterEach(cleanup);
+
+describe("AgentSidebarAgentMessage interleaved segments", () => {
+  const interleaved: AgentMessageSegment[] = [
+    { type: "text", text: "Let me check your account." },
+    {
+      type: "tool",
+      id: "t-1",
+      tool: { moduleSlug: "analytics", tool: "summarize_views", status: "done", durationMs: 120 },
+    },
+    { type: "text", text: "Here is what I found." },
+  ];
+
+  it("renders text and tool segments in occurrence order, not tools-first", () => {
+    const { container } = render(
+      <AgentSidebarAgentMessage content="Let me check your account.Here is what I found." segments={interleaved} />,
+    );
+
+    // The tool row sits BETWEEN the two text runs in DOM order — the bug was
+    // every tool call hoisting to the top of the message.
+    const text = container.textContent ?? "";
+    const firstText = text.indexOf("Let me check your account.");
+    const toolPos = text.indexOf("analytics");
+    const secondText = text.indexOf("Here is what I found.");
+    expect(firstText).toBeGreaterThanOrEqual(0);
+    expect(toolPos).toBeGreaterThan(firstText);
+    expect(secondText).toBeGreaterThan(toolPos);
+  });
+
+  it("shows the tool-call status row for an interleaved tool segment", () => {
+    render(<AgentSidebarAgentMessage content="x" segments={interleaved} />);
+    expect(
+      screen.getByRole("status", { name: /analytics · summarize_views/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("rides the blinking caret on the final text segment only while streaming", () => {
+    const { container } = render(
+      <AgentSidebarAgentMessage content="x" segments={interleaved} streaming />,
+    );
+    // One caret (animate-pulse w-[2px]) trailing the last text run.
+    const carets = container.querySelectorAll("span.animate-pulse.w-\\[2px\\]");
+    expect(carets).toHaveLength(1);
+  });
+
+  it("drops the caret when a trailing tool segment is the last segment", () => {
+    const trailingTool: AgentMessageSegment[] = [
+      { type: "text", text: "Working on it." },
+      { type: "tool", id: "t-2", tool: { moduleSlug: "cms", tool: "publish", status: "started" } },
+    ];
+    const { container } = render(
+      <AgentSidebarAgentMessage content="Working on it." segments={trailingTool} streaming />,
+    );
+    // The running tool spinner is the live indicator — no text caret after it.
+    const carets = container.querySelectorAll("span.animate-pulse.w-\\[2px\\]");
+    expect(carets).toHaveLength(0);
+    expect(within(container).getByRole("status", { name: /cms · publish/ })).toBeInTheDocument();
+  });
+
+  it("falls back to flat content when no segments are provided", () => {
+    render(<AgentSidebarAgentMessage content="Just a plain reply." />);
+    expect(screen.getByText("Just a plain reply.")).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/agent/messages/AgentSidebarMessage.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessage.tsx
@@ -3,6 +3,11 @@ import Markdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { cn } from "@/utils/cn";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
+import {
+  AgentSidebarToolCall,
+  type AgentToolCall,
+  type AgentToolCallLabels,
+} from "./AgentSidebarToolCall";
 
 export interface AgentSidebarUserMessageProps {
   content: string;
@@ -34,9 +39,25 @@ export interface AgentSidebarMessageActionLabels {
   rerun?: string;
 }
 
+/** One ordered piece of a streamed agent reply: a run of response text or a
+ *  tool call, in the order they occurred during streaming. Lets a single
+ *  message interleave prose and tool rows (text → tool → more text) instead of
+ *  hoisting every tool call to the top. */
+export type AgentMessageSegment =
+  | { type: "text"; text: string }
+  | { type: "tool"; id: string; tool: AgentToolCall };
+
 export interface AgentSidebarAgentMessageProps {
-  /** Rendered as Markdown (GFM). Raw HTML in the content is never rendered. */
+  /** Full reply text (concatenation of all text segments). Rendered as
+   *  Markdown (GFM) when `segments` is absent; always the copy/replay source.
+   *  Raw HTML in the content is never rendered. */
   content: string;
+  /** Ordered text/tool segments. When present, the body renders these
+   *  interleaved (preserving stream order) instead of the flat `content`.
+   *  Omit for plain replies (replay rows, finished bubbles with no tools). */
+  segments?: AgentMessageSegment[];
+  /** Localizable status/aria text for any interleaved tool-call rows. */
+  toolLabels?: AgentToolCallLabels;
   /** When true, renders typing indicator (if no content) or blinking cursor (if content). */
   streaming?: boolean;
   /** Current feedback rating reflected on the thumbs. */
@@ -55,6 +76,8 @@ export interface AgentSidebarAgentMessageProps {
 
 export function AgentSidebarAgentMessage({
   content,
+  segments,
+  toolLabels,
   streaming = false,
   feedback = null,
   onCopy,
@@ -71,12 +94,19 @@ export function AgentSidebarAgentMessage({
   return (
     <div className={cn("flex flex-col items-start", className)}>
       <div className="max-w-full min-w-0 text-sm text-inverse-on-surface break-words leading-relaxed">
-        {showThinking ? <ThinkingDots /> : <AgentMarkdown content={content} />}
-        {streaming && content.length > 0 && (
-          <span
-            className="ml-0.5 inline-block w-[2px] h-4 align-middle bg-inverse-on-surface animate-pulse"
-            aria-hidden
+        {showThinking ? (
+          <ThinkingDots />
+        ) : segments && segments.length > 0 ? (
+          <AgentSegments
+            segments={segments}
+            streaming={streaming}
+            toolLabels={toolLabels}
           />
+        ) : (
+          <>
+            <AgentMarkdown content={content} />
+            {streaming && content.length > 0 && <StreamingCaret />}
+          </>
         )}
       </div>
       {showActions && (
@@ -177,6 +207,59 @@ function AgentMarkdown({ content }: { content: string }) {
     <Markdown remarkPlugins={REMARK_PLUGINS} components={markdownComponents}>
       {content}
     </Markdown>
+  );
+}
+
+/** Blinking caret trailing the live text while a reply streams. */
+function StreamingCaret() {
+  return (
+    <span
+      className="ml-0.5 inline-block w-[2px] h-4 align-middle bg-inverse-on-surface animate-pulse"
+      aria-hidden
+    />
+  );
+}
+
+/** Render an ordered text/tool segment list in occurrence order. Each text run
+ *  is its own markdown block; tool rows sit between the prose exactly where the
+ *  stream emitted them. The blinking caret rides only the final text segment
+ *  while streaming — a trailing tool call carries its own spinner instead.
+ *  Each tool row gets a small top gap so it reads as a step between paragraphs,
+ *  matching the tool-stack rhythm in AgentSidebarMessages. */
+function AgentSegments({
+  segments,
+  streaming,
+  toolLabels,
+}: {
+  segments: AgentMessageSegment[];
+  streaming: boolean;
+  toolLabels?: AgentToolCallLabels;
+}) {
+  // The caret rides the last text run ONLY when it's also the final segment —
+  // a trailing tool call shows its own spinner, so a caret there would read as
+  // a stray cursor floating after the prose.
+  const caretIndex =
+    streaming && segments[segments.length - 1]?.type === "text"
+      ? segments.length - 1
+      : -1;
+  return (
+    <>
+      {segments.map((seg, i) =>
+        seg.type === "tool" ? (
+          // Tight symmetric gap so a tool row reads as a step between
+          // paragraphs without the heavier list-level rhythm. Adjacent text
+          // segments reset their own edge margins, so this is the only gap.
+          <div key={seg.id} className="my-1.5 first:mt-0 last:mb-0">
+            <AgentSidebarToolCall tool={seg.tool} toolLabels={toolLabels} />
+          </div>
+        ) : (
+          <div key={`text-${i}`}>
+            <AgentMarkdown content={seg.text} />
+            {i === caretIndex && seg.text.length > 0 && <StreamingCaret />}
+          </div>
+        ),
+      )}
+    </>
   );
 }
 

--- a/src/components/ui/agent/messages/AgentSidebarMessages.stories.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.stories.tsx
@@ -80,6 +80,70 @@ export const AgentStreaming: StoryObj = {
   ),
 };
 
+/** A reply whose tool calls are interleaved with the response text in stream
+ *  order — prose, then a tool step, then more prose — instead of every tool
+ *  call hoisted to the top of the message. */
+export const AgentInterleavedToolCalls: StoryObj = {
+  render: () => (
+    <AgentSidebarAgentMessage
+      content={
+        "Let me check your recent posts and tidy up the drafts.\n\nDone — published the latest draft and archived the two stale ones."
+      }
+      segments={[
+        {
+          type: "text",
+          text: "Let me check your recent posts and tidy up the drafts.",
+        },
+        {
+          type: "tool",
+          id: "t-1",
+          tool: {
+            moduleSlug: "cms",
+            tool: "list_posts",
+            status: "done",
+            durationMs: 214,
+            args: { limit: 5 },
+            result: [{ id: "p1", title: "Hello world" }],
+          },
+        },
+        {
+          type: "tool",
+          id: "t-2",
+          tool: {
+            moduleSlug: "cms",
+            tool: "publish_post",
+            status: "done",
+            durationMs: 96,
+          },
+        },
+        {
+          type: "text",
+          text: "Done — published the latest draft and archived the two stale ones.",
+        },
+      ]}
+    />
+  ),
+};
+
+/** Mid-stream: text has streamed, a tool is running, and the blinking caret
+ *  stays off because the trailing tool's spinner is the live indicator. */
+export const AgentInterleavedStreaming: StoryObj = {
+  render: () => (
+    <AgentSidebarAgentMessage
+      streaming
+      content="Checking your account settings."
+      segments={[
+        { type: "text", text: "Checking your account settings." },
+        {
+          type: "tool",
+          id: "t-1",
+          tool: { moduleSlug: "account", tool: "get_preferences", status: "started" },
+        },
+      ]}
+    />
+  ),
+};
+
 const noop = () => {};
 
 const actionCallbacks = {

--- a/src/components/ui/agent/messages/AgentSidebarMessages.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.tsx
@@ -5,6 +5,7 @@ import { Logo } from "@/components/ui/media/logo/Logo";
 import {
   AgentSidebarUserMessage,
   AgentSidebarAgentMessage,
+  type AgentMessageSegment,
   type AgentSidebarMessageFeedback,
   type AgentSidebarMessageActionLabels,
 } from "./AgentSidebarMessage";
@@ -31,6 +32,10 @@ export type AgentSidebarMessage =
       id: string;
       role: "agent";
       content: string;
+      /** Ordered text/tool segments — when present the bubble renders them
+       *  interleaved so streamed tool calls sit between the response text
+       *  instead of hoisted to the top. */
+      segments?: AgentMessageSegment[];
       streaming?: boolean;
       feedback?: AgentSidebarMessageFeedback;
     }
@@ -247,6 +252,8 @@ export function AgentSidebarMessages({
           <AgentSidebarAgentMessage
             key={m.id}
             content={m.content}
+            segments={m.segments}
+            toolLabels={toolLabels}
             streaming={m.streaming}
             feedback={m.feedback}
             onCopy={onCopyMessage && (() => onCopyMessage(m.id))}

--- a/src/hooks/agent-chat/useAgentChat.test.ts
+++ b/src/hooks/agent-chat/useAgentChat.test.ts
@@ -93,7 +93,13 @@ describe("useAgentChat", () => {
     act(() => stream.handlers.onDone("m-1"));
     stream.release();
     await flush();
-    expect(result.current.messages[1]).toEqual({ id: "m-1", role: "agent", content: "Hi there" });
+    // A text-only reply keeps a single text segment alongside the flat content.
+    expect(result.current.messages[1]).toEqual({
+      id: "m-1",
+      role: "agent",
+      content: "Hi there",
+      segments: [{ type: "text", text: "Hi there" }],
+    });
     expect(result.current.error).toBeNull();
   });
 
@@ -149,23 +155,76 @@ describe("useAgentChat", () => {
     expect(result.current.messages[1].id).not.toBe("__pending__");
   });
 
-  it("tool frames insert a running row above the placeholder and resolve it in place", async () => {
+  it("interleaves tool calls with response text in stream order, resolving in place", async () => {
     const stream = controlledStream();
     const client = fakeClient({ streamAgentReply: stream.fn });
     const { result } = renderHook(() => useAgentChat(client, { appId: null }));
 
     act(() => result.current.send("hello"));
     await flush();
+    // text → tool → more text: the reply is ONE bubble whose ordered segments
+    // preserve occurrence order (no top-level tool rows, no hoisting).
+    act(() => stream.handlers.onDelta("Let me check. "));
     act(() => stream.handlers.onTool?.("analytics__summarize_views", "started"));
+    act(() => stream.handlers.onDelta("Here's the result."));
 
-    expect(result.current.messages[1]).toMatchObject({
-      role: "tool",
-      tool: { moduleSlug: "analytics", tool: "summarize_views", status: "started" },
-    });
-    expect(result.current.messages[2]).toMatchObject({ role: "agent", streaming: true });
+    expect(result.current.messages).toHaveLength(2);
+    const pending = result.current.messages[1];
+    expect(pending).toMatchObject({ role: "agent", streaming: true });
+    expect((pending as { content: string }).content).toBe(
+      "Let me check. Here's the result.",
+    );
+    expect((pending as { segments: unknown }).segments).toEqual([
+      { type: "text", text: "Let me check. " },
+      {
+        type: "tool",
+        id: expect.any(String),
+        tool: { moduleSlug: "analytics", tool: "summarize_views", status: "started" },
+      },
+      { type: "text", text: "Here's the result." },
+    ]);
 
+    // done/error resolves the matching started segment in place (no new row).
     act(() => stream.handlers.onTool?.("analytics__summarize_views", "done"));
-    expect(result.current.messages[1]).toMatchObject({ tool: { status: "done" } });
+    const segs = (result.current.messages[1] as { segments: { type: string; tool?: { status: string } }[] }).segments;
+    expect(segs[1].tool?.status).toBe("done");
+    expect(segs).toHaveLength(3);
+
+    act(() => stream.handlers.onDone("m-1"));
+    stream.release();
+    await flush();
+    // done keeps the interleaved segments and swaps in the persisted id.
+    expect(result.current.messages[1]).toMatchObject({
+      id: "m-1",
+      role: "agent",
+      content: "Let me check. Here's the result.",
+    });
+    expect(
+      (result.current.messages[1] as { segments: unknown[] }).segments,
+    ).toHaveLength(3);
+  });
+
+  it("drops an unresolved tool segment when the stream errors but keeps text", async () => {
+    const stream = controlledStream();
+    const client = fakeClient({ streamAgentReply: stream.fn });
+    const { result } = renderHook(() => useAgentChat(client, { appId: null }));
+
+    act(() => result.current.send("hello"));
+    await flush();
+    act(() => stream.handlers.onDelta("Working on it. "));
+    act(() => stream.handlers.onTool?.("cms__publish", "started"));
+    act(() => stream.handlers.onError("reply_failed"));
+    stream.release();
+    await flush();
+
+    expect(result.current.error).toBe("reply_failed");
+    const reply = result.current.messages[1] as {
+      content: string;
+      segments: { type: string }[];
+    };
+    expect(reply.content).toBe("Working on it. ");
+    // The eternal-spinner tool segment is gone; the text segment survives.
+    expect(reply.segments).toEqual([{ type: "text", text: "Working on it. " }]);
   });
 
   it("skips the history refresh when a send is superseded (aborted) by a newer send", async () => {
@@ -229,7 +288,12 @@ describe("useAgentChat", () => {
     act(() => rerun.handlers.onDone("m-2"));
     rerun.release();
     await flush();
-    expect(result.current.messages[1]).toEqual({ id: "m-2", role: "agent", content: "fresh" });
+    expect(result.current.messages[1]).toEqual({
+      id: "m-2",
+      role: "agent",
+      content: "fresh",
+      segments: [{ type: "text", text: "fresh" }],
+    });
     expect(result.current.error).toBeNull();
   });
 

--- a/src/hooks/agent-chat/useAgentChat.ts
+++ b/src/hooks/agent-chat/useAgentChat.ts
@@ -297,7 +297,7 @@ function makeStreamHandlers(
                 id: messageId,
                 role: "agent",
                 content: m.content,
-                ...(m.segments && m.segments.length > 0 ? { segments: m.segments } : {}),
+                ...(m.segments?.length ? { segments: m.segments } : {}),
               }
             : m,
         ),

--- a/src/hooks/agent-chat/useAgentChat.ts
+++ b/src/hooks/agent-chat/useAgentChat.ts
@@ -7,7 +7,10 @@ import {
   type Dispatch,
   type SetStateAction,
 } from "react";
-import type { AgentSidebarMessageFeedback } from "@/components/ui/agent/messages/AgentSidebarMessage";
+import type {
+  AgentSidebarMessageFeedback,
+  AgentMessageSegment,
+} from "@/components/ui/agent/messages/AgentSidebarMessage";
 import type { AgentToolCall } from "@/components/ui/agent/messages/AgentSidebarToolCall";
 import type { AgentSidebarInputModel } from "@/components/ui/agent/sidebar/AgentSidebarInput";
 import type {
@@ -34,6 +37,12 @@ export type AgentChatMessage =
       id: string;
       role: "agent";
       content: string;
+      /** Ordered text/tool segments captured during streaming so tool calls
+       *  render interleaved with the response text (text → tool → more text)
+       *  instead of hoisted above the reply. `content` mirrors the text runs
+       *  for copy/replay. Absent on replayed rows (the server stores one text
+       *  blob; their tool calls are separate `role:"tool"` messages). */
+      segments?: AgentMessageSegment[];
       streaming?: boolean;
       feedback?: AgentSidebarMessageFeedback;
     }
@@ -112,17 +121,39 @@ const DEFAULT_MODEL_DISABLED_HINT = "Currently unavailable";
 // fractions at exactly two decimals ("$1.50/$9").
 const formatPrice = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(2));
 
+// Drop tool segments still running when the stream died — they never resolve,
+// and only resolved calls persist server-side, so leaving them would strand an
+// eternal spinner inside the finalized reply.
+function settleSegments(
+  segments: AgentMessageSegment[] | undefined,
+): AgentMessageSegment[] | undefined {
+  if (!segments) return undefined;
+  const kept = segments.filter(
+    (s) => s.type !== "tool" || s.tool.status !== "started",
+  );
+  return kept.length > 0 ? kept : undefined;
+}
+
 // Settle a stale pending reply before appending new turns: keep whatever
-// text already streamed in (finalized as a local message), drop it if empty.
+// text/resolved tool calls already streamed in (finalized as a local message),
+// drop it if nothing landed. Top-level `started` tool rows (replay/legacy
+// shape) are dropped for the same reason.
 function settlePending(list: AgentChatMessage[]): AgentChatMessage[] {
   return list.flatMap((m) => {
-    // A tool call still running when its stream dies never resolves — and
-    // only resolved calls persist server-side, so drop it with the pending
-    // bubble rather than leaving an eternal spinner.
     if (m.role === "tool" && m.tool.status === "started") return [];
     if (m.id !== PENDING_ID) return [m];
-    if (m.role === "agent" && m.content) {
-      return [{ id: `local-${crypto.randomUUID()}`, role: "agent" as const, content: m.content }];
+    if (m.role === "agent") {
+      const segments = settleSegments(m.segments);
+      if (m.content || segments) {
+        return [
+          {
+            id: `local-${crypto.randomUUID()}`,
+            role: "agent" as const,
+            content: m.content,
+            ...(segments ? { segments } : {}),
+          },
+        ];
+      }
     }
     return [];
   });
@@ -137,38 +168,56 @@ function parseToolWireName(name: string): { moduleSlug: string; tool: string } {
   return { moduleSlug: name.slice(0, i), tool: name.slice(i + 2) };
 }
 
-// Apply one tool lifecycle frame to the thread: "started" inserts a running
-// row above the streaming reply placeholder; "done"/"error" resolve the
-// OLDEST matching running row (frames carry no call id — wire name + order
-// is the join key). A resolution with no running counterpart (shouldn't
-// happen, but the wire allows it) inserts an already-resolved row.
+// Apply one tool lifecycle frame to the streaming reply's ordered segments,
+// preserving stream order so tool calls render interleaved with the response
+// text. "started" appends a running tool segment AFTER whatever text streamed
+// so far; "done"/"error" resolve the OLDEST matching running segment in place
+// (frames carry no call id — wire name + order is the join key). A resolution
+// with no running counterpart (shouldn't happen, but the wire allows it) is
+// appended as an already-resolved segment.
+function applyToolToSegments(
+  segments: AgentMessageSegment[],
+  name: string,
+  status: AgentToolEventStatus,
+): AgentMessageSegment[] {
+  const { moduleSlug, tool } = parseToolWireName(name);
+  if (status !== "started") {
+    const idx = segments.findIndex(
+      (s) =>
+        s.type === "tool" &&
+        s.tool.status === "started" &&
+        s.tool.moduleSlug === moduleSlug &&
+        s.tool.tool === tool,
+    );
+    if (idx !== -1) {
+      return segments.map((s, i) =>
+        i === idx && s.type === "tool" ? { ...s, tool: { ...s.tool, status } } : s,
+      );
+    }
+  }
+  return [
+    ...segments,
+    {
+      type: "tool",
+      id: `tool-${crypto.randomUUID()}`,
+      tool: { moduleSlug, tool, status },
+    },
+  ];
+}
+
+// Route a tool frame into the pending reply bubble's segments. Falls back to a
+// no-op when the bubble has gone (e.g. settled by an error) — a stray frame
+// must not resurrect a finished reply.
 function applyToolEvent(
   list: AgentChatMessage[],
   name: string,
   status: AgentToolEventStatus,
 ): AgentChatMessage[] {
-  const { moduleSlug, tool } = parseToolWireName(name);
-  if (status !== "started") {
-    const idx = list.findIndex(
-      (m) =>
-        m.role === "tool" &&
-        m.tool.status === "started" &&
-        m.tool.moduleSlug === moduleSlug &&
-        m.tool.tool === tool,
-    );
-    if (idx !== -1) {
-      return list.map((m, i) =>
-        i === idx && m.role === "tool" ? { ...m, tool: { ...m.tool, status } } : m,
-      );
-    }
-  }
-  const row: AgentChatMessage = {
-    id: `tool-${crypto.randomUUID()}`,
-    role: "tool",
-    tool: { moduleSlug, tool, status },
-  };
-  const at = list.findIndex((m) => m.id === PENDING_ID);
-  return at === -1 ? [...list, row] : [...list.slice(0, at), row, ...list.slice(at)];
+  return list.map((m) =>
+    m.id === PENDING_ID && m.role === "agent"
+      ? { ...m, segments: applyToolToSegments(m.segments ?? [], name, status) }
+      : m,
+  );
 }
 
 // Map one persisted replay row to its sidebar representation (or nothing).
@@ -203,9 +252,25 @@ function replayMessage(m: AgentApiMessage): AgentChatMessage[] {
   return [{ id: m.id, role: "agent", content: m.content, feedback: meta?.feedback }];
 }
 
+// Append a text delta to the reply's ordered segments: extend the trailing
+// text run, or open a new one when the last segment is a tool (so text after a
+// tool call lands below it, not merged into the pre-tool prose).
+function appendTextSegment(
+  segments: AgentMessageSegment[] | undefined,
+  text: string,
+): AgentMessageSegment[] {
+  const segs = segments ?? [];
+  const last = segs[segs.length - 1];
+  if (last?.type === "text") {
+    return [...segs.slice(0, -1), { type: "text", text: last.text + text }];
+  }
+  return [...segs, { type: "text", text }];
+}
+
 // Build the four SSE handlers shared by send and rerunMessage. Both paths
-// push deltas into the PENDING_ID bubble, update tool rows, swap the bubble
-// for the persisted id on done, and settle+error on failure.
+// push deltas into the PENDING_ID bubble (as ordered segments + flat content),
+// interleave tool rows, swap the bubble for the persisted id on done, and
+// settle+error on failure.
 function makeStreamHandlers(
   setMessages: Dispatch<SetStateAction<AgentChatMessage[]>>,
   setError: Dispatch<SetStateAction<string | null>>,
@@ -214,7 +279,13 @@ function makeStreamHandlers(
     onDelta: (text) =>
       setMessages((prev) =>
         prev.map((m) =>
-          m.id === PENDING_ID && m.role === "agent" ? { ...m, content: m.content + text } : m,
+          m.id === PENDING_ID && m.role === "agent"
+            ? {
+                ...m,
+                content: m.content + text,
+                segments: appendTextSegment(m.segments, text),
+              }
+            : m,
         ),
       ),
     onTool: (name, status) => setMessages((prev) => applyToolEvent(prev, name, status)),
@@ -222,7 +293,12 @@ function makeStreamHandlers(
       setMessages((prev) =>
         prev.map((m) =>
           m.id === PENDING_ID && m.role === "agent"
-            ? { id: messageId, role: "agent", content: m.content }
+            ? {
+                id: messageId,
+                role: "agent",
+                content: m.content,
+                ...(m.segments && m.segments.length > 0 ? { segments: m.segments } : {}),
+              }
             : m,
         ),
       ),


### PR DESCRIPTION
## Bug 1 — tool-call ordering (main fix)

In a streamed agent message, tool calls all rendered at the **top** of the message, before the entire response text. They now render **interleaved in chronological order** — response text, then a tool call, then more response text — matching stream order.

### Root cause
The agent reply was a single `PENDING` bubble that accumulated **all** text into one concatenated `content` string (`onDelta: content + text`), while `applyToolEvent` **inserted each tool row as a separate top-level message _before_ that bubble** (`[...slice(0, pendingIdx), toolRow, ...slice(pendingIdx)]`). Because text was one growing blob and every tool was forced ahead of it, the interleave order was structurally impossible to recover — tools always stacked at the top.

### Fix
The agent reply now preserves an **ordered `segments` sequence** (`{type:"text"} | {type:"tool"}`) captured in occurrence order during streaming:

- `onDelta` extends the trailing text segment (opening a new one if the last segment is a tool), and still mirrors the flat `content` for copy/replay.
- `onTool("started")` **appends** a running tool segment after whatever text streamed so far (no more hoisting); `done`/`error` resolve the oldest matching started segment in place (wire name + order join key, unchanged).
- `onDone` swaps in the persisted id while keeping the interleaved segments.
- `settlePending` drops only the unresolved (`started`) tool segments — the eternal-spinner case — and keeps streamed text + resolved tools.

`AgentSidebarAgentMessage` (singular) renders `segments` interleaved when present (each text run is its own markdown block; tool rows sit between), and falls back to flat `content` otherwise — so existing plain replies and **replay rows are unchanged** (replay still uses separate top-level `role:"tool"` messages; the server stores one text blob, so true interleave is only known at stream time). The streamed thinking dots, blinking caret (now only on the final text run; a trailing tool shows its own spinner), and a11y status roles are intact.

## Bug 2 — tool-call spacing
The interleaved tool row's wrapper gap was tightened to a symmetric `my-1.5` (with `first:mt-0 last:mb-0`) so a tool reads as a compact step between paragraphs rather than carrying the heavier list-level rhythm. The standalone top-level tool-stack path (owned by `AgentSidebarMessages.tsx`, see note below) keeps its existing `gap-1`/`gap-4`.

## Files changed
- `src/hooks/agent-chat/useAgentChat.ts` — segment model on the agent message; `applyToolEvent`/`onDelta`/`onDone`/`settlePending` rewritten to preserve order.
- `src/components/ui/agent/messages/AgentSidebarMessage.tsx` — `AgentMessageSegment` type + interleaved `AgentSegments` render + tightened tool gap.
- `src/components/ui/agent/messages/AgentSidebarMessage.test.tsx` — **new** focused tests for interleaved rendering, caret placement, fallback.
- `src/components/ui/agent/messages/AgentSidebarMessages.stories.tsx` — `AgentInterleavedToolCalls` + `AgentInterleavedStreaming` stories.
- `src/hooks/agent-chat/useAgentChat.test.ts` — updated the old "tool above placeholder" test to assert interleaved segments; added a stream-error settle test; updated two exact-equality assertions for the new `segments` field.
- ⚠️ `src/components/ui/agent/messages/AgentSidebarMessages.tsx` — **had to touch** (one-line pass-through of `segments`/`toolLabels` to the agent message + `segments` on the union). **Potential conflict with open PR #300**, which also edits this file — but PR #300 only touches the `showBrandLogo`/logo-render region (~L163–224); this change is in the agent-message render call (~L246–262) and the type union, so the regions are disjoint and should merge cleanly.

## Verification
- `pnpm exec tsc --noEmit`: no new errors (only the pre-existing `react-markdown`/`remark-gfm`/`_node` env errors that exist on `main`).
- vitest: hook suite 18/18, tool-call suite 16/16, new segments suite 5/5 pass. The 5 `AgentSidebarMessages` *markdown-rendering* assertions can't run in the local checkout because `react-markdown` isn't installed there (pre-existing, fails identically on `main`); verified green by aliasing a markdown passthrough stub. CI installs the real dep.

## Release
**No version bump, no `release` label** — this rides the next rollup release.

Generated with Claude Code (https://claude.com/claude-code)