### PR TITLE
ci: run on the shared self-hosted runner labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,33 @@ permissions:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    # Runner selection is data: unset RUNNER_LABELS falls back to GitHub-hosted ubuntu-24.04-arm; shared runner-group labels intentionally let any online box pick up the job.
+    runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      # TEMPORARY (removed before merge): prove what this fleet actually has.
+      # release.yml and notify-core-pointer.yml shell out to `gh`, which is
+      # preinstalled on GitHub's images but not guaranteed on a bare runner.
+      - name: Runner capability probe
+        run: |
+          echo "arch=$(uname -m) kernel=$(uname -sr)"
+          echo "gh=$(command -v gh || echo MISSING)"
+          gh --version 2>/dev/null || true
+          echo "git=$(command -v git) $(git --version)"
+          echo "docker=$(command -v docker || echo MISSING)"
+          echo "system node=$(command -v node || echo MISSING) $(node -v 2>/dev/null || true)"
 
+      # Install Node first: self-hosted boxes have ancient system Node; this is a harmless no-op on hosted runners.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          cache: pnpm
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.29.3
+          run_install: false
+          standalone: true
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,11 @@ permissions:
 
 jobs:
   check:
-    # Runner selection is data: unset RUNNER_LABELS falls back to GitHub-hosted ubuntu-24.04-arm; shared runner-group labels intentionally let any online box pick up the job.
+    # Runner selection is data, not code. RUNNER_LABELS is an org variable;
+    # unset falls back to the GitHub-hosted ubuntu-24.04-arm literal below.
+    # It targets the labels shared by every runner group rather than one
+    # group's label on purpose, so whichever box is online picks the job up
+    # and a group returning to the fleet needs no change here.
     runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -27,7 +31,12 @@ jobs:
           echo "docker=$(command -v docker || echo MISSING)"
           echo "system node=$(command -v node || echo MISSING) $(node -v 2>/dev/null || true)"
 
-      # Install Node first: self-hosted boxes have ancient system Node; this is a harmless no-op on hosted runners.
+      # setup-node MUST precede pnpm/action-setup: the self-hosted boxes carry
+      # an ancient system Node whose npm crashes on `node:path`, so pnpm has to
+      # install under the Node 24 below. On hosted runners the system Node is
+      # modern and the ordering is a no-op, so this works under either
+      # RUNNER_LABELS value. `cache: pnpm` is dropped because it would need
+      # pnpm on PATH before setup-node runs — the very ordering being fixed.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,18 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # TEMPORARY (removed before merge): prove what this fleet actually has.
-      # release.yml and notify-core-pointer.yml shell out to `gh`, which is
-      # preinstalled on GitHub's images but not guaranteed on a bare runner.
-      - name: Runner capability probe
-        run: |
-          echo "arch=$(uname -m) kernel=$(uname -sr)"
-          echo "gh=$(command -v gh || echo MISSING)"
-          gh --version 2>/dev/null || true
-          echo "git=$(command -v git) $(git --version)"
-          echo "docker=$(command -v docker || echo MISSING)"
-          echo "system node=$(command -v node || echo MISSING) $(node -v 2>/dev/null || true)"
-
       # setup-node MUST precede pnpm/action-setup: the self-hosted boxes carry
       # an ancient system Node whose npm crashes on `node:path`, so pnpm has to
       # install under the Node 24 below. On hosted runners the system Node is

--- a/.github/workflows/notify-core-pointer.yml
+++ b/.github/workflows/notify-core-pointer.yml
@@ -19,11 +19,8 @@ jobs:
         github.event.workflow_run.event == 'push' &&
         github.event.workflow_run.head_branch == 'main'
       }}
-    # Runner selection is data, not code. RUNNER_LABELS is an org variable;
-    # unset falls back to the GitHub-hosted ubuntu-24.04-arm literal below.
-    # It targets the labels shared by every runner group rather than one
-    # group's label on purpose, so whichever box is online picks the job up
-    # and a group returning to the fleet needs no change here.
+    # Runner selection is data, not code — see ci.yml for the rationale.
+    # Unset RUNNER_LABELS falls back to the GitHub-hosted literal below.
     runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     steps:
       - name: Mint core-only workflow dispatcher token

