### PR TITLE
fix: SnackbarProvider — supersede pending exit timer on dismiss

### DIFF
--- a/src/context/snackbar/SnackbarProvider.test.tsx
+++ b/src/context/snackbar/SnackbarProvider.test.tsx
@@ -79,6 +79,46 @@ describe("SnackbarProvider", () => {
     expect(screen.queryByText("Saved")).not.toBeInTheDocument();
   });
 
+  it("keeps a snackbar shown between a double dismiss and its exit timer", () => {
+    // Regression: two dismisses back-to-back (the module-mount unsaved bridge
+    // emits set(null) twice on a save) used to orphan the first exit timer —
+    // it would fire through a success toast shown in between and wipe it.
+    function Trigger() {
+      const { showSnackbar, dismissSnackbar } = useSnackbar();
+      return (
+        <>
+          <button
+            onClick={() => {
+              dismissSnackbar();
+              dismissSnackbar();
+              setTimeout(() => showSnackbar({ message: "Saved" }), 50);
+            }}
+          >
+            save
+          </button>
+          <button onClick={() => showSnackbar({ message: "Unsaved changes" })}>
+            show
+          </button>
+        </>
+      );
+    }
+    render(
+      <SnackbarProvider>
+        <Trigger />
+      </SnackbarProvider>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText("show"));
+    });
+    act(() => {
+      fireEvent.click(screen.getByText("save"));
+    });
+    act(() => {
+      vi.advanceTimersByTime(SNACKBAR_EXIT_MS + 100);
+    });
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+  });
+
   it("patches in-flight options via updateSnackbar", () => {
     function Trigger() {
       const { showSnackbar, updateSnackbar } = useSnackbar();

--- a/src/context/snackbar/SnackbarProvider.tsx
+++ b/src/context/snackbar/SnackbarProvider.tsx
@@ -50,6 +50,14 @@ export function SnackbarProvider({ children }: SnackbarProviderProps) {
 
   const dismissSnackbar = useCallback(() => {
     setOpen(false);
+    // A second dismiss before the first exit timer fires must supersede it —
+    // overwriting the ref without clearing would orphan the first timer, and
+    // its setCurrent(null) would later wipe whatever a showSnackbar in
+    // between put up (the show only clears the timer the ref still points
+    // at).
+    if (cleanupTimerRef.current) {
+      clearTimeout(cleanupTimerRef.current);
+    }
     cleanupTimerRef.current = setTimeout(() => {
       setCurrent(null);
       cleanupTimerRef.current = null;


### PR DESCRIPTION
## Summary

`dismissSnackbar` overwrote `cleanupTimerRef.current` without clearing a pending timer. Double dismiss (the module-mount unsaved bridge emits `set(null)` twice per save) orphaned the first 300ms exit timer, which fired through any toast shown in between and wiped it — with an `AppShell` `SnackbarOutlet` mounted, the outlet then rendered an empty pill. Now the pending timer is cleared before scheduling a new one.

Regression test added: "keeps a snackbar shown between a double dismiss and its exit timer" — verified to fail against the old provider and pass with the fix (7/7).

Tracker: mirrorstack-ai/mirrorstack-core-v2#216 · pairs with mirrorstack-ai/web-applications#202

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)