### PR TITLE
fix: FireScene phantom scroll inside AppShell (0.6.7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/feedback/error-scene/FireScene.tsx
+++ b/src/components/ui/feedback/error-scene/FireScene.tsx
@@ -137,7 +137,12 @@ export function FireScene({
   };
 
   return (
-    <main className={cn("flex min-h-screen items-center justify-center p-6", className)}>
+    // No viewport-height claim: the scene renders inside AppShell's inner
+    // scroll container (main is viewport MINUS shell chrome + gutters), where
+    // `min-h-screen` guaranteed ~9rem of phantom scroll on a page that fits.
+    // Natural height composes anywhere; a standalone full-page consumer can
+    // pass `className="min-h-screen"` (cn/tailwind-merge lets it win).
+    <main className={cn("flex items-center justify-center p-6", className)}>
       <style>{SCENE_CSS}</style>
       <div className="w-full max-w-4xl">
         <div className="flex flex-col gap-4">


### PR DESCRIPTION
## Problem (reported on apps.mirrorstack.ai)

The 404/error pages scroll vertically with no visible overflow. `FireScene` claims `min-h-screen` (100dvh), but it renders inside `AppShell`'s inner scroll container — `main` is viewport height MINUS shell chrome (`py-4`) and content gutters (`pt-12 pb-16`) — so the scene is guaranteed ~9rem taller than the visible area on every page that otherwise fits.

## Change

- `FireScene` drops the viewport-height claim and takes its natural height — composes without phantom scroll inside any shell/container. Vertical position now follows the shell's normal content flow (same `pt-12` start as every page).
- A standalone full-page consumer can pass `className="min-h-screen"`; `cn`/tailwind-merge lets the override win over the base classes.
- Version 0.6.7 (pre-1.0 patch), `release` label on this PR per release mechanics.

824/824 tests pass, typecheck clean. Consumers (web-applications / web-account) pick 0.6.7 up on their next lockfile refresh — I'll pair the bumps with the deploy.