### PR TITLE
chore: release 0.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Rollup release 0.5.5 → 0.5.6

Bundles the agent-sidebar kit changes merged to `main` since `v0.5.5` (`release.yml` reads the version from `package.json`; merging tags `v0.5.6` + publishes):

- **#300** — Logo redesigned as an inline-SVG aperture mark (transparent center, larger via viewBox, `loading` counter-rotate + agent-message responding story/wiring)
- **#301** — agent message tool calls now interleave with response text in chronological order (no longer top-grouped) + tighter tool-call spacing

After publish, the host apps (web-applications, web-account) bump to `^0.5.6` to pick these up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)