### PR TITLE
fix: ThemeProvider corrects mount state before paint, not after

### DIFF
--- a/src/context/theme/ThemeProvider.test.tsx
+++ b/src/context/theme/ThemeProvider.test.tsx
@@ -76,4 +76,28 @@ describe("ThemeProvider", () => {
       "useTheme must be used within a ThemeProvider",
     );
   });
+
+  it("resolves to dark on mount when OS prefers dark and no preference is stored (incognito repro)", () => {
+    (window.matchMedia as ReturnType<typeof vi.fn>).mockImplementation(
+      (query: string) => ({
+        matches: query === "(prefers-color-scheme: dark)",
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }),
+    );
+
+    render(
+      <ThemeProvider>
+        <TestConsumer />
+      </ThemeProvider>,
+    );
+
+    expect(screen.getByTestId("resolved").textContent).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
 });

--- a/src/context/theme/ThemeProvider.tsx
+++ b/src/context/theme/ThemeProvider.tsx
@@ -3,10 +3,19 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useState,
   type ReactNode,
 } from "react";
+
+// useEffect fires after the browser paints; useLayoutEffect fires synchronously
+// before it. The mount correction below must run before paint so it never
+// visibly overrides what the pre-paint <head> script already applied to
+// document.documentElement (SSR has no window, so fall back to useEffect there
+// to avoid React's "useLayoutEffect does nothing on the server" warning).
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
 export type Theme = "auto" | "light" | "dark";
 
@@ -65,7 +74,7 @@ export function ThemeProvider({ children }: ThemeProviderProps) {
     applyClass(resolved);
   }, []);
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const stored = normalize(getCookie() ?? localStorage.getItem(STORAGE_KEY));
     setThemeState(stored);
     localStorage.setItem(STORAGE_KEY, stored);


### PR DESCRIPTION
Closes #336

## Problem
One wrong-theme frame paints before the correct theme applies, specifically when no theme is stored (incognito + OS dark mode) — mirrorstack-ai/mirrorstack-core-v2#15.

The pre-paint `<head>` script in consuming apps (e.g. web-account's `layout.tsx`) already applies `.dark` to `document.documentElement` before React mounts. But `ThemeProvider`'s initial `resolvedTheme` state defaults to `"light"`, and was only corrected in a mount `useEffect` — which fires *after* the browser paints. Any component reading `resolvedTheme` from context renders with the stale default for one frame until the effect catches up.

## Fix
Swap the mount-correction effect to an isomorphic `useLayoutEffect` (falls back to `useEffect` when `window` is undefined, to avoid React's SSR warning) so the correction runs synchronously before paint instead of asynchronously after it. `applyClass`'s DOM-class toggle was already correct throughout (the pre-paint script sets it before React mounts) — this only fixes the React *state* value lagging behind by one paint.

Scope note: this repo's own tests (`vitest`/jsdom) flush both `useEffect` and `useLayoutEffect` synchronously within `act()`, so they can't directly observe the paint-timing difference this fix relies on. Added a regression test for the exact reported scenario (no stored preference + OS dark mode → resolves to dark) instead, and verified the fix against the diagnosed root cause by code inspection. Manual/visual verification (incognito + OS dark mode + reload on account.mirrorstack.ai) is still recommended before closing the parent issue.

## Local verification (GitHub Actions minutes are currently exhausted for this org — see mirrorstack-core-v2, unrelated billing issue)
- `pnpm typecheck` — clean
- `pnpm test` — 76 files / 825 tests pass, including the new regression test
- `pnpm lint` — `src/context/theme/` clean; the only lint errors in the full run are pre-existing in unrelated files (`SidebarProvider.tsx`, `useAgentSession.ts`), confirmed present on `origin/main` before this change too

🤖 Generated by an autonomous background fix run (mirrorstack-ai/mirrorstack-core-v2#15).