### PR TITLE
security: harden Storybook preview deployment

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -7,9 +7,7 @@ on:
   pull_request:
     types: [closed]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   deploy-main:
@@ -19,6 +17,9 @@ jobs:
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -33,14 +34,15 @@ jobs:
           path: /tmp/storybook-static
 
       - name: Deploy to GitHub Pages
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           find . -maxdepth 1 ! -name '.' ! -name '.git' ! -name 'pr' -exec rm -rf {} +
           cp -r /tmp/storybook-static/* .
-          rm -f PR_NUMBER
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git diff --cached --quiet || git commit -m "deploy: update Storybook from ${{ github.event.workflow_run.head_sha }}"
+          git diff --cached --quiet || git commit -m "deploy: update Storybook from $HEAD_SHA"
           git push origin gh-pages
 
   deploy-pr-preview:
@@ -49,6 +51,10 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -62,27 +68,67 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: /tmp/storybook-static
 
-      - name: Get PR number
+      - name: Resolve pull request
         id: pr
-        run: echo "number=$(cat /tmp/storybook-static/PR_NUMBER)" >> "$GITHUB_OUTPUT"
+        uses: actions/github-script@v8
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        with:
+          script: |
+            const headSha = process.env.HEAD_SHA;
+            if (!/^[0-9a-f]{40}$/.test(headSha)) {
+              core.setFailed('Workflow run did not provide a valid commit SHA.');
+              return;
+            }
+
+            const { data: pullRequests } =
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: headSha,
+              });
+            const matches = pullRequests.filter((pullRequest) =>
+              pullRequest.base.repo.full_name ===
+                `${context.repo.owner}/${context.repo.repo}` &&
+              pullRequest.base.ref === 'main' &&
+              pullRequest.head.sha === headSha
+            );
+
+            if (matches.length !== 1) {
+              core.setFailed(
+                `Expected one pull request for ${headSha}, found ${matches.length}.`
+              );
+              return;
+            }
+
+            core.setOutput('number', matches[0].number);
 
       - name: Deploy PR preview
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
-          rm -rf pr/${{ steps.pr.outputs.number }}
-          mkdir -p pr/${{ steps.pr.outputs.number }}
-          cp -r /tmp/storybook-static/* pr/${{ steps.pr.outputs.number }}/
-          rm -f pr/${{ steps.pr.outputs.number }}/PR_NUMBER
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] || exit 1
+          preview_dir="pr/$PR_NUMBER"
+          rm -rf -- "$preview_dir"
+          mkdir -p -- "$preview_dir"
+          cp -r /tmp/storybook-static/* "$preview_dir/"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git diff --cached --quiet || git commit -m "deploy: PR #${{ steps.pr.outputs.number }} preview"
+          git diff --cached --quiet || git commit -m "deploy: PR #$PR_NUMBER preview"
           git push origin gh-pages
 
       - name: Comment PR link
         uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           script: |
-            const prNumber = parseInt('${{ steps.pr.outputs.number }}');
+            const prNumber = Number(process.env.PR_NUMBER);
+            if (!Number.isSafeInteger(prNumber) || prNumber < 1) {
+              core.setFailed('Pull request number is invalid.');
+              return;
+            }
             const url = `https://mirrorstack-ai.github.io/web-ui-kit/pr/${prNumber}/`;
             const body = `**Storybook Preview:** ${url}`;
             const { data: comments } = await github.rest.issues.listComments({
@@ -110,16 +156,21 @@ jobs:
   cleanup-pr:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
           ref: gh-pages
 
       - name: Remove PR preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          rm -rf pr/${{ github.event.pull_request.number }}
+          [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]] || exit 1
+          rm -rf -- "pr/$PR_NUMBER"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git diff --cached --quiet || git commit -m "chore: clean up PR #${{ github.event.pull_request.number }} preview"
+          git diff --cached --quiet || git commit -m "chore: clean up PR #$PR_NUMBER preview"
           git push

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -29,10 +29,6 @@ jobs:
 
       - run: pnpm build-storybook
 
-      - name: Save PR number
-        if: github.event_name == 'pull_request'
-        run: echo "${{ github.event.pull_request.number }}" > storybook-static/PR_NUMBER
-
       - name: Upload Storybook build
         uses: actions/upload-artifact@v6
         with:


### PR DESCRIPTION
## Summary

- resolve preview pull requests from GitHub's commit-to-PR API instead of trusting artifact metadata
- validate workflow-derived identifiers and consume them through environment variables
- scope the workflow token to the permissions required by each job
- stop publishing PR_NUMBER inside Storybook artifacts

## Security impact

This removes the injection path reported by CodeQL alerts 5 through 10 in .github/workflows/storybook-deploy.yml. The privileged deployment workflow no longer interpolates artifact-controlled values into shell commands or JavaScript.

## Validation

- YAML parsing
- git diff --check
- actionlint v1.7.12
- commit-to-PR lookup verified against three recent Storybook workflow runs

This PR is intentionally not auto-merged.
