### PR TITLE
chore: release 0.6.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- Bump version 0.6.8 -> 0.6.9 to publish #339 (notch dropdown right offset -7 -> -8px), which merged to main without a version bump.

## Test plan
- [ ] Merge with the `release` label so release.yml publishes 0.6.9 to GitHub Packages.