### PR TITLE
fix: Graph — imperative rAF position writes, no per-frame reconcile (core#178)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.13",
+  "version": "0.6.14",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/graph/graph/Graph.tsx
+++ b/src/components/ui/graph/graph/Graph.tsx
@@ -285,6 +285,8 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
 ) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const svgRef = useRef<SVGSVGElement | null>(null);
+  const nodeGroupEls = useRef<Map<string, SVGGElement>>(new Map());
+  const edgeEls = useRef<Map<string, SVGLineElement>>(new Map());
 
   const [size, setSize] = useState<{ w: number; h: number }>({
     w: DEFAULT_W,
@@ -407,7 +409,6 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
     seededFor.current = { nodes: allNodes, edges: allEdges };
   }
 
-  const [, setFrame] = useState(0);
   const [hoveredId, setHoveredId] = useState<string | null>(null);
   const [draggingId, setDraggingId] = useState<string | null>(null);
   // Ref mirror of draggingId so the window-level safety listener (which is
@@ -488,7 +489,30 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
           repulsionRef.current,
           linkDistanceRef.current,
         );
-        setFrame((f) => f + 1);
+        // Node group translate (1 attr write/node) + edge endpoints (4/edge).
+        // Runs only while the sim is active; a parked graph does zero
+        // per-frame DOM work.
+        const groups = nodeGroupEls.current;
+        for (let i = 0; i < ns.length; i++) {
+          const n = ns[i];
+          const g = groups.get(n.id);
+          if (g) g.setAttribute("transform", `translate(${n.x} ${n.y})`);
+        }
+        const es = edgesRef.current;
+        const byId = byIdRef.current;
+        const lines = edgeEls.current;
+        for (let i = 0; i < es.length; i++) {
+          const e = es[i];
+          const l = lines.get(`${e.source}-${e.target}-${i}`);
+          if (!l) continue;
+          const a = byId.get(e.source);
+          const b = byId.get(e.target);
+          if (!a || !b) continue;
+          l.setAttribute("x1", String(a.x));
+          l.setAttribute("y1", String(a.y));
+          l.setAttribute("x2", String(b.x));
+          l.setAttribute("y2", String(b.y));
+        }
         // Park once the cluster has settled and nothing is driving motion, so
         // an at-rest graph stops re-running physics + reconciling its SVG every
         // frame for the life of the page. Checked AFTER step() so a just-
@@ -878,9 +902,15 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
               const visible =
                 revealedRef.current.has(e.source) &&
                 revealedRef.current.has(e.target);
