### PR TITLE
chore: release 0.6.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- Version bump 0.6.10 → 0.6.11 to publish the ThemeProvider pre-paint theme correction (#337), needed by tracker mirrorstack-ai/mirrorstack-core-v2#15 so both web apps can pick up the fix.
- No API changes; CHANGELOG untouched per its API-additions-only convention.

## Test plan
- CI `check` + `build`; release.yml publishes v0.6.11 on merge (release label attached).

Part of mirrorstack-ai/mirrorstack-core-v2#15

🤖 Generated with [Claude Code](https://claude.com/claude-code)