### PR TITLE
feat: Alert reload affordance (onReload / reloadLabel / reloadPending)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.16",
+  "version": "0.6.17",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/feedback/alert/Alert.stories.tsx
+++ b/src/components/ui/feedback/alert/Alert.stories.tsx
@@ -64,6 +64,30 @@ export const WithAction: Story = {
   },
 };
 
+export const WithReload: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <Alert
+        variant="error"
+        title="Could not load activity"
+        onReload={() => {}}
+        onDismiss={() => {}}
+      >
+        The latest activity could not be fetched. Reload to try again.
+      </Alert>
+      <Alert
+        variant="error"
+        title="Reloading activity"
+        onReload={() => {}}
+        reloadPending
+        onDismiss={() => {}}
+      >
+        Fetching the latest activity. The reload control is disabled while the request is pending.
+      </Alert>
+    </div>
+  ),
+};
+
 export const WithCustomIcon: Story = {
   args: {
     variant: "primary",

--- a/src/components/ui/feedback/alert/Alert.test.tsx
+++ b/src/components/ui/feedback/alert/Alert.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, fireEvent } from "@testing-library/react";
+import { cleanup, render, screen, fireEvent, within } from "@testing-library/react";
 import { describe, expect, it, vi, afterEach } from "vitest";
 import { Alert } from "./Alert";
 
@@ -49,6 +49,94 @@ describe("Alert", () => {
       </Alert>,
     );
     expect(screen.getByRole("button", { name: "Update" })).toBeInTheDocument();
+  });
+
+  it("renders the reload control when onReload is set", () => {
+    render(
+      <Alert variant="error" onReload={() => {}}>
+        Could not load data
+      </Alert>,
+    );
+    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+    expect(screen.getByText("refresh")).toBeInTheDocument();
+  });
+
+  it("does not render the reload control when onReload is absent", () => {
+    render(<Alert variant="error">Could not load data</Alert>);
+    expect(screen.queryByRole("button", { name: "Reload" })).not.toBeInTheDocument();
+  });
+
+  it("fires onReload once when the reload control is clicked", () => {
+    const onReload = vi.fn();
+    render(
+      <Alert variant="error" onReload={onReload}>
+        Could not load data
+      </Alert>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
+    expect(onReload).toHaveBeenCalledOnce();
+  });
+
+  it("disables the reload control and does not fire onReload when reloadPending", () => {
+    const onReload = vi.fn();
+    render(
+      <Alert variant="error" onReload={onReload} reloadPending>
+        Could not load data
+      </Alert>,
+    );
+    const reload = screen.getByRole("button", { name: "Reload" });
+    expect(reload).toBeDisabled();
+    expect(screen.queryByText("refresh")).not.toBeInTheDocument();
+    fireEvent.click(reload);
+    expect(onReload).not.toHaveBeenCalled();
+  });
+
+  it("uses the default reload accessible name and supports a custom reloadLabel", () => {
+    const { rerender } = render(
+      <Alert variant="error" onReload={() => {}}>
+        Could not load data
+      </Alert>,
+    );
+    expect(screen.getByRole("button", { name: "Reload" })).toBeInTheDocument();
+
+    rerender(
+      <Alert variant="error" onReload={() => {}} reloadLabel="Try again">
+        Could not load data
+      </Alert>,
+    );
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reload" })).not.toBeInTheDocument();
+  });
+
+  it("keeps action, reload, and dismiss controls individually addressable", () => {
+    const onAction = vi.fn();
+    const onReload = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <Alert
+        variant="error"
+        action={<button onClick={onAction}>View details</button>}
+        onReload={onReload}
+        reloadLabel="Try again"
+        onDismiss={onDismiss}
+      >
+        Could not load data
+      </Alert>,
+    );
+
+    const buttons = within(screen.getByRole("alert")).getAllByRole("button");
+    expect(buttons).toHaveLength(3);
+    expect(buttons[0]).toHaveAccessibleName("View details");
+    expect(buttons[1]).toHaveAccessibleName("Try again");
+    expect(buttons[2]).toHaveAccessibleName("Dismiss");
+
+    fireEvent.click(screen.getByRole("button", { name: "View details" }));
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(onAction).toHaveBeenCalledOnce();
+    expect(onReload).toHaveBeenCalledOnce();
+    expect(onDismiss).toHaveBeenCalledOnce();
   });
 
   it("applies custom className", () => {

--- a/src/components/ui/feedback/alert/Alert.tsx
+++ b/src/components/ui/feedback/alert/Alert.tsx
@@ -7,7 +7,7 @@ import { IconButton } from "@/components/ui/actions/icon-button/IconButton";
 export const meta: ComponentMeta = {
   name: "Alert",
   description:
-    "Dismissible inline alert banner with error/success/warning/primary/secondary variants and an optional trailing action slot",
+    "Dismissible inline alert banner with error/success/warning/primary/secondary variants, an optional trailing action slot, and an optional reload control",
 };
 
 export type AlertVariant =
@@ -33,6 +33,13 @@ export interface AlertProps {
   /** Optional trailing action (e.g. a Button), vertically centered against the
    * whole banner. Sits before the dismiss control when both are present. */
   action?: ReactNode;
+  /** When set, renders a trailing reload icon button. Use for an alert that reports a failed
+   *  READ, where re-running the fetch is the recovery. */
+  onReload?: () => void;
+  /** Accessible name for the reload control. Defaults to "Reload". */
+  reloadLabel?: string;
+  /** Disables the reload control and shows a pending spinner while a refetch is in flight. */
+  reloadPending?: boolean;
 }
 
 const variantStyles: Record<AlertVariant, string> = {
@@ -61,6 +68,9 @@ export function Alert({
   iconSize,
   hideIcon,
   action,
+  onReload,
+  reloadLabel = "Reload",
+  reloadPending,
 }: AlertProps) {
   return (
     <div
@@ -84,6 +94,17 @@ export function Alert({
           <div className={cn("text-sm", title && "mt-1.5")}>{children}</div>
         </div>
         {action && <div className="ml-3 shrink-0">{action}</div>}
+        {onReload && (
+          <IconButton
+            icon="refresh"
+            variant="text"
+            size="sm"
+            className="-my-1 ml-1 text-current"
+            onClick={onReload}
+            aria-label={reloadLabel}
+            loading={reloadPending}
+          />
+        )}
         {onDismiss && (
           <IconButton
             icon="close"


### PR DESCRIPTION
## Why

`Alert` can report a failed read, but it offers no way to re-run it. The generic `action` slot can carry a retry button, but then every consumer invents its own icon, its own label, and its own in-flight handling — and the ones that forget an `aria-label` ship an icon-only control with no accessible name.

This makes the recovery a first-class part of the component.

## New API

```ts
/** When set, renders a trailing reload icon button. Use for an alert that reports a failed
 *  READ, where re-running the fetch is the recovery. */
onReload?: () => void;
/** Accessible name for the reload control. Defaults to "Reload". */
reloadLabel?: string;
/** Disables the reload control and shows a pending spinner while a refetch is in flight. */
reloadPending?: boolean;
```

Rendered as an `IconButton` with `icon="refresh"` — the name this codebase already uses for
this meaning (`AgentSidebarMessage`'s `onRerun` control) — matching how `onDismiss` renders its
close button (`variant="text" size="sm"`, `text-current`) so the two sit together consistently.

**Trailing order, left to right: `action`, then reload, then dismiss.** All three coexist; none
swallows another. There is a DOM-order assertion pinning this, not just a "each callback fires"
assertion.

### One deliberate call worth reviewing

`reloadPending` maps onto `IconButton`'s **existing `loading` prop**, not a bare `disabled`.
`IconButton` already does `disabled={disabled || loading}`, so the control is genuinely inert and
a user cannot queue five refetches — the hard requirement is met either way. `loading` additionally
swaps the glyph for the kit's `Progress` spinner, which tells the user *why* the control is inert.
A greyed-out refresh icon cannot distinguish "refetching" from "unavailable". Passing both `loading`
and `disabled` would be redundant, so only `loading` is passed.

`AlertProps` is already re-exported from `src/index.ts`, so the new fields propagate to consumers
with no barrel change.

## Version

`0.6.16` -> `0.6.17`, in this PR, with the `release` label.

Confirmed against `.github/workflows/release.yml` rather than assumed: the workflow triggers on
`pull_request: [closed]`, gated on `merged == true && contains(labels.*.name, 'release')`, and reads
the version with `node -p "require('./package.json').version"` — it does **not** compute or bump
anything. A merged PR without the bump and the label ships nothing. Patch-only is confirmed by
precedent: #359 was a `feat:` and took `0.6.14 -> 0.6.15`. Latest published tag is `v0.6.16`.

## Test evidence

`pnpm exec vitest run src/components/ui/feedback/alert/Alert.test.tsx --reporter=verbose` — 6 new
cases (last 6 of the reload group), 17 total:

```
 ✓ Alert > renders the reload control when onReload is set 7ms
 ✓ Alert > does not render the reload control when onReload is absent 2ms
 ✓ Alert > fires onReload once when the reload control is clicked 5ms
 ✓ Alert > disables the reload control and does not fire onReload when reloadPending 7ms
 ✓ Alert > uses the default reload accessible name and supports a custom reloadLabel 17ms
 ✓ Alert > keeps action, reload, and dismiss controls individually addressable 15ms

 Test Files  1 passed (1)
      Tests  17 passed (17)
```

Full suite — `pnpm test`:

```
 Test Files  76 passed (76)
      Tests  836 passed (836)
   Duration  50.55s
```

`pnpm typecheck`:

```
> tsc --noEmit
typecheck exit=0
```

`pnpm build`:

```
> tsc -p tsconfig.build.json && tsc-alias -p tsconfig.build.json
(exit 0)
```

`pnpm components validate`:

```
All 68 component(s) have valid metadata.
```

`pnpm lint` — the alert directory is clean:

```
$ pnpm exec eslint src/components/ui/feedback/alert/
ALERT_LINT_EXIT=0
```

Repo-wide `pnpm lint` currently exits 1 on **two pre-existing errors in files this PR does not
touch** — `src/context/sidebar/SidebarProvider.tsx:208` and
`src/hooks/agent-chat/useAgentSession.ts:347`, both `react-hooks/exhaustive-deps`. `git diff
--name-only origin/main` returns only the four files below, so these are inherited from `main`, not
introduced here. Note CI (`ci.yml`) runs `typecheck`, `test` and `components validate` — it does not
run `lint` — so this does not gate the merge. Flagging it rather than silently fixing it in an
unrelated PR.

## Diff scope

```
 package.json                                       |  2 +-
 src/components/ui/feedback/alert/Alert.stories.tsx | 24 ++++++
 src/components/ui/feedback/alert/Alert.test.tsx    | 90 +++++++++++++++++++++-
 src/components/ui/feedback/alert/Alert.tsx         | 23 +++++-
 4 files changed, 136 insertions(+), 3 deletions(-)
```

`git diff --diff-filter=D --name-only origin/main...HEAD` is empty — no deletions.

## Storybook

`WithReload` renders a failed-read error alert with reload + dismiss, and a second instance with
`reloadPending` so the in-flight spinner state is visible side by side.

## Consumer wiring lands separately

This PR ships the kit capability only. No consumer is wired to `onReload` here — the
`web-account` / `web-applications` changes that adopt it land in their own PRs, pinned to
`0.6.17` once this merges and the release workflow publishes.
