### PR TITLE
fix(Dialog): tighten title bottom margin to mb-3 (0.6.19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.6.19
+
+- **`Dialog` title sits closer to its body.** The title's bottom margin drops
+  from `mb-4` to `mb-3`. At `mb-4` a short title read as detached from the
+  content it introduces, particularly in confirm dialogs where the body is a
+  single line. Affects every `Dialog` and everything built on it
+  (`TypeToConfirmDialog`, `ReauthDialog`).
+
 ## 0.6.0
 
 - **Fix: `NotchGrid` no longer lets distinct panels overlap or render flush at

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/surfaces/dialog/Dialog.tsx
+++ b/src/components/ui/surfaces/dialog/Dialog.tsx
@@ -170,7 +170,7 @@ export function Dialog({
             {title && (
               <h3
                 id={titleId}
-                className="text-lg font-semibold text-on-surface mb-4 pr-8"
+                className="text-lg font-semibold text-on-surface mb-3 pr-8"
               >
                 {title}
               </h3>


### PR DESCRIPTION
## What

`Dialog`'s title goes from `mb-4` to `mb-3`.

At `mb-4` a short title read as detached from the content it introduces — most visible in confirm dialogs whose body is a single line, where the gap above the body matched the gap between body and actions, so the heading stopped looking attached to anything.

## Blast radius — deliberate

This lands on **every** `Dialog` in the platform, and on everything built on it (`TypeToConfirmDialog`, `ReauthDialog`). That is the point: title-to-body spacing is a design-system decision, not a per-consumer one. The alternative — one module overriding the heading locally — is the divergence a kit exists to prevent.

## Release

Version bumped to **0.6.19** in this PR, alongside the `release` label. `release.yml` *reads* the version rather than incrementing it, so a labelled PR that forgets the bump collides with the existing tag and fails silently (this bit #232).

## Verification

`vitest run` — 837 tests / 76 files green. `npm run build` clean.