+              const k = `${e.source}-${e.target}-${i}`;
               return (
                 <line
-                  key={`${e.source}-${e.target}-${i}`}
+                  key={k}
+                  ref={(el) => {
+                    const m = edgeEls.current;
+                    if (el) m.set(k, el);
+                    else m.delete(k);
+                  }}
                   x1={a.x}
                   y1={a.y}
                   x2={b.x}
@@ -916,6 +946,12 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
                 <g
                   key={n.id}
                   data-node-id={n.id}
+                  ref={(el) => {
+                    const m = nodeGroupEls.current;
+                    if (el) m.set(n.id, el);
+                    else m.delete(n.id);
+                  }}
+                  transform={`translate(${n.x} ${n.y})`}
                   className="cursor-grab active:cursor-grabbing"
                   onPointerDown={handleNodePointerDown(n.id)}
                   onPointerEnter={() => setHoveredId(n.id)}
@@ -926,16 +962,16 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
                   style={REVEAL_TRANSITION_STYLE}
                 >
                   <circle
-                    cx={n.x}
-                    cy={n.y}
+                    cx={0}
+                    cy={0}
                     r={r}
                     className={circleClass}
                     strokeWidth={isTagNode ? 1.25 / view.zoom : undefined}
                     style={isTagNode ? undefined : nodeStyle}
                   />
                   <text
-                    x={n.x}
-                    y={n.y + r + LABEL_BASE_FONT_SIZE * textSize}
+                    x={0}
+                    y={r + LABEL_BASE_FONT_SIZE * textSize}
                     textAnchor="middle"
                     className="fill-on-surface-variant pointer-events-none"
                     style={labelTextStyle}

--- a/src/components/ui/graph/graph/Graph.tsx
+++ b/src/components/ui/graph/graph/Graph.tsx
@@ -225,6 +225,11 @@ const DEFAULT_H = 400;
 // when revealedRef changes.
 const REVEAL_TRANSITION_STYLE = { transition: "opacity 200ms ease" };
 
+// Single source of the edge-element map key. The render callback-ref registers
+// under this key and the rAF fast path looks it up per frame — if the two ever
+// drift, edges silently stop animating, so both sites MUST go through here.
+const edgeKey = (e: GraphEdge, i: number) => `${e.source}-${e.target}-${i}`;
+
 // Base font size for node labels. Multiplied by nodeSize so labels grow
 // in step with circles when the consumer bumps node size — the per-frame
 // style object is memoised below in the component so we still avoid
@@ -503,7 +508,7 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
         const lines = edgeEls.current;
         for (let i = 0; i < es.length; i++) {
           const e = es[i];
-          const l = lines.get(`${e.source}-${e.target}-${i}`);
+          const l = lines.get(edgeKey(e, i));
           if (!l) continue;
           const a = byId.get(e.source);
           const b = byId.get(e.target);
@@ -902,7 +907,7 @@ export const Graph = forwardRef<GraphHandle, GraphProps>(function Graph(
               const visible =
                 revealedRef.current.has(e.source) &&
                 revealedRef.current.has(e.target);
-              const k = `${e.source}-${e.target}-${i}`;
+              const k = edgeKey(e, i);
               return (
                 <line
                   key={k}


### PR DESCRIPTION
## What

Eliminates the per-frame React reconcile in web-ui-kit `Graph`. The `requestAnimationFrame` loop previously called `setFrame((f) => f + 1)` on **every active frame**, forcing React to reconcile the entire ~40-element SVG subtree at 60fps. This PR writes the per-frame-changing geometry **imperatively via DOM refs** instead.

- **Node position** is now carried by a `transform="translate(x y)"` on the per-node `<g>`; the child `<circle>`/`<text>` became group-relative (`cx/cy=0`, label `y = r + font`). Per frame the loop does one `setAttribute("transform", …)` per node.
- **Edge endpoints** are written via `x1/y1/x2/y2` `setAttribute` per line per frame.
- React state/reconcile is kept **only** for structural / non-physics changes: node & edge set identity, reveal-set membership (250 ms BFS ticks), hover / drag / `selectedId`, view zoom+pan and the `fit()` animation, and resize.

Every JSX position expression still reads the live `nodesRef` entries, so structural reconciles paint correct positions and never drift from the imperative writes.

## Why

Root cause of the landing-page showcase scroll jank (core#178): three showcase `Graph` force-sims cold-start on one normal-speed scroll frame, so three full React reconciles ran per frame on top of the pinned cinematic + Lenis. This is fix direction 2 (the kit fix) from the tracker.

## Guarantees

- **Public API 100% unchanged** — `Graph`, `GraphProps`, `GraphNode`, `GraphEdge`, `GraphHandle` (`replay`/`stop`/`fit`), `meta`, and all props (incl. `onPlaybackEnd`, `scrollZoom`, `colors`) are byte-identical. Consumers need only a version bump.
- **Behaviour pixel-equivalent** — force layout, node-by-node BFS reveal (250 ms/node), per-module colors, drag-to-pin, settle-parking (idle graph does zero per-frame DOM work), reduced-motion path (decided by the consumer; no reduced-motion code lives in `Graph`).
- Patch bump `0.6.13 → 0.6.14` in this PR + `release` label (release.yml reads the version on merge). web-landing bumps the dependency separately.

## Validation (run locally, node 25 / pnpm 10.29.3)

| Check | Result |
| --- | --- |
| `pnpm typecheck` | pass (exit 0) |
| `pnpm test` | 826 passed / 76 files (incl. `Graph.test.tsx`, unmodified) |
| `pnpm build` | pass |
| `pnpm components validate` | 68/68 components pass |
| `pnpm build-storybook` | built successfully (Storybook PR gate) |

These are exactly the checks in `ci.yml` + `storybook.yml`.

Tracker: mirrorstack-ai/mirrorstack-core-v2#178
