### PR TITLE
security: restrict build workflow tokens to read-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 concurrency:
   group: storybook-${{ github.event.pull_request.number || 'main' }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

Set explicit read-only GITHUB_TOKEN permissions for the CI and Storybook build workflows.

Neither workflow needs repository write access. This follows least privilege and addresses CodeQL alerts 3 and 4.

## Validation

- YAML parsing
- git diff --check
- actionlint v1.7.12

This PR is not auto-merged.
