### PR TITLE
feat(theme): warm the dark-mode neutral palette to #1a1a18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.5.10
+
+- **Warm dark theme.** The dark-mode neutral tokens shift from cool near-black
+  (`background #000`, `surface #101417`, blue-grey `surface-variant`/`outline`)
+  to a warm `#1a1a18` charcoal family on a `#14110f` base, with warm off-white
+  ink (`on-surface #e8e2d7`) and warm muted/outline tones. Only the neutral
+  surface/ink ramp changes — every brand and semantic accent (primary,
+  secondary, tertiary, error, success, warning) is untouched, so contrast pairs
+  hold. Light mode is unchanged. Every app inherits the warmth via
+  `bg-background` / `bg-surface` / `text-on-surface`; no app-level overrides.
+
 ## 0.5.9
 
 - Agent sidebar reload **clobber fix**: a mount-time mutation (the host bridge's

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/theme.css
+++ b/src/theme.css
@@ -113,28 +113,28 @@
   --color-warning-container: #5e4200;
   --color-on-warning-container: #ffdea6;
 
-  --color-background: #000000;
-  --color-on-background: #ffffff;
+  --color-background: #14110f;
+  --color-on-background: #f1ece2;
 
-  --color-surface: #101417;
-  --color-on-surface: #dfe3e7;
-  --color-surface-variant: #3c494b;
-  --color-on-surface-variant: #bbc9cb;
+  --color-surface: #1a1815;
+  --color-on-surface: #e8e2d7;
+  --color-surface-variant: #3a342c;
+  --color-on-surface-variant: #b7ab99;
 
-  --color-outline: #869395;
-  --color-outline-variant: #3c494b;
+  --color-outline: #968a78;
+  --color-outline-variant: #3a342c;
 
-  --color-surface-dim: #101417;
-  --color-surface-bright: #343a3b;
-  --color-surface-container-lowest: #090f10;
-  --color-surface-container-low: #171d1e;
-  --color-surface-container: #1b2122;
-  --color-surface-container-high: #252b2c;
-  --color-surface-container-highest: #303637;
+  --color-surface-dim: #14110f;
+  --color-surface-bright: #3a342d;
+  --color-surface-container-lowest: #0e0c0a;
+  --color-surface-container-low: #1c1915;
+  --color-surface-container: #211d18;
+  --color-surface-container-high: #2a251f;
+  --color-surface-container-highest: #332d26;
 
   --color-inverse-primary: #006973;
-  --color-inverse-surface: #dee3e4;
-  --color-inverse-on-surface: #101417;
+  --color-inverse-surface: #e8e2d7;
+  --color-inverse-on-surface: #1a1815;
 }
 
 /* Base */


### PR DESCRIPTION
## What

Warm the **dark-mode neutral tokens** from cool near-black to a warm `#1a1a18` charcoal family, bumping `0.5.9 → 0.5.10`.

| token | before (cool) | after (warm) |
|---|---|---|
| `background` | `#000000` | `#14110f` |
| `surface` | `#101417` | `#1a1815` |
| `on-surface` | `#dfe3e7` | `#e8e2d7` |
| `surface-variant` | `#3c494b` | `#3a342c` |
| `on-surface-variant` | `#bbc9cb` | `#b7ab99` |
| `outline` | `#869395` | `#968a78` |
| `surface-container-*` | blue-grey ramp | warm ramp |

## Why

The brand's dark surfaces read cold/blue-black; the editorial direction (and the landing nav's glass) is a warm `#1a1a18`. Owning this at the **token** layer means every app — account, applications, the new landing page — inherits the warmth with no per-app overrides, instead of each repo hardcoding `#1a1a18`.

## Scope / safety

- **Only the neutral surface + ink ramp changes.** Every brand/semantic accent (primary, secondary, tertiary, error, success, warning, inverse-primary) is untouched, so contrast pairs hold.
- **Light mode unchanged.**
- Theme ships from source (`exports["./theme.css"] → ./src/theme.css`) — no dist rebuild.
- Version bumped in this PR (`release` label) per the kit's release mechanics.

## Blast radius

All apps consuming `@mirrorstack-ai/web-ui-kit` dark mode get warmer surfaces on next bump. Reviewed as intentional & brand-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)