### PR TITLE
fix: revert notch base offset -8 → -6 (release 0.6.10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
+++ b/src/components/ui/navigation/dropdown-menu/DropdownMenu.tsx
@@ -277,7 +277,7 @@ export function DropdownMenu({
             // so the menu grows upward instead of down.
             [openUp ? "bottom" : "top"]: useNotch ? -7 : "calc(100% + 8px)",
             [fromEnd ? "right" : "left"]: useNotch
-              ? (fromEnd ? -8 : -7) - Math.abs(offset)
+              ? (fromEnd ? -6 : -7) - Math.abs(offset)
               : -Math.abs(offset),
             filter: "drop-shadow(0 4px 12px rgb(0 0 0 / 0.12))",
           }}


### PR DESCRIPTION
## What
Reverts the notch right-offset **base** literal `-8 → -6` and bumps to **0.6.10** (carries `release` → publishes on merge).

## Why (regression from #341)
`right = (fromEnd ? base : -7) - Math.abs(offset)`. #339 correctly set base `-6`; with the invite ⋮ menu's `offset={-2}` that renders `right:-8` — exactly as asked. #341 misread #339's commit message "-7 → -8" (the *rendered* value) as the base literal and pushed base `-6 → -8`, so the same menu now renders `-10`, and **every** right-anchored notched dropdown shifted 2px outward.

Restoring base `-6` fixes the invite menu (back to `-8`) and un-regresses all other notched dropdowns in one place — root cause, not a per-caller offset patch.

| offset | base -8 (0.6.9, wrong) | base -6 (this PR) |
|---|---|---|
| `0` (`-0`, right-anchored) | -8 | **-6** |
| `-2` (invite ⋮ menu) | -10 | **-8** ✅ |

Notch corner radius (`12px`, shipped 0.6.9) is untouched.

## Verify
- `pnpm typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)