### PR TITLE
feat(service-logcat): load-older paging affordance + stable row keys (0.6.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/dev/service-logcat/ServiceLogcat.stories.tsx
+++ b/src/components/ui/dev/service-logcat/ServiceLogcat.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { ServiceLogcat } from "./ServiceLogcat";
 import type { LogEntry } from "./types";
@@ -64,4 +65,54 @@ export const WithRequestResponseDetail: Story = {
 
 export const Empty: Story = {
   args: { logs: [] },
+};
+
+// Older pages are generated on demand, seq-keyed, and appended at the OLD end
+// (the bottom). Scroll near the bottom or click the row to load a page.
+const PAGE_SIZE = 20;
+const TOTAL_OLDER = 60;
+
+function olderPage(before: number): LogEntry[] {
+  return Array.from({ length: PAGE_SIZE }, (_, i): LogEntry => {
+    const seq = before - PAGE_SIZE + i;
+    const sec = String(seq % 60).padStart(2, "0");
+    return {
+      seq,
+      ts: `2026-06-30T16:22:${sec}.000000000Z`,
+      level: seq % 13 === 0 ? "warn" : "info",
+      msg: `GET /api/items?page=${seq} 200 ${5 + (seq % 20)}ms`,
+      duration_ms: 5 + (seq % 20),
+    };
+  });
+}
+
+function LoadOlderDemo() {
+  const [logs, setLogs] = useState<LogEntry[]>(() =>
+    SAMPLE_LOGS.map((l, i) => ({ ...l, seq: TOTAL_OLDER + i })),
+  );
+  const [loadingOlder, setLoadingOlder] = useState(false);
+  const oldestSeq = logs[0]?.seq ?? TOTAL_OLDER;
+
+  const onLoadOlder = () => {
+    setLoadingOlder(true);
+    setTimeout(() => {
+      setLogs((cur) => [...olderPage(oldestSeq), ...cur]);
+      setLoadingOlder(false);
+    }, 800);
+  };
+
+  return (
+    <div className="h-96">
+      <ServiceLogcat
+        logs={logs}
+        onLoadOlder={onLoadOlder}
+        hasOlder={oldestSeq > 0}
+        loadingOlder={loadingOlder}
+      />
+    </div>
+  );
+}
+
+export const LoadOlder: Story = {
+  render: () => <LoadOlderDemo />,
 };

--- a/src/components/ui/dev/service-logcat/ServiceLogcat.stories.tsx
+++ b/src/components/ui/dev/service-logcat/ServiceLogcat.stories.tsx
@@ -67,6 +67,42 @@ export const Empty: Story = {
   args: { logs: [] },
 };
 
+/** Seeds the text filter box on mount — e.g. landing pre-filtered from a deep link. */
+export const WithInitialQuery: Story = {
+  args: { logs: SAMPLE_LOGS, initialQuery: "users" },
+};
+
+/** Every user-facing string overridden — e.g. for a non-English locale. */
+export const Localized: Story = {
+  args: {
+    logs: SAMPLE_LOGS,
+    labels: {
+      title: "日誌",
+      live: "即時",
+      paused: "已暫停",
+      floorAll: "全部",
+      floorWarn: "警告以上",
+      floorError: "錯誤",
+      filterAriaLabel: "依層級篩選",
+      filterPlaceholder: "篩選紀錄",
+      clearFilterAriaLabel: "清除篩選",
+      copyAriaLabel: "複製紀錄",
+      noMatchingEntries: "沒有符合的紀錄。",
+      request: "請求",
+      response: "回應",
+      noRequestResponseBody: "沒有請求或回應內容。",
+      loadOlderEntries: "載入較舊的紀錄",
+      entriesLabel: (filteredCount, total, query) => {
+        const base =
+          filteredCount === total ? `共 ${total} 筆` : `${total} 筆中的 ${filteredCount} 筆`;
+        return query ? `${base} · "${query}"` : base;
+      },
+      tailingStatus: "即時追蹤中",
+      pausedStatus: "已暫停",
+    },
+  },
+};
+
 // Older pages are generated on demand, seq-keyed, and appended at the OLD end
 // (the bottom). Scroll near the bottom or click the row to load a page.
 const PAGE_SIZE = 20;

--- a/src/components/ui/dev/service-logcat/ServiceLogcat.test.tsx
+++ b/src/components/ui/dev/service-logcat/ServiceLogcat.test.tsx
@@ -1,0 +1,124 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ServiceLogcat } from "./ServiceLogcat";
+import type { LogEntry } from "./types";
+
+afterEach(cleanup);
+
+// Chronological (oldest first), matching the component contract.
+const LOGS: LogEntry[] = [
+  { ts: "2026-06-30T16:23:40.000000000Z", level: "info", msg: "GET /api/a 200 8ms" },
+  { ts: "2026-06-30T16:23:41.000000000Z", level: "warn", msg: "Rate limit approaching" },
+  { ts: "2026-06-30T16:23:42.000000000Z", level: "error", msg: "GET /api/b 500" },
+];
+
+// The mono scroll surface inside the Surface card.
+function scrollEl(container: HTMLElement): HTMLElement {
+  return container.querySelector(".overflow-y-auto") as HTMLElement;
+}
+
+// jsdom reports zero layout; stub the metrics the scroll handler reads.
+function stubMetrics(el: HTMLElement, metrics: { scrollHeight: number; clientHeight: number }) {
+  Object.defineProperty(el, "scrollHeight", {
+    get: () => metrics.scrollHeight,
+    configurable: true,
+  });
+  Object.defineProperty(el, "clientHeight", {
+    get: () => metrics.clientHeight,
+    configurable: true,
+  });
+}
+
+describe("ServiceLogcat load-older", () => {
+  it("fires onLoadOlder from the button row", () => {
+    const onLoadOlder = vi.fn();
+    render(<ServiceLogcat logs={LOGS} onLoadOlder={onLoadOlder} hasOlder />);
+    fireEvent.click(screen.getByText("Load older entries"));
+    expect(onLoadOlder).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders no affordance when hasOlder is false or onLoadOlder is absent", () => {
+    const { rerender } = render(
+      <ServiceLogcat logs={LOGS} onLoadOlder={() => {}} hasOlder={false} />,
+    );
+    expect(screen.queryByText("Load older entries")).not.toBeInTheDocument();
+    rerender(<ServiceLogcat logs={LOGS} hasOlder />);
+    expect(screen.queryByText("Load older entries")).not.toBeInTheDocument();
+  });
+
+  it("shows the loading state and suppresses re-fire while loadingOlder", () => {
+    const onLoadOlder = vi.fn();
+    const { container } = render(
+      <ServiceLogcat logs={LOGS} onLoadOlder={onLoadOlder} hasOlder loadingOlder />,
+    );
+    const row = screen.getByText("Loading older entries…");
+    expect(row.closest("button")).toBeDisabled();
+    fireEvent.click(row);
+    // Near-bottom scroll must not fire either while a page is in flight.
+    // (Twice: the first event is consumed by the programmatic-scroll guard.)
+    const el = scrollEl(container);
+    stubMetrics(el, { scrollHeight: 1000, clientHeight: 200 });
+    el.scrollTop = 790;
+    fireEvent.scroll(el);
+    fireEvent.scroll(el);
+    expect(onLoadOlder).not.toHaveBeenCalled();
+  });
+
+  it("auto-fires once when scrolled near the bottom", () => {
+    const onLoadOlder = vi.fn();
+    const { container } = render(
+      <ServiceLogcat logs={LOGS} onLoadOlder={onLoadOlder} hasOlder />,
+    );
+    const el = scrollEl(container);
+    stubMetrics(el, { scrollHeight: 1000, clientHeight: 200 });
+    el.scrollTop = 400; // far from the bottom
+    fireEvent.scroll(el); // consumed by the programmatic-scroll guard
+    fireEvent.scroll(el);
+    expect(onLoadOlder).not.toHaveBeenCalled();
+    el.scrollTop = 790; // 10px from the bottom
+    fireEvent.scroll(el);
+    fireEvent.scroll(el); // burst of events fires once
+    expect(onLoadOlder).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps scrollTop when older rows append at the bottom, still offsets prepends", () => {
+    const metrics = { scrollHeight: 400, clientHeight: 200 };
+    const withSeq = (l: LogEntry, seq: number): LogEntry => ({ ...l, seq });
+    const logs = LOGS.map((l, i) => withSeq(l, 10 + i));
+    const { container, rerender } = render(
+      <ServiceLogcat logs={logs} onLoadOlder={() => {}} hasOlder />,
+    );
+    const el = scrollEl(container);
+    stubMetrics(el, metrics);
+    fireEvent.click(screen.getByText("Live")); // stop tail-follow
+    el.scrollTop = 150;
+    fireEvent.scroll(el); // unpin from the top
+
+    // Older page appended at the bottom: height grows below, scrollTop holds.
+    metrics.scrollHeight = 600;
+    const older: LogEntry[] = [
+      withSeq({ ts: "2026-06-30T16:22:00.000000000Z", level: "info", msg: "older line" }, 1),
+    ];
+    rerender(<ServiceLogcat logs={[...older, ...logs]} onLoadOlder={() => {}} hasOlder />);
+    expect(el.scrollTop).toBe(150);
+
+    // Newer line prepended above: scrollTop offsets by the added height.
+    metrics.scrollHeight = 800;
+    const newer: LogEntry[] = [
+      withSeq({ ts: "2026-06-30T16:24:00.000000000Z", level: "info", msg: "newer line" }, 99),
+    ];
+    rerender(
+      <ServiceLogcat logs={[...older, ...logs, ...newer]} onLoadOlder={() => {}} hasOlder />,
+    );
+    expect(el.scrollTop).toBe(350);
+  });
+
+  it("renders seq-keyed rows, including repeated ts+msg lines", () => {
+    const dup: LogEntry[] = [
+      { seq: 1, ts: "2026-06-30T16:23:40.000000000Z", level: "info", msg: "retrying" },
+      { seq: 2, ts: "2026-06-30T16:23:40.000000000Z", level: "info", msg: "retrying" },
+    ];
+    render(<ServiceLogcat logs={dup} />);
+    expect(screen.getAllByText("retrying")).toHaveLength(2);
+  });
+});

--- a/src/components/ui/dev/service-logcat/ServiceLogcat.test.tsx
+++ b/src/components/ui/dev/service-logcat/ServiceLogcat.test.tsx
@@ -51,7 +51,7 @@ describe("ServiceLogcat load-older", () => {
     const { container } = render(
       <ServiceLogcat logs={LOGS} onLoadOlder={onLoadOlder} hasOlder loadingOlder />,
     );
-    const row = screen.getByText("Loading older entries…");
+    const row = screen.getByText("Load older entries");
     expect(row.closest("button")).toBeDisabled();
     fireEvent.click(row);
     // Near-bottom scroll must not fire either while a page is in flight.

--- a/src/components/ui/dev/service-logcat/ServiceLogcat.tsx
+++ b/src/components/ui/dev/service-logcat/ServiceLogcat.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Badge, type BadgeVariant } from "@/components/ui/feedback/badge/Badge";
+import { Button } from "@/components/ui/actions/button/Button";
 import { FloatingLabelInput } from "@/components/ui/inputs/floating-label-input/FloatingLabelInput";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 import { SectionLabel } from "@/components/ui/display/section-label/SectionLabel";
@@ -64,10 +65,28 @@ function fmtTs(ts: string): string {
 // 24px pinned-at-top threshold with room for the load-older row itself.
 const LOAD_OLDER_NEAR_PX = 48;
 
-// Stable row key: the source's sequence number when present; otherwise the
-// ts/msg/filtered-index composite (ts+msg alone collides on repeated lines).
-function rowKey(l: LogEntry, i: number): string {
-  return l.seq != null ? `${l.seq}` : `${l.ts}-${l.msg}-${i}`;
+// Stable row keys for one filtered window: the source's sequence number when
+// present; otherwise ts+msg plus a duplicate-occurrence suffix (ts+msg alone
+// collides on repeated lines, and an index suffix would re-key every row each
+// time a new line prepends). Occurrences count from the OLD end so existing
+// rows keep their keys as newer lines arrive; seq-less sources don't page
+// older (seq is what the cursor API provides), so bottom-appends can't shift
+// them in practice.
+function rowKeysFor(filtered: LogEntry[]): string[] {
+  const seen = new Map<string, number>();
+  const keys = new Array<string>(filtered.length);
+  for (let i = filtered.length - 1; i >= 0; i--) {
+    const l = filtered[i];
+    if (l.seq != null) {
+      keys[i] = `${l.seq}`;
+      continue;
+    }
+    const base = `${l.ts}-${l.msg}`;
+    const n = seen.get(base) ?? 0;
+    seen.set(base, n + 1);
+    keys[i] = n === 0 ? base : `${base}-${n}`;
+  }
+  return keys;
 }
 
 /**
@@ -85,6 +104,7 @@ export function ServiceLogcat({
 }: ServiceLogcatProps) {
   const { query, setQuery, floor, setFloor, tailing, setTailing, filtered, total } =
     useLogcat(logs);
+  const rowKeys = useMemo(() => rowKeysFor(filtered), [filtered]);
   const scrollRef = useRef<HTMLDivElement>(null);
   const pinnedRef = useRef(true); // is the view currently pinned at the top?
   const programmaticRef = useRef(false);
@@ -141,11 +161,11 @@ export function ServiceLogcat({
   // baseline updates after an expand/collapse too (no false offset).
   const prevLenRef = useRef(filtered.length);
   const prevHeightRef = useRef(0);
-  const prevTopKeyRef = useRef(filtered.length > 0 ? rowKey(filtered[0], 0) : null);
+  const prevTopKeyRef = useRef<string | null>(rowKeys[0] ?? null);
   useLayoutEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
-    const topKey = filtered.length > 0 ? rowKey(filtered[0], 0) : null;
+    const topKey = rowKeys[0] ?? null;
     const grewAbove =
       filtered.length > prevLenRef.current && topKey !== prevTopKeyRef.current;
     if (tailing && pinnedRef.current) {
@@ -160,7 +180,7 @@ export function ServiceLogcat({
     prevLenRef.current = filtered.length;
     prevHeightRef.current = el.scrollHeight;
     prevTopKeyRef.current = topKey;
-  }, [tailing, filtered, openKey]);
+  }, [tailing, filtered, rowKeys, openKey]);
 
   const copyAll = () => {
     const text = filtered.map((l) => `${l.ts} ${l.level.toUpperCase()} ${l.msg}`).join("\n");
@@ -243,7 +263,7 @@ export function ServiceLogcat({
           ) : (
             <div className="space-y-0.5">
               {filtered.map((l, i) => {
-                const key = rowKey(l, i);
+                const key = rowKeys[i];
                 const hasDetail =
                   l.method != null || l.req_body != null || l.res_body != null;
                 const open = openKey === key;
@@ -287,21 +307,16 @@ export function ServiceLogcat({
             </div>
           )}
           {onLoadOlder && hasOlder && (
-            <button
-              type="button"
-              disabled={loadingOlder}
+            <Button
+              variant="text"
+              size="xs"
+              fullWidth
+              loading={loadingOlder}
               onClick={onLoadOlder}
-              className={cn(
-                "mt-1 flex w-full items-center justify-center gap-2 rounded py-1.5",
-                "text-on-surface-variant/60 hover:bg-surface-container hover:text-on-surface",
-                loadingOlder && "pointer-events-none",
-              )}
+              className="mt-1"
             >
-              {loadingOlder && (
-                <span className="inline-block w-3 h-3 rounded-full border-2 border-on-surface-variant/30 border-t-on-surface-variant animate-spin" />
-              )}
-              {loadingOlder ? "Loading older entries…" : "Load older entries"}
-            </button>
+              Load older entries
+            </Button>
           )}
         </div>
       </Surface>

--- a/src/components/ui/dev/service-logcat/ServiceLogcat.tsx
+++ b/src/components/ui/dev/service-logcat/ServiceLogcat.tsx
@@ -23,6 +23,53 @@ export const meta: ComponentMeta = {
     "Service log console with severity-floor filter, text filter, live-tail toggle, copy, load-older paging, and an expandable request/response detail per line",
 };
 
+/** Every user-facing string ServiceLogcat renders, for callers that need it
+ *  in a locale other than English — all optional, defaulting to the current
+ *  English copy, so passing nothing is fully backward compatible. */
+export interface ServiceLogcatLabels {
+  /** Default: "Logcat" */
+  title?: string;
+  /** Live-tail toggle when on. Default: "Live" */
+  live?: string;
+  /** Live-tail toggle when off. Default: "Paused" */
+  paused?: string;
+  /** Severity-floor option: no filter. Default: "All" */
+  floorAll?: string;
+  /** Severity-floor option: warn and above. Default: "Warn+" */
+  floorWarn?: string;
+  /** Severity-floor option: errors only. Default: "Errors" */
+  floorError?: string;
+  /** aria-label on the severity-floor segmented control. Default: "Filter by level" */
+  filterAriaLabel?: string;
+  /** Text-filter input label. Default: "Filter logs" */
+  filterPlaceholder?: string;
+  /** aria-label on the clear-filter button. Default: "Clear filter" */
+  clearFilterAriaLabel?: string;
+  /** aria-label on the copy-logs button. Default: "Copy logs" */
+  copyAriaLabel?: string;
+  /** Shown when the filter matches nothing. Default: "No matching log entries." */
+  noMatchingEntries?: string;
+  /** Expanded-row request section heading. Default: "Request" */
+  request?: string;
+  /** Expanded-row response section heading. Default: "Response" */
+  response?: string;
+  /** Expanded-row body when neither request nor response is present.
+   *  Default: "No request or response body." */
+  noRequestResponseBody?: string;
+  /** Load-older-entries row label. Default: "Load older entries" */
+  loadOlderEntries?: string;
+  /** Footer entry-count line, e.g. "42 entries" or "5 of 42" plus the active
+   *  query. Called with (filteredCount, total, query). */
+  entriesLabel?: (filteredCount: number, total: number, query: string) => string;
+  /** Footer status when tailing. Default: "tailing" */
+  tailingStatus?: string;
+  /** Footer status when paused. Default: "paused" */
+  pausedStatus?: string;
+}
+
+const defaultEntriesLabel = (filteredCount: number, total: number, query: string) =>
+  `${filteredCount === total ? `${total} entries` : `${filteredCount} of ${total}`}${query ? ` · "${query}"` : ""}`;
+
 export interface ServiceLogcatProps {
   /** Log entries, chronological (oldest first); the console reverses them so the newest line sits at the top. */
   logs: LogEntry[];
@@ -32,6 +79,12 @@ export interface ServiceLogcatProps {
   hasOlder?: boolean;
   /** Older page currently loading — shows the row in a loading state and suppresses re-fire. */
   loadingOlder?: boolean;
+  /** Seeds the text filter box on mount (e.g. a module slug, to land pre-filtered
+   *  from a deep link) — after that, the input is normal uncontrolled state. */
+  initialQuery?: string;
+  /** Override any/all of the component's own strings for i18n. Unset fields
+   *  fall back to the English default. */
+  labels?: ServiceLogcatLabels;
 }
 
 const LEVEL_BADGE: Record<LogLevel, BadgeVariant> = {
@@ -47,12 +100,6 @@ const LEVEL_TEXT: Record<LogLevel, string> = {
   warn: "text-warning",
   error: "text-error",
 };
-
-const FLOOR_OPTIONS: readonly { value: LevelFloor; label: string }[] = [
-  { value: "all", label: "All" },
-  { value: "warn", label: "Warn+" },
-  { value: "error", label: "Errors" },
-];
 
 // Compact single-line timestamp: "2026-06-30T16:23:45.225373081Z" ->
 // "2026-06-30 16:23:45.225" (drop the T, nanoseconds, and trailing Z).
@@ -101,9 +148,16 @@ export function ServiceLogcat({
   onLoadOlder,
   hasOlder = false,
   loadingOlder = false,
+  initialQuery,
+  labels,
 }: ServiceLogcatProps) {
+  const floorOptions: readonly { value: LevelFloor; label: string }[] = [
+    { value: "all", label: labels?.floorAll ?? "All" },
+    { value: "warn", label: labels?.floorWarn ?? "Warn+" },
+    { value: "error", label: labels?.floorError ?? "Errors" },
+  ];
   const { query, setQuery, floor, setFloor, tailing, setTailing, filtered, total } =
-    useLogcat(logs);
+    useLogcat(logs, initialQuery);
   const rowKeys = useMemo(() => rowKeysFor(filtered), [filtered]);
   const scrollRef = useRef<HTMLDivElement>(null);
   const pinnedRef = useRef(true); // is the view currently pinned at the top?
@@ -190,7 +244,7 @@ export function ServiceLogcat({
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div className="flex items-center gap-2 mb-2">
-        <SectionLabel>Logcat</SectionLabel>
+        <SectionLabel>{labels?.title ?? "Logcat"}</SectionLabel>
         <button
           type="button"
           onClick={() => {
@@ -212,14 +266,14 @@ export function ServiceLogcat({
               tailing ? "bg-success animate-pulse" : "bg-on-surface-variant/40",
             )}
           />
-          {tailing ? "Live" : "Paused"}
+          {tailing ? (labels?.live ?? "Live") : (labels?.paused ?? "Paused")}
         </button>
       </div>
 
       <div className="flex items-center gap-2 mb-3">
         <SegmentedButton
-          aria-label="Filter by level"
-          options={FLOOR_OPTIONS}
+          aria-label={labels?.filterAriaLabel ?? "Filter by level"}
+          options={floorOptions}
           value={floor}
           onChange={setFloor}
           size="sm"
@@ -227,7 +281,7 @@ export function ServiceLogcat({
         <div className="flex-1">
           <FloatingLabelInput
             id="logcat-filter"
-            label="Filter logs"
+            label={labels?.filterPlaceholder ?? "Filter logs"}
             size="sm"
             hideLabel
             value={query}
@@ -236,7 +290,7 @@ export function ServiceLogcat({
         </div>
         <IconButton
           icon="close"
-          aria-label="Clear filter"
+          aria-label={labels?.clearFilterAriaLabel ?? "Clear filter"}
           variant="filled"
           size="md"
           disabled={!query}
@@ -244,7 +298,7 @@ export function ServiceLogcat({
         />
         <IconButton
           icon="content_copy"
-          aria-label="Copy logs"
+          aria-label={labels?.copyAriaLabel ?? "Copy logs"}
           variant="tonal"
           size="md"
           disabled={filtered.length === 0}
@@ -259,7 +313,7 @@ export function ServiceLogcat({
           className="h-full overflow-y-auto p-3 font-mono text-xs"
         >
           {filtered.length === 0 ? (
-            <p className="text-on-surface-variant/50 py-6 text-center">No matching log entries.</p>
+            <p className="text-on-surface-variant/50 py-6 text-center">{labels?.noMatchingEntries ?? "No matching log entries."}</p>
           ) : (
             <div className="space-y-0.5">
               {filtered.map((l, i) => {
@@ -294,10 +348,12 @@ export function ServiceLogcat({
                     </div>
                     {open && (
                       <div className="mb-1 mt-0.5 ml-4 space-y-1.5 border-l border-outline-variant/40 pl-3">
-                        {l.req_body ? <LogDetail label="Request" body={l.req_body} /> : null}
-                        {l.res_body ? <LogDetail label="Response" body={l.res_body} /> : null}
+                        {l.req_body ? <LogDetail label={labels?.request ?? "Request"} body={l.req_body} /> : null}
+                        {l.res_body ? <LogDetail label={labels?.response ?? "Response"} body={l.res_body} /> : null}
                         {!l.req_body && !l.res_body ? (
-                          <p className="text-on-surface-variant/40">No request or response body.</p>
+                          <p className="text-on-surface-variant/40">
+                            {labels?.noRequestResponseBody ?? "No request or response body."}
+                          </p>
                         ) : null}
                       </div>
                     )}
@@ -315,7 +371,7 @@ export function ServiceLogcat({
               onClick={onLoadOlder}
               className="mt-1"
             >
-              Load older entries
+              {labels?.loadOlderEntries ?? "Load older entries"}
             </Button>
           )}
         </div>
@@ -323,10 +379,9 @@ export function ServiceLogcat({
 
       <div className="flex items-center justify-between mt-2 px-1 text-xs text-on-surface-variant/50">
         <span>
-          {filtered.length === total ? `${total} entries` : `${filtered.length} of ${total}`}
-          {query && ` · “${query}”`}
+          {(labels?.entriesLabel ?? defaultEntriesLabel)(filtered.length, total, query)}
         </span>
-        <span className={cn(tailing && "text-success/70")}>{tailing ? "tailing" : "paused"}</span>
+        <span className={cn(tailing && "text-success/70")}>{tailing ? (labels?.tailingStatus ?? "tailing") : (labels?.pausedStatus ?? "paused")}</span>
       </div>
     </div>
   );

--- a/src/components/ui/dev/service-logcat/ServiceLogcat.tsx
+++ b/src/components/ui/dev/service-logcat/ServiceLogcat.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Badge, type BadgeVariant } from "@/components/ui/feedback/badge/Badge";
 import { FloatingLabelInput } from "@/components/ui/inputs/floating-label-input/FloatingLabelInput";
 import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
@@ -19,12 +19,18 @@ import {
 export const meta: ComponentMeta = {
   name: "ServiceLogcat",
   description:
-    "Service log console with severity-floor filter, text filter, live-tail toggle, copy, and an expandable request/response detail per line",
+    "Service log console with severity-floor filter, text filter, live-tail toggle, copy, load-older paging, and an expandable request/response detail per line",
 };
 
 export interface ServiceLogcatProps {
   /** Log entries, chronological (oldest first); the console reverses them so the newest line sits at the top. */
   logs: LogEntry[];
+  /** Load the next page of older entries. With `hasOlder`, renders a load-older row at the old end (bottom) that also auto-fires when the user scrolls near it. */
+  onLoadOlder?: () => void;
+  /** Whether older entries exist beyond the current `logs` window. */
+  hasOlder?: boolean;
+  /** Older page currently loading — shows the row in a loading state and suppresses re-fire. */
+  loadingOlder?: boolean;
 }
 
 const LEVEL_BADGE: Record<LogLevel, BadgeVariant> = {
@@ -54,6 +60,16 @@ function fmtTs(ts: string): string {
   return m ? `${m[1]} ${m[2]}.${m[3]}` : ts;
 }
 
+// Auto-fire distance from the bottom (old end) for load-older, mirroring the
+// 24px pinned-at-top threshold with room for the load-older row itself.
+const LOAD_OLDER_NEAR_PX = 48;
+
+// Stable row key: the source's sequence number when present; otherwise the
+// ts/msg/filtered-index composite (ts+msg alone collides on repeated lines).
+function rowKey(l: LogEntry, i: number): string {
+  return l.seq != null ? `${l.seq}` : `${l.ts}-${l.msg}-${i}`;
+}
+
 /**
  * ServiceLogcat — the module service log console. A severity-floor filter, a
  * text filter, a live-tail toggle, copy, and a mono scroll surface that pins to
@@ -61,7 +77,12 @@ function fmtTs(ts: string): string {
  * `logs` array (mock today; a live stream tomorrow) and the co-located
  * `useLogcat` hook owns all internal state.
  */
-export function ServiceLogcat({ logs }: ServiceLogcatProps) {
+export function ServiceLogcat({
+  logs,
+  onLoadOlder,
+  hasOlder = false,
+  loadingOlder = false,
+}: ServiceLogcatProps) {
   const { query, setQuery, floor, setFloor, tailing, setTailing, filtered, total } =
     useLogcat(logs);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -80,9 +101,17 @@ export function ServiceLogcat({ logs }: ServiceLogcatProps) {
     pinnedRef.current = true;
   };
 
+  // One-shot latch so a burst of scroll events fires onLoadOlder once; rearmed
+  // when the caller reacts (loadingOlder toggles or new entries arrive).
+  const loadOlderFiredRef = useRef(false);
+  useEffect(() => {
+    loadOlderFiredRef.current = false;
+  }, [loadingOlder, logs]);
+
   // Track whether the view is at the top. A programmatic scroll-to-top is
   // ignored (guarded by programmaticRef). No auto-pause: tailing stays on; we
   // just stop following while the user is scrolled away from the top.
+  // Scrolling near the bottom (the OLD end) auto-fires load-older.
   const onScroll = () => {
     const el = scrollRef.current;
     if (!el) return;
@@ -91,22 +120,37 @@ export function ServiceLogcat({ logs }: ServiceLogcatProps) {
       return;
     }
     pinnedRef.current = el.scrollTop < 24;
+    if (
+      onLoadOlder &&
+      hasOlder &&
+      !loadingOlder &&
+      !loadOlderFiredRef.current &&
+      el.scrollHeight - el.scrollTop - el.clientHeight < LOAD_OLDER_NEAR_PX
+    ) {
+      loadOlderFiredRef.current = true;
+      onLoadOlder();
+    }
   };
 
   // Newest sits at the TOP. When tailing + pinned, follow to the top. Otherwise,
   // if new lines were prepended above while the user is reading lower down, they
   // would shove the view down — so offset scrollTop by the added height to keep
-  // the user anchored to the line they're reading. openKey is a dep so the
-  // height baseline updates after an expand/collapse too (no false offset).
+  // the user anchored to the line they're reading. Older pages append at the
+  // BOTTOM (the top row's key is unchanged) — content below the viewport never
+  // moves scrollTop, so no offset there. openKey is a dep so the height
+  // baseline updates after an expand/collapse too (no false offset).
   const prevLenRef = useRef(filtered.length);
   const prevHeightRef = useRef(0);
+  const prevTopKeyRef = useRef(filtered.length > 0 ? rowKey(filtered[0], 0) : null);
   useLayoutEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
-    const grew = filtered.length > prevLenRef.current;
+    const topKey = filtered.length > 0 ? rowKey(filtered[0], 0) : null;
+    const grewAbove =
+      filtered.length > prevLenRef.current && topKey !== prevTopKeyRef.current;
     if (tailing && pinnedRef.current) {
       scrollToTop();
-    } else if (grew) {
+    } else if (grewAbove) {
       const added = el.scrollHeight - prevHeightRef.current;
       if (added > 0) {
         programmaticRef.current = true;
@@ -115,7 +159,8 @@ export function ServiceLogcat({ logs }: ServiceLogcatProps) {
     }
     prevLenRef.current = filtered.length;
     prevHeightRef.current = el.scrollHeight;
-  }, [tailing, filtered.length, openKey]);
+    prevTopKeyRef.current = topKey;
+  }, [tailing, filtered, openKey]);
 
   const copyAll = () => {
     const text = filtered.map((l) => `${l.ts} ${l.level.toUpperCase()} ${l.msg}`).join("\n");
@@ -197,8 +242,8 @@ export function ServiceLogcat({ logs }: ServiceLogcatProps) {
             <p className="text-on-surface-variant/50 py-6 text-center">No matching log entries.</p>
           ) : (
             <div className="space-y-0.5">
-              {filtered.map((l) => {
-                const key = `${l.ts}-${l.msg}`;
+              {filtered.map((l, i) => {
+                const key = rowKey(l, i);
                 const hasDetail =
                   l.method != null || l.req_body != null || l.res_body != null;
                 const open = openKey === key;
@@ -240,6 +285,23 @@ export function ServiceLogcat({ logs }: ServiceLogcatProps) {
                 );
               })}
             </div>
+          )}
+          {onLoadOlder && hasOlder && (
+            <button
+              type="button"
+              disabled={loadingOlder}
+              onClick={onLoadOlder}
+              className={cn(
+                "mt-1 flex w-full items-center justify-center gap-2 rounded py-1.5",
+                "text-on-surface-variant/60 hover:bg-surface-container hover:text-on-surface",
+                loadingOlder && "pointer-events-none",
+              )}
+            >
+              {loadingOlder && (
+                <span className="inline-block w-3 h-3 rounded-full border-2 border-on-surface-variant/30 border-t-on-surface-variant animate-spin" />
+              )}
+              {loadingOlder ? "Loading older entries…" : "Load older entries"}
+            </button>
           )}
         </div>
       </Surface>

--- a/src/components/ui/dev/service-logcat/types.ts
+++ b/src/components/ui/dev/service-logcat/types.ts
@@ -13,6 +13,8 @@ export interface LogEntry {
   ts: string;
   level: LogLevel;
   msg: string;
+  /** Monotonic sequence number from the log source; used as a stable row key when present. */
+  seq?: number;
   // Optional request/response detail — present on access-log lines captured by
   // the dev-proxy, absent on plain log lines. Keys match the dispatch ring
   // Entry JSON (snake_case).

--- a/src/components/ui/dev/service-logcat/useLogcat.ts
+++ b/src/components/ui/dev/service-logcat/useLogcat.ts
@@ -32,8 +32,8 @@ export interface UseLogcatResult {
  * first); the hook reverses them to newest-first so the console shows the
  * latest line at the top.
  */
-export function useLogcat(logs: LogEntry[]): UseLogcatResult {
-  const [query, setQuery] = useState("");
+export function useLogcat(logs: LogEntry[], initialQuery = ""): UseLogcatResult {
+  const [query, setQuery] = useState(initialQuery);
   const [floor, setFloor] = useState<LevelFloor>("all");
   const [tailing, setTailing] = useState(true);
 

--- a/src/components/ui/inputs/segmented-button/SegmentedButton.stories.tsx
+++ b/src/components/ui/inputs/segmented-button/SegmentedButton.stories.tsx
@@ -82,6 +82,18 @@ export const Disabled: Story = {
   },
 };
 
+/** A small red count badge anchored to an option's corner (e.g. an open-items count) */
+export const WithBadge: Story = {
+  args: {
+    options: [
+      { value: "list", label: "List" },
+      { value: "issues", label: "Issues", badge: 4 },
+    ],
+    value: "list",
+    "aria-label": "Select view",
+  },
+};
+
 /** Boxed/connected track with an inset selected pill */
 export const Boxed: Story = {
   render: (args) => {

--- a/src/components/ui/inputs/segmented-button/SegmentedButton.tsx
+++ b/src/components/ui/inputs/segmented-button/SegmentedButton.tsx
@@ -21,6 +21,9 @@ export interface SegmentedButtonOption<T extends string = string> {
   readonly icon?: string;
   /** Visual tone for the unselected state. Defaults to "default". */
   readonly tone?: SegmentedButtonOptionTone;
+  /** Small red count badge anchored to the option's top-right corner (e.g. an
+   *  open-items count). Omit for no badge. */
+  readonly badge?: string | number;
 }
 
 export type SegmentedButtonSize = "sm" | "md";
@@ -139,7 +142,7 @@ export function SegmentedButton<T extends string = string>({
           disabled={disabled}
           aria-pressed={value === opt.value}
           className={cn(
-            "font-medium transition-colors inline-flex items-center justify-center gap-1.5",
+            "relative font-medium transition-colors inline-flex items-center justify-center gap-1.5",
             isBoxed ? boxedSizeStyles[size] : sizeStyles[size],
             isBoxed
               ? boxedButtonStyle(value === opt.value, inverse)
@@ -151,6 +154,14 @@ export function SegmentedButton<T extends string = string>({
         >
           {opt.icon && <Icon name={opt.icon} size={size === "sm" ? 16 : 18} />}
           {opt.label}
+          {opt.badge != null && (
+            <span
+              aria-hidden="true"
+              className="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-error px-1 text-[10px] font-semibold leading-none text-on-error"
+            >
+              {opt.badge}
+            </span>
+          )}
         </button>
       ))}
     </div>


### PR DESCRIPTION
## What

ServiceLogcat grows an optional paging surface for the dispatch log-cursor API:

- `onLoadOlder?: () => void`, `hasOlder?`, `loadingOlder?` — renders a load-older row at the OLD end (bottom; newest sits at top) with an explicit button + auto-fire when scrolled near it (one-shot latch, re-armed when the caller reacts)
- `LogEntry.seq?: number` — row keys prefer `seq`; the fallback key gains the filtered index (`ts+msg` alone collided on repeated lines)
- Scroll-anchor fix: the pre-existing prepend compensation offset `scrollTop` on ANY list growth, which would have yanked the view on bottom-appends — it now keys off the top row's identity (`grewAbove`)
- Fully backwards compatible: without the new props there is no affordance and no auto-fire

Version 0.6.0 → **0.6.1** in this PR (pre-1.0 patch convention), `release` label set.

## Verification

- `pnpm typecheck` / `pnpm build` clean (verified independently)
- ServiceLogcat tests 6/6: button fires, gating off, loading suppresses re-fire, auto-fire once near bottom, bottom-append keeps scrollTop while prepend still offsets, seq-keyed duplicate rows
- Full suite 793 green in implementation run; `LoadOlder` story added (3 pages × 20 entries, simulated fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWoUBtpYmAJ6MW81W3ayTL