### PR TITLE
feat(Avatar): add `plain` variant (no background/border)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/media/avatar/Avatar.tsx
+++ b/src/components/ui/media/avatar/Avatar.tsx
@@ -70,6 +70,14 @@ export interface AvatarProps {
    * an AvatarStack) need this to fully occlude what's beneath them.
    */
   opaque?: boolean;
+  /**
+   * Drop the decorative frame — the primary tint background and the primary
+   * border — leaving only the normalized fixed-size box. For using the avatar
+   * as a bare, consistently-sized slot for a brand logo (`src`) or a centered
+   * icon (`overlay`), e.g. a leading glyph beside a page heading. Images fit
+   * with object-contain (not cropped) in this mode.
+   */
+  plain?: boolean;
   overlay?: ReactNode;
   className?: string;
 }
@@ -83,6 +91,7 @@ export function Avatar({
   accept = "image/jpeg,image/png,image/gif,image/webp",
   square = false,
   opaque = false,
+  plain = false,
   overlay,
   className,
 }: AvatarProps) {
@@ -119,14 +128,19 @@ export function Avatar({
       src={src}
       alt=""
       onError={() => setImgFailed(true)}
-      className={cn(s.container, radius, "object-cover border-2 border-primary")}
+      className={cn(
+        s.container,
+        radius,
+        plain ? "object-contain" : "object-cover border-2 border-primary",
+      )}
     />
   ) : (
     <div
       className={cn(
         s.container,
         radius,
-        "bg-primary/20 flex items-center justify-center border-2 border-primary",
+        "flex items-center justify-center",
+        !plain && "bg-primary/20 border-2 border-primary",
       )}
     >
       {showInitial && initials && (


### PR DESCRIPTION
## What

Adds an optional `plain` prop to `Avatar` that drops the decorative frame — the primary tint background (`bg-primary/20`) and the primary border (`border-2 border-primary`) — leaving only the normalized fixed-size box.

## Why

We want a leading brand glyph beside a page heading (a provider logo, a section icon) that is **consistently sized across every page**. `Avatar`'s fixed `size` tokens (`sm`/`md`/`lg`/`xl`) already give that normalization, but its hardcoded frame made it read as a user avatar. `className` only reaches the outer wrapper, so there was no way to clear the inner frame from the outside. `plain` makes `Avatar` reusable as a bare, normalized media slot:

```tsx
// brand logo (image) — fit with object-contain, no crop, no frame
<Avatar plain size="md" src={googleLogoDataUri} />

// centered icon via overlay — no frame behind it
<Avatar plain size="md" overlay={<Icon name="group" size={24} className="text-on-surface-variant" />} />
```

## Behaviour

- `plain` defaults to `false` — **non-breaking**, existing avatars are unchanged.
- Image path: drops the border; switches `object-cover` → `object-contain` so a non-square logo isn't cropped.
- Fallback/overlay path: drops the tint background and border.

## Consumers

First use is the oauth-core / oauth-google module pages (frameless users-icon and Google-logo beside their headings). Those modules currently pin older web-ui-kit (`0.3.x`/`0.4.x`); they'll pick this up when they bump to `^0.6.5`.

## Version

Patch bump `0.6.4` → `0.6.5` (pre-1.0 patch-only), paired with the `release` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)