### PR TITLE
feat: localizable Alert dismiss label (dismissLabel)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.17",
+  "version": "0.6.18",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/feedback/alert/Alert.stories.tsx
+++ b/src/components/ui/feedback/alert/Alert.stories.tsx
@@ -51,6 +51,18 @@ export const Dismissible: Story = {
   },
 };
 
+/** The dismiss control's accessible name is localizable via `dismissLabel`,
+ *  mirroring `reloadLabel`. Omit it and the name defaults to "Dismiss". */
+export const DismissibleLocalized: Story = {
+  args: {
+    variant: "warning",
+    title: "連線不穩定",
+    children: "部分功能可能無法正常運作。",
+    onDismiss: () => {},
+    dismissLabel: "關閉",
+  },
+};
+
 export const WithAction: Story = {
   args: {
     variant: "warning",

--- a/src/components/ui/feedback/alert/Alert.test.tsx
+++ b/src/components/ui/feedback/alert/Alert.test.tsx
@@ -42,6 +42,27 @@ describe("Alert", () => {
     expect(screen.queryByLabelText("Dismiss")).not.toBeInTheDocument();
   });
 
+  it("uses the default dismiss accessible name and supports a custom dismissLabel", () => {
+    const onDismiss = vi.fn();
+    const { rerender } = render(
+      <Alert variant="warning" onDismiss={onDismiss}>
+        Warning
+      </Alert>,
+    );
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeInTheDocument();
+
+    rerender(
+      <Alert variant="warning" onDismiss={onDismiss} dismissLabel="關閉">
+        Warning
+      </Alert>,
+    );
+    const dismiss = screen.getByRole("button", { name: "關閉" });
+    expect(dismiss).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Dismiss" })).not.toBeInTheDocument();
+    fireEvent.click(dismiss);
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
   it("renders the action node when provided", () => {
     render(
       <Alert variant="warning" title="Update available" action={<button>Update</button>}>

--- a/src/components/ui/feedback/alert/Alert.tsx
+++ b/src/components/ui/feedback/alert/Alert.tsx
@@ -23,6 +23,8 @@ export interface AlertProps {
   children: ReactNode;
   className?: string;
   onDismiss?: () => void;
+  /** Accessible name for the dismiss control. Defaults to "Dismiss". */
+  dismissLabel?: string;
   /** Override the default icon for this variant. */
   icon?: string;
   /** Override the default icon size (default: 20). */
@@ -64,6 +66,7 @@ export function Alert({
   children,
   className,
   onDismiss,
+  dismissLabel = "Dismiss",
   icon,
   iconSize,
   hideIcon,
@@ -112,7 +115,7 @@ export function Alert({
             size="sm"
             className="-my-1 ml-auto text-current"
             onClick={onDismiss}
-            aria-label="Dismiss"
+            aria-label={dismissLabel}
           />
         )}
       </div>


### PR DESCRIPTION
## Problem

`Alert` rendered its dismiss control with a hardcoded `aria-label="Dismiss"`, so every consumer in a non-English UI got an English accessible name — 16 call sites across 7 module bundles today.

The companion reload control already does this correctly via `reloadLabel`. The dismiss control was simply missing its equivalent.

## Fix

Adds `dismissLabel?: string`, mirroring `reloadLabel` exactly:

| | dismiss | reload |
|---|---|---|
| declaration | `dismissLabel?: string` | `reloadLabel?: string` |
| default | `dismissLabel = "Dismiss"` | `reloadLabel = "Reload"` |
| application | `aria-label={dismissLabel}` | `aria-label={reloadLabel}` |

Omitting the prop renders **exactly** as before, so existing consumers are unchanged. Nothing else about `Alert` was renamed or restructured.

## Version

`0.6.17` → `0.6.18`. This repo is pre-1.0 and releases **patch-only even for features**, and `release.yml` reads the version from `package.json` — so the bump ships in this PR, with the `release` label applied.

## Tests

The pre-existing assertions on the name `"Dismiss"` are **unchanged** — they now assert the *default*. A new case proves a supplied `dismissLabel` becomes the accessible name.

Verified the new test is not vacuous by restoring the bug (`aria-label="Dismiss"`) and re-running: exactly 1 test fails, the 17 default-case tests still pass.

```
 ❯ src/components/ui/feedback/alert/Alert.test.tsx:59:28
     59|     const dismiss = screen.getByRole("button", { name: "關閉" });
 Test Files  1 failed (1)
      Tests  1 failed | 17 passed (18)
```

Restored, then the full CI-equivalent suite:

```
$ pnpm typecheck
> tsc --noEmit          (clean)

$ pnpm test
 Test Files  76 passed (76)
      Tests  837 passed (837)

$ pnpm components validate
All 68 component(s) have valid metadata.
```

## Storybook

`Dismissible` is left as the canonical default-behaviour example. A new `DismissibleLocalized` story demonstrates the prop, matching how `WithReload` keeps the default visible rather than overriding it.

## Note for a separate PR (not fixed here)

`pnpm lint` is **already red on `main`** — `eslint-plugin-react-hooks@7.1.1` reports 2 errors + 2 unused-directive warnings in `SidebarProvider.tsx` and `useAgentSession.ts`. CI does not run `pnpm lint` (only `typecheck`, `test`, `components validate`), which is why it went unnoticed. Deliberately left out of this PR to keep it scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)