--- a/.github/workflows/notify-core-pointer.yml
+++ b/.github/workflows/notify-core-pointer.yml
@@ -19,7 +19,11 @@ jobs:
         github.event.workflow_run.event == 'push' &&
         github.event.workflow_run.head_branch == 'main'
       }}
-    # Runner selection is data: unset RUNNER_LABELS falls back to GitHub-hosted ubuntu-24.04-arm; shared runner-group labels intentionally let any online box pick up the job.
+    # Runner selection is data, not code. RUNNER_LABELS is an org variable;
+    # unset falls back to the GitHub-hosted ubuntu-24.04-arm literal below.
+    # It targets the labels shared by every runner group rather than one
+    # group's label on purpose, so whichever box is online picks the job up
+    # and a group returning to the fleet needs no change here.
     runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     steps:
       - name: Mint core-only workflow dispatcher token

--- a/.github/workflows/notify-core-pointer.yml
+++ b/.github/workflows/notify-core-pointer.yml
@@ -19,7 +19,8 @@ jobs:
         github.event.workflow_run.event == 'push' &&
         github.event.workflow_run.head_branch == 'main'
       }}
-    runs-on: ubuntu-latest
+    # Runner selection is data: unset RUNNER_LABELS falls back to GitHub-hosted ubuntu-24.04-arm; shared runner-group labels intentionally let any online box pick up the job.
+    runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     steps:
       - name: Mint core-only workflow dispatcher token
         id: app-token

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,11 +7,8 @@ on:
 jobs:
   release:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
-    # Runner selection is data, not code. RUNNER_LABELS is an org variable;
-    # unset falls back to the GitHub-hosted ubuntu-24.04-arm literal below.
-    # It targets the labels shared by every runner group rather than one
-    # group's label on purpose, so whichever box is online picks the job up
-    # and a group returning to the fleet needs no change here.
+    # Runner selection is data, not code — see ci.yml for the rationale.
+    # Unset RUNNER_LABELS falls back to the GitHub-hosted literal below.
     runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     permissions:
       contents: write
@@ -21,12 +18,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      # setup-node MUST precede pnpm/action-setup: the self-hosted boxes carry
-      # an ancient system Node whose npm crashes on `node:path`, so pnpm has to
-      # install under the Node 24 below. On hosted runners the system Node is
-      # modern and the ordering is a no-op, so this works under either
-      # RUNNER_LABELS value. `cache: pnpm` is dropped because it would need
-      # pnpm on PATH before setup-node runs — the very ordering being fixed.
+      # setup-node MUST precede pnpm/action-setup on the self-hosted boxes —
+      # see ci.yml. A no-op on hosted runners.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,11 @@ on:
 jobs:
   release:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
-    # Runner selection is data: unset RUNNER_LABELS falls back to GitHub-hosted ubuntu-24.04-arm; shared runner-group labels intentionally let any online box pick up the job.
+    # Runner selection is data, not code. RUNNER_LABELS is an org variable;
+    # unset falls back to the GitHub-hosted ubuntu-24.04-arm literal below.
+    # It targets the labels shared by every runner group rather than one
+    # group's label on purpose, so whichever box is online picks the job up
+    # and a group returning to the fleet needs no change here.
     runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     permissions:
       contents: write
@@ -17,7 +21,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Install Node first: self-hosted boxes have ancient system Node; this is a harmless no-op on hosted runners.
+      # setup-node MUST precede pnpm/action-setup: the self-hosted boxes carry
+      # an ancient system Node whose npm crashes on `node:path`, so pnpm has to
+      # install under the Node 24 below. On hosted runners the system Node is
+      # modern and the ordering is a no-op, so this works under either
+      # RUNNER_LABELS value. `cache: pnpm` is dropped because it would need
+      # pnpm on PATH before setup-node runs — the very ordering being fixed.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   release:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
-    runs-on: ubuntu-latest
+    # Runner selection is data: unset RUNNER_LABELS falls back to GitHub-hosted ubuntu-24.04-arm; shared runner-group labels intentionally let any online box pick up the job.
+    runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     permissions:
       contents: write
       packages: write
