### PR TITLE
fix(app-shell): content gutter xl padding 12 → 10

### DIFF
--- a/src/components/layout/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/AppShell.tsx
@@ -440,7 +440,7 @@ function AppShellInner({
                     // Responsive gutters — tight on phones, roomier as the
                     // viewport grows. Pages must NOT add their own horizontal
                     // padding (it would double up); they own max-width only.
-                    "mx-auto w-full px-4 md:px-8 xl:px-12 pt-12",
+                    "mx-auto w-full px-4 md:px-8 xl:px-10 pt-12",
                     // Clear the pinned mobile bottom nav so content isn't hidden
                     // behind it. No-op at lg+, with no mobile navigation, and
                     // for the drawer variant (an overlay, not a pinned bar).


### PR DESCRIPTION
Tightens the AppShell content gutter at the xl breakpoint: `xl:px-12` → `xl:px-10` (48px → 40px). One-token change on the gutter div; `px-4`/`md:px-8` and vertical padding unchanged. No version bump — rides the next kit rollup (0.5.8).