### PR TITLE
fix: notch dropdown right offset -8 + smaller notch radius (12px)

### DIFF
--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
@@ -16,7 +16,7 @@ import { useMenuKeyNav } from "@/hooks/useMenuKeyNav";
 
 const DD_NOTCH_W = 52;
 const DD_NOTCH_H = 46;
-const DD_R = 16;
+const DD_R = 12;
 const DD_IR = 10;
 const DD_SW = 1.5;
 
@@ -70,7 +70,7 @@ export interface DropdownMenuProps {
   notchWidth?: number;
   /** Height of the notch tab (SVG units). Default `46`. */
   notchHeight?: number;
-  /** Corner radius of the notch outline (SVG units). Default `16`. Lower it to
+  /** Corner radius of the notch outline (SVG units). Default `12`. Lower it to
    *  match a small trigger's own radius for a less-rounded head (e.g. an icon
    *  button with an 8px radius). */
   notchRadius?: number;
@@ -277,7 +277,7 @@ export function DropdownMenu({
             // so the menu grows upward instead of down.
             [openUp ? "bottom" : "top"]: useNotch ? -7 : "calc(100% + 8px)",
             [fromEnd ? "right" : "left"]: useNotch
-              ? (fromEnd ? -6 : -7) - Math.abs(offset)
+              ? (fromEnd ? -8 : -7) - Math.abs(offset)
               : -Math.abs(offset),
             filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))",
           }}


### PR DESCRIPTION
## What

Two visual corrections to the notched dropdown (`DropdownMenu`):

1. **Right-anchored notch offset `-6 → -8`.** #339's commit message said "-7 → -8" but the diff only shifted the `fromEnd` branch `-5 → -6`. This lands it at the requested `-8`.
2. **Notch outline corner radius `DD_R 16 → 12`** (−4px) for a tighter, less-rounded head. JSDoc default updated to match.

## Why this is separate from #340

#340 (`chore: release 0.6.9`) is the pure release PR (version bump + `release` label). This is the one-concept code fix. **Merge order: this PR first, then #340** — on merge #340 reads `0.6.9` and publishes `main` (now including these corrections) to GitHub Packages. web-applications then bumps its dep to consume it.

## Verify
- `pnpm typecheck` — clean.
- Right-anchored notched dropdown at `offset:0` computes `right: -8px`; notch corners visibly tighter (12 vs 16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)