@@ -16,12 +17,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
+      # Install Node first: self-hosted boxes have ancient system Node; this is a harmless no-op on hosted runners.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
           registry-url: https://npm.pkg.github.com
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.29.3
+          run_install: false
+          standalone: true
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -16,11 +16,8 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main'
-    # Runner selection is data, not code. RUNNER_LABELS is an org variable;
-    # unset falls back to the GitHub-hosted ubuntu-24.04-arm literal below.
-    # It targets the labels shared by every runner group rather than one
-    # group's label on purpose, so whichever box is online picks the job up
-    # and a group returning to the fleet needs no change here.
+    # Runner selection is data, not code — see ci.yml for the rationale.
+    # Unset RUNNER_LABELS falls back to the GitHub-hosted literal below.
     runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     permissions:
       actions: read

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -16,7 +16,8 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main'
-    runs-on: ubuntu-latest
+    # Runner selection is data: unset RUNNER_LABELS falls back to GitHub-hosted ubuntu-24.04-arm; shared runner-group labels intentionally let any online box pick up the job.
+    runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     permissions:
       actions: read
       contents: write
@@ -50,7 +51,7 @@ jobs:
       github.event_name == 'workflow_run' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     permissions:
       actions: read
       contents: write
@@ -155,7 +156,7 @@ jobs:
 
   cleanup-pr:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     permissions:
       contents: write
     steps:

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -16,7 +16,11 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.head_branch == 'main'
-    # Runner selection is data: unset RUNNER_LABELS falls back to GitHub-hosted ubuntu-24.04-arm; shared runner-group labels intentionally let any online box pick up the job.
+    # Runner selection is data, not code. RUNNER_LABELS is an org variable;
+    # unset falls back to the GitHub-hosted ubuntu-24.04-arm literal below.
+    # It targets the labels shared by every runner group rather than one
+    # group's label on purpose, so whichever box is online picks the job up
+    # and a group returning to the fleet needs no change here.
     runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     permissions:
       actions: read

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -15,16 +15,21 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Runner selection is data: unset RUNNER_LABELS falls back to GitHub-hosted ubuntu-24.04-arm; shared runner-group labels intentionally let any online box pick up the job.
+    runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
+      # Install Node first: self-hosted boxes have ancient system Node; this is a harmless no-op on hosted runners.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
-          cache: pnpm
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.29.3
+          run_install: false
+          standalone: true
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -15,12 +15,21 @@ concurrency:
 
 jobs:
   build:
-    # Runner selection is data: unset RUNNER_LABELS falls back to GitHub-hosted ubuntu-24.04-arm; shared runner-group labels intentionally let any online box pick up the job.
+    # Runner selection is data, not code. RUNNER_LABELS is an org variable;
+    # unset falls back to the GitHub-hosted ubuntu-24.04-arm literal below.
+    # It targets the labels shared by every runner group rather than one
+    # group's label on purpose, so whichever box is online picks the job up
+    # and a group returning to the fleet needs no change here.
     runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # Install Node first: self-hosted boxes have ancient system Node; this is a harmless no-op on hosted runners.
+      # setup-node MUST precede pnpm/action-setup: the self-hosted boxes carry
+      # an ancient system Node whose npm crashes on `node:path`, so pnpm has to
+      # install under the Node 24 below. On hosted runners the system Node is
+      # modern and the ordering is a no-op, so this works under either
+      # RUNNER_LABELS value. `cache: pnpm` is dropped because it would need
+      # pnpm on PATH before setup-node runs — the very ordering being fixed.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -15,21 +15,14 @@ concurrency:
 
 jobs:
   build:
-    # Runner selection is data, not code. RUNNER_LABELS is an org variable;
-    # unset falls back to the GitHub-hosted ubuntu-24.04-arm literal below.
-    # It targets the labels shared by every runner group rather than one
-    # group's label on purpose, so whichever box is online picks the job up
-    # and a group returning to the fleet needs no change here.
+    # Runner selection is data, not code — see ci.yml for the rationale.
+    # Unset RUNNER_LABELS falls back to the GitHub-hosted literal below.
     runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # setup-node MUST precede pnpm/action-setup: the self-hosted boxes carry
-      # an ancient system Node whose npm crashes on `node:path`, so pnpm has to
-      # install under the Node 24 below. On hosted runners the system Node is
-      # modern and the ordering is a no-op, so this works under either
-      # RUNNER_LABELS value. `cache: pnpm` is dropped because it would need
-      # pnpm on PATH before setup-node runs — the very ordering being fixed.
+      # setup-node MUST precede pnpm/action-setup on the self-hosted boxes —
+      # see ci.yml. A no-op on hosted runners.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24


