### PR TITLE
fix: shift notch dropdown right offset -7 → -8px

### DIFF
--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
@@ -277,7 +277,7 @@ export function DropdownMenu({
             // so the menu grows upward instead of down.
             [openUp ? "bottom" : "top"]: useNotch ? -7 : "calc(100% + 8px)",
             [fromEnd ? "right" : "left"]: useNotch
-              ? (fromEnd ? -5 : -7) - Math.abs(offset)
+              ? (fromEnd ? -6 : -7) - Math.abs(offset)
               : -Math.abs(offset),
             filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))",
           }}


### PR DESCRIPTION
Nudges the notch-framed `DropdownMenu`'s right anchor one px tighter (`right: -7px` → `-8px`)
so the framed menu sits flush against the trigger's right edge.

Single-line change in `DropdownMenu.tsx`: the from-end (right) base literal in the inline
offset ternary. `top`/`left` bases are untouched (they're independent literals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)