### PR TITLE
feat: AppShell agent button uses robot_2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.14",
+  "version": "0.6.15",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/AppShell.tsx
@@ -632,7 +632,7 @@ function AppShellInner({
       {/* Agent toggle button */}
       {!isOpen && (
         <IconButton
-          icon="smart_toy"
+          icon="robot_2"
           variant="tonal"
           size="md"
           className="fixed top-2 right-2 z-50"


### PR DESCRIPTION
Closes #358

Swap the app-shell agent toggle `IconButton` from the `smart_toy` Material Symbol to `robot_2`.

- `src/components/layout/app-shell/AppShell.tsx` — agent toggle button `icon="smart_toy"` → `icon="robot_2"`. It is the only `smart_toy` reference in the repo; the AppShell stories/tests target the button by `aria-label="Open agent"`, so no other changes are needed.
- `package.json` — version bump 0.6.14 → 0.6.15 (pre-1.0 patch-only convention; release.yml reads the version, it does not bump it), paired with the `release` label.

Validation: `pnpm install --no-frozen-lockfile`, `pnpm typecheck` (clean), `pnpm test` (76 files, 826 tests passing).

Part of mirrorstack-ai/mirrorstack-core-v2#242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)