### PR TITLE
chore: release 0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.5.7
+
+- `AppShell`: new optional controlled-open props `open?` / `onOpenChange?`. The
+  agent sidebar's open/closed state can now be driven (and persisted) by the
+  host — on reload the shell paints the persisted open flag instead of always
+  deriving visibility from width. Uncontrolled usage (`open === undefined`) is
+  unchanged.
+- Agent sidebar: a persisted drag-width is now restored on **reload**, not just
+  on the next open gesture (the fetched width is reconciled into the rendered
+  state on mount; a user gesture landing before the async fetch is never
+  clobbered).
+- `AgentChatClient` / `useAgentChat` / `useAgentSession`: new `deleteConversation`
+  (optimistic history removal + open-thread clear, rollback on failure) backing
+  the existing history trash-icon control.
+- `AgentSidebarMessages`: the empty-state icon no longer renders inside a filled
+  background box (the redesigned `Logo` carries its own brand fill + transparent
+  centre).
+
 ## 0.5.2
 
 - `AgentSidebarMessages`: new optional `emptyState?: ReactNode`. When the

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
Rollup release **0.5.7** — publishes what's on main since 0.5.6:
- #305 — agent sidebar: width + open restore on reload, `deleteConversation` in `useAgentChat`/`useAgentSession`, `AppShell` controlled-open (`open`/`onOpenChange`)
- #304 — empty-state icon background box removed

Version bump + CHANGELOG only. Carries the `release` label so the Release workflow publishes 0.5.7 to GitHub Packages on merge.