### PR DESCRIPTION
GitHub-hosted runners are billing-blocked org-wide — every hosted job dies at start with
*"The job was not started because recent account payments have failed or your spending limit needs
to be increased."* This routes every job in the repo to the org's self-hosted fleet.

```yaml
runs-on: ${{ fromJSON(vars.RUNNER_LABELS || '["ubuntu-24.04-arm"]') }}
```

`RUNNER_LABELS` is the org variable (`["self-hosted","ARM64"]`, `visibility: all`). The literal is
only the fallback for when the variable is unset, and it stays `ubuntu-24.04-arm` — never plain
`ubuntu-latest`. Targeting the labels *shared* by every runner group, rather than one group's
label, means whichever box is online takes the job and `dgx-spark` returning needs no change here.

> [!IMPORTANT]
> **Do not merge this until the runner-group policy is flipped.** This repo is **public**, and all
> three org runner groups are `allows_public_repositories: false`, so its jobs are never assigned
> to the fleet — they queue forever. Merging first makes CI *hang indefinitely* instead of failing
> fast in 3s, which is strictly worse. Details and evidence below.

## Jobs moved (7 of 7)

| Workflow | Job | Why it is safe on linux/arm64 |
| --- | --- | --- |
| `ci.yml` | `check` | `tsc` + `vitest` + `tsx`. `vitest.config.ts` is `environment: "jsdom"` — no browser binary, no arch-specific toolchain. |
| `storybook.yml` | `build` | Vite/Storybook build. Its three native deps all have linux-arm64 variants present in `pnpm-lock.yaml` (`@rollup/rollup-linux-arm64-{gnu,musl}`, `@tailwindcss/oxide-linux-arm64-{gnu,musl}`, `lightningcss-linux-arm64-{gnu,musl}`), so `--frozen-lockfile` resolves. Output is static HTML/JS — arch-independent. |
| `storybook-deploy.yml` | `deploy-main` | git + `actions/download-artifact` + coreutils only. |
| `storybook-deploy.yml` | `deploy-pr-preview` | git + `actions/github-script` (runs on the runner's own bundled Node). |
| `storybook-deploy.yml` | `cleanup-pr` | git + `rm` only. |
| `notify-core-pointer.yml` | `dispatch` | `actions/create-github-app-token` + one `gh workflow run`. Same shape already routed to the fleet in api-platform and ms-app-modules. |
| `release.yml` | `release` | See below — this one was checked on its own terms. |

Nothing was left on hosted runners, and nothing was collapsed: there are no macOS/Windows matrix
legs in this repo. Every job here is a Linux job.

## Release job — the part that needed care

A broken publish is worse than a slow one, so this was not converted by pattern:

- **The published artifact is architecture-independent.** `files` is `["dist", "src/theme.css"]`
  and `build` is `tsc -p tsconfig.build.json && tsc-alias`. No native addon, no prebuilt binary,
  no per-arch tarball — an arm64 runner emits the same output as an x64 one.
- **Workspace reuse is not a risk.** Self-hosted runners are reused, but `actions/checkout` runs
  with its default `clean: true`, which `git clean -ffdx`s the tree. Verified in a real fleet log
  (`##[group]Cleaning the repository`), so no stale `dist/` from a previous job can leak into the
  tarball.
- **git is present** — `/usr/bin/git`, `git version 2.43.0`, read out of a real fleet log — so the
  tag push is fine.
- **Unverified:** `Create GitHub Release` shells out to `gh`, which is preinstalled on GitHub's
  images but not guaranteed on a bare self-hosted box. I could not confirm it: a probe step cannot
  run here (see the blocker), and `release.yml` only fires on a merged PR labelled `release`, so no
  PR can exercise it. If the first post-merge release fails, it will fail at `gh release create`,
  and the fix is installing `gh` on the runners — or swapping that step for
  `actions/github-script` + `repos.createRelease({generate_release_notes: true})`, which needs no
  preinstalled CLI. `notify-core-pointer.yml` carries the same unverified `gh` dependency.

## Toolchain ordering fix (required by this fleet)

`actions/setup-node` now runs **before** `pnpm/action-setup` in `ci.yml`, `storybook.yml` and
`release.yml`: the self-hosted boxes carry an ancient system Node whose npm crashes on
`node:path`, so pnpm must install under the Node 24 that `setup-node` provides. pnpm is pinned to
`10.29.3` and installed `standalone: true` as belt-and-suspenders against that same system Node.
On hosted runners the reordering is a no-op, so this works under either `RUNNER_LABELS` value.

`cache: pnpm` is dropped from `setup-node` in `ci.yml` and `storybook.yml` — it needs pnpm on
`PATH`, which is exactly what the new ordering defers. Caching is not worth reintroducing that
chicken-and-egg.

## The blocker — why there is no green run on this PR

**`web-ui-kit` is a public repository, and every org runner group refuses public repos.**

```
$ gh api repos/mirrorstack-ai/web-ui-kit --jq .visibility
public

$ gh api orgs/mirrorstack-ai/actions/runner-groups \
    --jq '.runner_groups[]|"\(.name): allows_public_repositories=\(.allows_public_repositories)"'
Default:     allows_public_repositories=false
dgx-spark:   allows_public_repositories=false
mac-mini-m4: allows_public_repositories=false
```

So jobs are accepted, labelled correctly, and then never assigned. Confirmed end to end:

```
$ gh api repos/mirrorstack-ai/web-ui-kit/actions/runs/31275411403/jobs \
    --jq '.jobs[]|"\(.name) \(.status) runner=\(.runner_name//"-") labels=\(.labels|join(","))"'
check queued runner=- labels=self-hosted,ARM64

$ gh api orgs/mirrorstack-ai/actions/runners --jq '.runners[]|"\(.name) \(.status) busy=\(.busy)"'
mac-mini-m4-5cc140fdd4c7 online busy=false
mac-mini-m4-ac12179301e5 online busy=false
mac-mini-m4-d6df8f53a911 online busy=false
```

Idle runners carrying `self-hosted,Linux,ARM64,mac-mini-m4,docker`, a job asking for
`self-hosted,ARM64`, and no assignment. It is not contention and not a label typo.

The split is exactly public-vs-private, across the whole org:

| repo | visibility | self-hosted jobs |
| --- | --- | --- |
| api-platform, ms-app-modules, web-account, api-client-shared | private | run fine on `mac-mini-m4-*` |
| **web-ui-kit, billing-engine, app-module-sdk** | **public** | **queued forever — zero have ever landed** |

No job from any of the three public repos has ever been assigned to the fleet. Meanwhile
api-platform / api-client-shared / ms-app-modules jobs submitted at 19:04–19:27 all ran to
completion on `self-hosted,ARM64` while this PR's 18:35 job sat queued — newer private jobs
overtaking an older public one is the same fact from the other side.

I re-triggered three times against three separately reprovisioned fleets (runner IDs rotated
`1bc4371b…`/`bc4a6027…`/`e25c1b92…` → `5cc140fd…`/`ac121793…`/`d6df8f53…` → `1ffff71b…`/`31c8a48c…`/…)
and the result was identical every time.

## What has to happen before this merges

One of:

1. **Set `allows_public_repositories: true` on the `mac-mini-m4` and `dgx-spark` groups.** One
   admin toggle, but a real security decision: it lets pull requests **from forks** of a public
   repo execute on org hardware. GitHub explicitly recommends against it. If taken, pair it with
   `Require approval for all external contributors` in Actions settings.
2. **Make `web-ui-kit` private.** It publishes Storybook to GitHub Pages at
   `mirrorstack-ai.github.io/web-ui-kit`, so check that first.
3. **Leave this repo on hosted runners** and accept that its CI stays dead until org billing is
   restored.

Same call applies to `billing-engine` and `app-module-sdk`.

## Not verifiable even after the policy flip

Three converted jobs cannot run from a PR branch — a property of their triggers, not of this change:

- `storybook-deploy.yml`'s `deploy-main` and `deploy-pr-preview` are `workflow_run`-triggered, and
  `workflow_run` workflows always execute the copy on the **default branch**, so this PR's version
  does not run until merge. (`cleanup-pr` is `pull_request: closed` and does run from the head
  branch — it was dispatched here and queued behind the same blocker.)
- `notify-core-pointer.yml` — same `workflow_run` constraint, plus gated on
  `event == 'push' && head_branch == 'main'`.
- `release.yml` — only on a merged PR labelled `release`.
