### PR TITLE
fix: remove background box behind agent sidebar empty-state icon

### DIFF
--- a/src/components/ui/agent/messages/AgentSidebarMessages.tsx
+++ b/src/components/ui/agent/messages/AgentSidebarMessages.tsx
@@ -105,13 +105,14 @@ const DEFAULT_EMPTY_STATE = (
 
 /** Brand signature above the empty-state opener — the same MirrorStack `Logo`
  *  the greeting hero shows, sized for the narrower sidebar (size-10 vs the
- *  hero's size-14) and tinted with `bg-inverse-primary` for the dark agent
- *  surface. Decorative: the host's opener carries the accessible name.
- *  Exported so `AppShell`, which renders the empty body itself, paints the
- *  identical logo without duplicating the markup. */
+ *  hero's size-14). The aperture mark carries its own fixed brand colours and a
+ *  transparent centre, so it needs no background tint — adding one would paint a
+ *  solid square behind the mark. Decorative: the host's opener carries the
+ *  accessible name. Exported so `AppShell`, which renders the empty body itself,
+ *  paints the identical logo without duplicating the markup. */
 export const AGENT_EMPTY_STATE_LOGO = (
   <div aria-hidden className="flex justify-start">
-    <Logo className="size-10 bg-inverse-primary" />
+    <Logo className="size-10" />
   </div>
 );
 


### PR DESCRIPTION
## Problem

In the agent sidebar empty/greeting state, the MirrorStack `Logo` was rendered inside an unwanted filled background box. `AGENT_EMPTY_STATE_LOGO` carried `bg-inverse-primary`, which painted a solid square behind the mark on the dark inverse agent surface.

This was a leftover from the post-0.5.6 Logo aperture redesign (#300): the redesigned `Logo` now renders its own fixed brand colours (teal/cyan) and masks out a transparent centre circle, so it reads correctly on the dark surface without any background fill. The lingering tint just added a square behind it.

## Fix

Scoped, minimal change in `src/components/ui/agent/messages/AgentSidebarMessages.tsx`:

- `<Logo className="size-10 bg-inverse-primary" />` → `<Logo className="size-10" />`
- Doc comment updated to explain why no tint is needed (Logo carries fixed brand colours + transparent centre).

This makes all three `<Logo>` renders agree: the responding/brand logo (same file) and the greeting hero (`AgentGreeting.tsx`) already render untinted — the empty-state logo was the lone outlier. Sizing (`size-10`), wrapper, and surrounding layout are unchanged. Other `bg-inverse-primary` usages (multi-question chips, `SegmentedButton`, `Switch`) are unrelated selection/toggle surfaces and are untouched.

## Notes

- No version bump — rides the 0.5.7 rollup release.
- `git diff --stat`: 1 file, 6 insertions / 5 deletions (only non-JSX change is the doc comment).
- Pre-existing typecheck errors in this package are from an uninstalled `react-markdown`/`remark-gfm` dependency in a different file; none reference the edited file.