### PR TITLE
feat: dashed GraphEdge for a second edge kind (0.6.12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/graph/graph/Graph.test.tsx
+++ b/src/components/ui/graph/graph/Graph.test.tsx
@@ -79,4 +79,18 @@ describe("Graph", () => {
       "fill-on-surface-variant",
     );
   });
+
+  it("renders a dashed edge with stroke-dasharray and leaves plain edges solid", () => {
+    const mixedEdges: GraphEdge[] = [
+      { source: "a", target: "b", dashed: true },
+      { source: "b", target: "c" },
+    ];
+    const { container } = render(<Graph nodes={nodes} edges={mixedEdges} />);
+    const dashArrays = Array.from(container.querySelectorAll("line")).map((l) =>
+      l.getAttribute("stroke-dasharray"),
+    );
+    // Exactly one edge is dashed; the other stays solid (no dasharray).
+    expect(dashArrays.filter((d) => d != null)).toHaveLength(1);
+    expect(dashArrays.filter((d) => d == null)).toHaveLength(1);
+  });
 });

--- a/src/components/ui/graph/graph/Graph.tsx
+++ b/src/components/ui/graph/graph/Graph.tsx
@@ -32,6 +32,13 @@ export type GraphEdge = {
   source: string;
   target: string;
   weight?: number;
+  /**
+   * Render this edge as a dashed line instead of solid. Lets consumers
+   * distinguish a second edge kind (e.g. a "provides"/contributes relation
+   * alongside solid "depends on" edges) without any other styling change.
+   * Defaults to solid.
+   */
+  dashed?: boolean;
 };
 
 export interface GraphHandle {
@@ -879,6 +886,9 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
                   x2={b.x}
                   y2={b.y}
                   strokeWidth={((lit ? 1.5 : 1) * lineSize) / view.zoom}
+                  strokeDasharray={
+                    e.dashed ? `${6 / view.zoom} ${4 / view.zoom}` : undefined
+                  }
                   strokeOpacity={lit ? 0.7 : 0.15}
                   opacity={visible ? 1 : 0}
                   style={REVEAL_TRANSITION_STYLE}


### PR DESCRIPTION
## What

Adds an optional `dashed?: boolean` to `GraphEdge`. When set, the edge's `<line>` renders with a zoom-divided `strokeDasharray` (`${6 / view.zoom} ${4 / view.zoom}`) — scaled the same way as `strokeWidth`, so the dash pattern stays visually constant across zoom levels — instead of a solid stroke.

Defaults to solid: tag virtual edges and every existing `Graph` consumer are byte-identical. No other behavior change.

## Why

Today every edge renders as one undifferentiated `<line>`, so a graph can't show two kinds of relation at once. `web-applications#173` needs to draw dashed "provides"/contributes edges alongside the existing solid "depends on" edges in the installed-modules graph. This is the required kit prerequisite (contract PR 1).

## Test

- `Graph.test.tsx`: new case asserts a `dashed` edge gets a `stroke-dasharray` attribute and a plain edge does not.
- `pnpm typecheck`, `pnpm test` (826 passed), `pnpm build` all green.

## Release

Pre-1.0 patch-only bump `0.6.11 → 0.6.12` in the same PR + `release` label (release.yml reads the version, does not bump).

Part of mirrorstack-ai/mirrorstack-core-v2#112. Unblocks mirrorstack-ai/web-applications#173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)