### PR TITLE
fix: share theme cookie across sibling subdomains (core#113)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.15",
+  "version": "0.6.16",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/context/theme/ThemeProvider.test.tsx
+++ b/src/context/theme/ThemeProvider.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, screen, fireEvent, act } from "@testing-library/react";
 import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
-import { ThemeProvider, useTheme } from "./ThemeProvider";
+import { ThemeProvider, useTheme, parentDomain } from "./ThemeProvider";
 
 Object.defineProperty(window, "matchMedia", {
   writable: true,
@@ -99,5 +99,24 @@ describe("ThemeProvider", () => {
 
     expect(screen.getByTestId("resolved").textContent).toBe("dark");
     expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+});
+
+describe("parentDomain (theme cookie sharing)", () => {
+  it("strips the leftmost label so siblings share the cookie", () => {
+    expect(parentDomain("apps.mirrorstack.ai")).toBe("mirrorstack.ai");
+    expect(parentDomain("account.mirrorstack.ai")).toBe("mirrorstack.ai");
+    expect(parentDomain("admin.acme.com")).toBe("acme.com");
+    expect(parentDomain("apps.acme.co.uk")).toBe("acme.co.uk");
+  });
+
+  it("returns the host unchanged for an apex domain", () => {
+    expect(parentDomain("mirrorstack.ai")).toBe("mirrorstack.ai");
+  });
+
+  it("stays host-only (undefined) for localhost, IPs, and single-label hosts", () => {
+    expect(parentDomain("localhost")).toBeUndefined();
+    expect(parentDomain("127.0.0.1")).toBeUndefined();
+    expect(parentDomain("host")).toBeUndefined();
   });
 });

--- a/src/context/theme/ThemeProvider.tsx
+++ b/src/context/theme/ThemeProvider.tsx
@@ -30,8 +30,31 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 const STORAGE_KEY = "theme";
 const COOKIE_KEY = "ms-theme";
 
+// Registrable parent domain so the theme cookie is shared across sibling
+// subdomains (account.mirrorstack.ai + apps.mirrorstack.ai → .mirrorstack.ai,
+// admin.acme.com + apps.acme.com → .acme.com). Strip the leftmost label; keep
+// the cookie host-only for localhost, bare IPs, and single-label hosts (dev),
+// where a Domain attribute is invalid or rejected.
+export function parentDomain(
+  host: string = window.location.hostname,
+): string | undefined {
+  if (host === "localhost" || /^[0-9.]+$/.test(host) || !host.includes(".")) {
+    return undefined;
+  }
+  const parts = host.split(".");
+  if (parts.length <= 2) return host; // apex, e.g. mirrorstack.ai
+  return parts.slice(1).join("."); // apps.mirrorstack.ai → mirrorstack.ai
+}
+
 function setCookie(theme: Theme) {
-  document.cookie = `${COOKIE_KEY}=${theme}; path=/; max-age=31536000; SameSite=Lax`;
+  const domain = parentDomain();
+  if (domain) {
+    // Expire any legacy host-only cookie first so it cannot shadow the shared,
+    // parent-domain cookie in document.cookie reads.
+    document.cookie = `${COOKIE_KEY}=; path=/; max-age=0; SameSite=Lax`;
+  }
+  const domainAttr = domain ? `; Domain=${domain}` : "";
+  document.cookie = `${COOKIE_KEY}=${theme}; path=/; max-age=31536000; SameSite=Lax${domainAttr}`;
 }
 
 function getCookie(): string | null {


### PR DESCRIPTION
## What
ThemeProvider wrote `ms-theme` host-only, so appearance never synced across subdomains (core-v2#113). Now derives the registrable parent domain from `location.hostname` and sets `Domain=<parent>` so account/apps siblings share one cookie; expires any legacy host-only cookie first so it can't shadow the shared one. localhost/IP/single-label stay host-only.

## Tests
`parentDomain` exported as a pure function + unit tested (apex, sibling strip, white-label, localhost/IP). `pnpm typecheck` + ThemeProvider suite green (8/8).

## Release
Patch bump 0.6.15 → **0.6.16** (pre-1.0 patch-only), `release` label set.

Closes #351
Refs mirrorstack-ai/mirrorstack-core-v2#113