### PR TITLE
fix: open agent sidebar at ~30% of viewport for fresh accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.12",
+  "version": "0.6.13",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/AppShell.test.tsx
+++ b/src/components/layout/app-shell/AppShell.test.tsx
@@ -395,23 +395,36 @@ describe("AppShell sidebar width persistence", () => {
       await Promise.resolve();
     });
     fireEvent.click(screen.getByLabelText("Open agent"));
-    // No 500px panel — reopen fell back to the 50%-of-viewport default.
+    // No 500px panel — reopen fell back to the 30%-of-viewport default.
     expect(document.querySelector('[style*="width: 500px"]')).toBeNull();
   });
 
   it("writes the dragged width back through the injected persistence", async () => {
-    const set = vi.fn();
-    const widthPersistence = { get: () => 0, set };
-    render(
-      <AppShell sidebarWidthPersistence={widthPersistence}>content</AppShell>,
-    );
-    await act(async () => {
-      await Promise.resolve();
+    const originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 2000,
     });
-    // Open the sidebar — the reopen width (50% of the 1024 viewport = 512) is a
-    // real open width strictly above the 350 floor, so it persists.
-    fireEvent.click(screen.getByLabelText("Open agent"));
-    expect(set).toHaveBeenCalledWith(512);
+
+    try {
+      const set = vi.fn();
+      const widthPersistence = { get: () => 0, set };
+      render(
+        <AppShell sidebarWidthPersistence={widthPersistence}>content</AppShell>,
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      // Open the sidebar — 30% of the 2000 viewport = 600, safely above the
+      // 350 floor.
+      fireEvent.click(screen.getByLabelText("Open agent"));
+      expect(set).toHaveBeenCalledWith(600);
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        value: originalInnerWidth,
+      });
+    }
   });
 
   it("works with no persistence injected (in-memory only, never touches localStorage)", () => {

--- a/src/components/layout/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/AppShell.tsx
@@ -39,6 +39,10 @@ export const meta: ComponentMeta = {
 
 const MIN_WIDTH = 350;
 const PADDING = 20;
+// Fresh-account default: with no persisted width, the agent sidebar opens at
+// ~30% of the viewport (then clamped to [MIN_WIDTH, viewport]). A saved width
+// always wins over this — see reopenWidth().
+const DEFAULT_OPEN_WIDTH_RATIO = 0.3;
 
 export interface AppShellProps {
   children: ReactNode;
@@ -70,7 +74,7 @@ export interface AppShellProps {
    *  the state the user left it — without it the shell derives visibility from
    *  width alone and always paints closed on reload. When `true` while the
    *  width is still 0 (fresh open, or restored-open before the width fetch
-   *  lands) the shell seeds the width from the remembered/half-viewport size;
+   *  lands) the shell seeds the width from the remembered/~30%-viewport size;
    *  when `false` while open it collapses to 0. Omit it (undefined) to keep the
    *  uncontrolled width-derived behavior unchanged. */
   open?: boolean;
@@ -401,16 +405,16 @@ function AppShellInner({
   useEffect(() => { dragWidthRef.current = sidebarWidth; }, [sidebarWidth]);
 
   // Reopen to the user's remembered (persisted) width, clamped to the live
-  // viewport. Falls back to half the viewport when no wider width was ever
+  // viewport. Falls back to ~30% of the viewport when no wider width was ever
   // recorded (lastOpenWidth still at the MIN_WIDTH floor).
   const reopenWidth = () => {
     // `>=`: lastOpenWidth === MIN_WIDTH is a real remembered width (user dragged
     // to the floor), not "no saved width" — restore it instead of falling back
-    // to half-viewport. Only the seed default (0, below the floor) falls back.
+    // to ~30% of the viewport. Only the seed default (0, below the floor) falls back.
     const remembered =
       lastOpenWidth >= MIN_WIDTH
         ? lastOpenWidth
-        : (windowWidth || 1000) * 0.5;
+        : (windowWidth || 1000) * DEFAULT_OPEN_WIDTH_RATIO;
     return Math.min(Math.max(remembered, MIN_WIDTH), maxWidthRef.current);
   };
 
@@ -423,7 +427,7 @@ function AppShellInner({
   // On reload this seed is a PLACEHOLDER: the persisted open:true hydrates
   // synchronously while the async width GET (SidebarProvider) is still in
   // flight, and lastOpenWidth is still 0 at that instant, so reopenWidth()
-  // returns the half-viewport fallback — not the user's saved drag. We seed
+  // returns the ~30%-viewport fallback — not the user's saved drag. We seed
   // through `seedWidth`, NOT `setSidebarWidth`, so this placeholder does NOT
   // mark the width hydrated; the fetched stored width then overrides it exactly
   // once when the GET lands (SidebarProvider). A genuine user drag still goes

--- a/src/context/sidebar/SidebarProvider.test.tsx
+++ b/src/context/sidebar/SidebarProvider.test.tsx
@@ -427,7 +427,7 @@ describe("SidebarProvider injected server persistence (docs 12.4 + 13b)", () => 
   //
   // On reload SidebarProvider mounts with defaultWidth 0, so sidebarWidth and
   // lastOpenWidth are both 0. A NON-ZERO placeholder writer then runs BEFORE the
-  // async width GET resolves — either AppShell's controlled-open half-viewport
+  // async width GET resolves — either AppShell's controlled-open ~30%-viewport
   // seed, or (in web-applications) AgentSessionBridge's setSidebarWidth(350)
   // clobber. The old reconcile only seeded a default-0 width
   // (`cur <= 0 ? stored : cur`), so any non-zero placeholder won the race and

--- a/src/context/sidebar/SidebarProvider.tsx
+++ b/src/context/sidebar/SidebarProvider.tsx
@@ -49,7 +49,7 @@ export interface SidebarContextType {
   setSidebarWidth: (width: number) => void;
   /** Set a PLACEHOLDER width that must yield to the persisted width once it is
    *  fetched. Use for the open-flag-driven seed (AppShell's controlled-open
-   *  effect, which on reload derives a half-viewport / floor value because the
+   *  effect, which on reload derives a ~30%-viewport / floor value because the
    *  real width hasn't hydrated yet) — NOT for a user gesture. Unlike
    *  `setSidebarWidth`, it never marks the width hydrated, so the async-fetched
    *  stored width overrides it exactly once on first hydrate (first REAL writer
@@ -146,7 +146,7 @@ export function SidebarProvider({
   // async-fetched stored width landed (apply() below) OR a genuine user drag
   // recorded an open width before the fetch resolved. Until then, an open-flag
   // PLACEHOLDER seed (AppShell's controlled-open effect, which derives a
-  // half-viewport / floor width because lastOpenWidth is still 0 mid-restore)
+  // ~30%-viewport / floor width because lastOpenWidth is still 0 mid-restore)
   // does NOT count as hydrated, so the fetched stored width may overwrite it
   // exactly once. This makes the persisted width authoritative for the hydrate
   // window regardless of which writer seeded a non-zero placeholder first.


### PR DESCRIPTION
## What
Fresh accounts open the agent sidebar at the designed ~30% of the viewport instead of ~50%.

## Why / root cause
`AppShell` `reopenWidth()` fell back to `(windowWidth || 1000) * 0.5` (half the viewport) when a user had **no persisted width** — a brand-new account, where `lastOpenWidth` is still at the 0 seed (below `MIN_WIDTH`). So clicking the robot icon opened the sidebar at ~50% of the page (see #353 / tracker screenshot) instead of the intended ~30%.

Accounts **with** a saved width are unaffected: a persisted value hydrates `lastOpenWidth >= MIN_WIDTH` and is restored by the branch above the fallback — that path is untouched and still wins.

## Change
- New named constant `DEFAULT_OPEN_WIDTH_RATIO = 0.3`; `reopenWidth()` uses it in place of the `* 0.5` literal. Clamp to `[MIN_WIDTH, viewport]` is unchanged.
- Corrected the now-stale "half-viewport" wording in AppShell / SidebarProvider comments.
- Updated the persistence test to a viewport where 30% is above the floor (2000 → 600) so it actually pins the ratio.
- Patch bump `0.6.12` → `0.6.13` (`release` label → publish on merge).

## Validation
`pnpm typecheck`, `pnpm test` (826 passed), `pnpm build` all green. Lockfile unchanged.

Closes #353
Tracker: mirrorstack-ai/mirrorstack-core-v2#139

🤖 Generated with [Claude Code](https://claude.com/claude-code)