### PR TITLE
fix(service-logcat): make the console fill its container (flex-fill)

### DIFF
--- a/src/components/ui/dev/service-logcat/ServiceLogcat.tsx
+++ b/src/components/ui/dev/service-logcat/ServiceLogcat.tsx
@@ -123,7 +123,7 @@ export function ServiceLogcat({ logs }: ServiceLogcatProps) {
   };
 
   return (
-    <div>
+    <div className="flex h-full min-h-0 flex-col">
       <div className="flex items-center gap-2 mb-2">
         <SectionLabel>Logcat</SectionLabel>
         <button
@@ -187,11 +187,11 @@ export function ServiceLogcat({ logs }: ServiceLogcatProps) {
         />
       </div>
 
-      <Surface className="overflow-hidden">
+      <Surface className="overflow-hidden flex-1 min-h-0">
         <div
           ref={scrollRef}
           onScroll={onScroll}
-          className="max-h-80 overflow-y-auto p-3 font-mono text-xs"
+          className="h-full overflow-y-auto p-3 font-mono text-xs"
         >
           {filtered.length === 0 ? (
             <p className="text-on-surface-variant/50 py-6 text-center">No matching log entries.</p>


### PR DESCRIPTION
`ServiceLogcat`'s scroll area was capped at a hard `max-h-80`, so a consumer could never give it full height. Make the height come from the **parent** instead — device-adaptively, no `vh` magic:

- root → `flex h-full min-h-0 flex-col`
- surface → `flex-1 min-h-0`
- scroll region → `h-full` (was `max-h-80`)

**No version bump** — batched into the upcoming **0.6.0** release (multiple sessions are landing kit work concurrently).

Consumer: web-applications #101 gives the debug page a full-viewport height and the dev-module page a bounded `h-96`.
🤖 Generated with [Claude Code](https://claude.com/claude-code)