### PR TITLE
fix: AppShell content gutter is a collision-proof dedicated class

### DIFF
--- a/src/components/layout/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/AppShell.tsx
@@ -394,13 +394,20 @@ function AppShellInner({
                     // Responsive gutters — tight on phones, roomier as the
                     // viewport grows. Pages must NOT add their own horizontal
                     // padding (it would double up); they own max-width only.
-                    "mx-auto w-full px-4 md:px-8 xl:px-12 pt-12",
+                    // The padding lives in the dedicated `ms-content-gutter`
+                    // class (theme.css) instead of Tailwind utilities so a
+                    // module-injected global `.px-4`/`.pt-12` cannot override
+                    // it by cascade order — see theme.css.
+                    "mx-auto w-full ms-content-gutter",
                     // Clear the pinned mobile bottom nav so content isn't hidden
                     // behind it. No-op at lg+, with no mobile navigation, and
                     // for the drawer variant (an overlay, not a pinned bar).
+                    // Bottom padding is conditional, so it stays its own
+                    // dedicated class (also leak-proof) rather than folding
+                    // into ms-content-gutter.
                     mobileNavigation && mobileNavigationVariant === "bottom"
-                      ? "pb-28 lg:pb-16"
-                      : "pb-16",
+                      ? "ms-content-gutter-pb-bottomnav"
+                      : "ms-content-gutter-pb",
                     contentClassName,
                   )}
                 >

--- a/src/theme.css
+++ b/src/theme.css
@@ -151,6 +151,43 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+/* AppShell content gutter — emitted as a dedicated (non-utility) class so a
+   module-injected global Tailwind stylesheet (.px-4, .pt-12, etc.) cannot
+   override it by cascade order. Raw CSS, not @apply, so the resolved values
+   can't be re-clobbered by the same leaking utilities. Mirrors the original
+   utilities: px-4 / md:px-8 / xl:px-12 / pt-12, with the conditional bottom
+   padding split out (default pb-16, mobile-bottom-nav pb-28 → lg:pb-16). */
+.ms-content-gutter {
+  padding-inline: 1rem; /* px-4 */
+  padding-top: 3rem; /* pt-12 */
+}
+@media (min-width: 48rem) {
+  .ms-content-gutter {
+    padding-inline: 2rem; /* md:px-8 */
+  }
+}
+@media (min-width: 80rem) {
+  .ms-content-gutter {
+    padding-inline: 3rem; /* xl:px-12 */
+  }
+}
+
+/* Default bottom padding (no pinned mobile bottom nav). */
+.ms-content-gutter-pb {
+  padding-bottom: 4rem; /* pb-16 */
+}
+
+/* Bottom padding when the pinned mobile bottom nav is shown: clear the bar on
+   small screens, collapse back to the default at lg+. */
+.ms-content-gutter-pb-bottomnav {
+  padding-bottom: 7rem; /* pb-28 */
+}
+@media (min-width: 64rem) {
+  .ms-content-gutter-pb-bottomnav {
+    padding-bottom: 4rem; /* lg:pb-16 */
+  }
+}
+
 /* Progress indicator animations */
 @keyframes progress-bar-1 {
   0% {


### PR DESCRIPTION
## Root cause

The AppShell content gutter set its horizontal/top/bottom padding with raw Tailwind utilities on the content div (`px-4 md:px-8 xl:px-12 pt-12` plus `pb-16` / `pb-28 lg:pb-16`).

When a module injects its own global Tailwind stylesheet, that sheet emits the **same single-class utilities** (`.px-4`, `.pt-12`, ...). Because the module sheet loads *after* the kit's CSS and the selectors have identical specificity (0,1,0), the module's utilities win purely on cascade order and clobber the host gutter. Observed in production: oauth-core rendered a 16px gutter where oauth-google rendered the intended 48px.

## The fix

Move the gutter padding into **dedicated, namespaced classes** defined as raw CSS in the published `theme.css`:

- `.ms-content-gutter` — horizontal + top padding (`padding-inline` 1rem → 2rem@48rem → 3rem@80rem, `padding-top` 3rem)
- `.ms-content-gutter-pb` — default bottom padding (4rem)
- `.ms-content-gutter-pb-bottomnav` — bottom padding when the pinned mobile bottom nav is shown (7rem, collapsing to 4rem@64rem)

Values mirror the original utilities exactly (`px-4`=1rem, `md:px-8`=2rem@48rem, `xl:px-12`=3rem@80rem, `pt-12`=3rem, `pb-16`=4rem, `pb-28`=7rem, `lg:pb-16`=4rem@64rem; breakpoints match Tailwind v4 defaults). Because these are **raw declarations (not `@apply`)**, the resolved padding cannot be re-clobbered by the same leaking utilities — the gutter is now immune for **all** modules, not just the one we saw. Non-padding classes (`mx-auto w-full`) stay on the element; no behavior change for hosts. The rules are unlayered top-level CSS loaded after `@import "tailwindcss"`, so they win the cascade regardless of source order against `@layer` utilities.

## Note

This PR carries **no version bump on purpose** — it stays at 0.5.6 and will ride the next `0.5.7` rollup release (patch bump + `release` label applied there per web-ui-kit release mechanics).