### PR TITLE
feat(skeleton): SkeletonRegion + skeletonPreview, and cut 0.6.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.6.20
+
+- **Shared skeleton-loading primitives.** Adds `skeletonPreview()` for an
+  SSR-safe, call-time `?skeleton` design-preview branch and `SkeletonRegion`
+  for localized loading announcements that hide decorative placeholder boxes
+  from assistive technology. Both primitives and `SkeletonRegionProps` are
+  exported from the package root.
+
 ## 0.6.19
 
 - **`Dialog` title sits closer to its body.** The title's bottom margin drops

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/feedback/skeleton/Skeleton.stories.tsx
+++ b/src/components/ui/feedback/skeleton/Skeleton.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Skeleton } from "./Skeleton";
+import { SkeletonRegion } from "./SkeletonRegion";
 
 const meta: Meta<typeof Skeleton> = {
   title: "UI/Feedback/Skeleton",
@@ -45,5 +46,17 @@ export const CardPlaceholder: Story = {
       <Skeleton width="w-3/4" height="h-5" />
       <Skeleton lines={3} />
     </div>
+  ),
+};
+
+export const Region: Story = {
+  render: () => (
+    <SkeletonRegion label="Loading profile">
+      <div className="w-80 space-y-3 rounded-lg border border-outline-variant p-4">
+        <Skeleton width="w-12" height="h-12" className="rounded-full" />
+        <Skeleton width="w-2/3" height="h-5" />
+        <Skeleton lines={3} />
+      </div>
+    </SkeletonRegion>
   ),
 };

--- a/src/components/ui/feedback/skeleton/SkeletonRegion.test.tsx
+++ b/src/components/ui/feedback/skeleton/SkeletonRegion.test.tsx
@@ -1,0 +1,21 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SkeletonRegion } from "./SkeletonRegion";
+
+afterEach(cleanup);
+
+describe("SkeletonRegion", () => {
+  it("announces the busy region and hides its visual subtree", () => {
+    const { container } = render(
+      <SkeletonRegion label="Loading account details">
+        <div data-testid="placeholder" />
+      </SkeletonRegion>,
+    );
+
+    const region = screen.getByRole("status");
+    expect(region).toBe(container.firstElementChild);
+    expect(region).toHaveAttribute("aria-busy", "true");
+    expect(region).toHaveAttribute("aria-label", "Loading account details");
+    expect(region.firstElementChild).toHaveAttribute("aria-hidden", "true");
+  });
+});

--- a/src/components/ui/feedback/skeleton/SkeletonRegion.tsx
+++ b/src/components/ui/feedback/skeleton/SkeletonRegion.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+
+import type { ComponentMeta } from "@/types/component-meta";
+
+export const meta: ComponentMeta = {
+  name: "SkeletonRegion",
+  description:
+    "Accessible wrapper announcing a loading region while hiding its placeholders from assistive technology",
+};
+
+export interface SkeletonRegionProps {
+  /** Visual skeleton elements to hide from assistive technology. */
+  children: ReactNode;
+  /** Already-localized text announcing what is loading. */
+  label: string;
+}
+
+/**
+ * Announces a loading region once while hiding its decorative placeholders
+ * from assistive technology. The required label is supplied by the host so the
+ * kit does not own module locale catalogs or silently fall back to English.
+ */
+export function SkeletonRegion({ children, label }: SkeletonRegionProps) {
+  return (
+    <div role="status" aria-busy="true" aria-label={label}>
+      <div aria-hidden="true">{children}</div>
+    </div>
+  );
+}

--- a/src/components/ui/feedback/skeleton/skeletonPreview.test.ts
+++ b/src/components/ui/feedback/skeleton/skeletonPreview.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { skeletonPreview } from "./skeletonPreview";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  window.history.replaceState({}, "", "/");
+});
+
+describe("skeletonPreview", () => {
+  it("returns true for a valueless skeleton parameter", () => {
+    window.history.replaceState({}, "", "/?skeleton");
+    expect(skeletonPreview()).toBe(true);
+  });
+
+  it("returns true for skeleton=1", () => {
+    window.history.replaceState({}, "", "/?skeleton=1");
+    expect(skeletonPreview()).toBe(true);
+  });
+
+  it("returns false when the skeleton parameter is absent", () => {
+    window.history.replaceState({}, "", "/?other=1");
+    expect(skeletonPreview()).toBe(false);
+  });
+
+  it("returns false for a malformed search string", () => {
+    window.history.replaceState({}, "", "/?%E0%A4%A");
+    expect(skeletonPreview()).toBe(false);
+  });
+
+  it("reads the current URL on every call", () => {
+    window.history.replaceState({}, "", "/");
+    expect(skeletonPreview()).toBe(false);
+
+    window.history.replaceState({}, "", "/?skeleton");
+    expect(skeletonPreview()).toBe(true);
+  });
+
+  it("returns false when window is undefined", () => {
+    vi.stubGlobal("window", undefined);
+    expect(skeletonPreview()).toBe(false);
+  });
+});

--- a/src/components/ui/feedback/skeleton/skeletonPreview.ts
+++ b/src/components/ui/feedback/skeleton/skeletonPreview.ts
@@ -1,0 +1,22 @@
+/**
+ * Reports whether the host page URL carries `?skeleton`, allowing a loading
+ * placeholder to remain visible for design review.
+ *
+ * The URL is read at call time because one module bundle can mount on many URLs
+ * during a client-side navigation session. The flag only forces a loading
+ * branch: it changes no fetch, suppresses no error, and is read nowhere except
+ * a loading decision. Shipping it in production is deliberate and safe because
+ * the only thing it can do is render a placeholder, and a placeholder carries
+ * no data; release builds do not need to strip it.
+ */
+export function skeletonPreview(): boolean {
+  if (typeof window === "undefined") return false;
+
+  try {
+    // `has` matches both a valueless `?skeleton` and `?skeleton=1`.
+    return new URLSearchParams(window.location.search).has("skeleton");
+  } catch {
+    // An unparseable URL is not a reason to break the page.
+    return false;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -224,6 +224,11 @@ export {
   type SkeletonProps,
 } from "./components/ui/feedback/skeleton/Skeleton";
 export {
+  SkeletonRegion,
+  type SkeletonRegionProps,
+} from "./components/ui/feedback/skeleton/SkeletonRegion";
+export { skeletonPreview } from "./components/ui/feedback/skeleton/skeletonPreview";
+export {
   EmptyState,
   type EmptyStateProps,
 } from "./components/ui/feedback/empty-state/EmptyState";


### PR DESCRIPTION
`oauth-core` carried both of these in its own bundle, and four more module bundles are about to need them (oauth-google, users-profile, users-roles, user-approval). A convention defined five times drifts — and the kit already owns `Skeleton`, so these belong beside it.

## `skeletonPreview()`

Reports whether the host page URL carries `?skeleton`, so a designer can review loading states without having to catch a real slow load.

- Reads the URL at **call time, never at import**. A module bundle is imported once per host document but mounts on many URLs across one client-side navigation session, so a value bound at import is the first URL's answer forever.
- `has()` semantics: true for a valueless `?skeleton` *and* for `?skeleton=1`.
- `false` when `window` is undefined (SSR / `renderToStaticMarkup`), and `false` rather than throwing on a URL it cannot parse — an unparseable URL is not a reason to break the page.
- It only ever forces a loading branch: it changes no fetch, suppresses no error, and is read nowhere else. That is why shipping it in a production build is safe — the one thing it can do is render a placeholder, and a placeholder carries no data.

## `SkeletonRegion`

Carries the accessibility the spinner it replaces was providing. `Progress` renders `role="progressbar"` with its own hardcoded English label; swapping it for silent grey boxes would remove a screen reader's only signal that the page is still working. `role="status"` + `aria-busy` announces the wait, and `aria-hidden` on the visual subtree keeps a reader from walking dozens of meaningless placeholder boxes.

`label` is **required** and takes already-localized text rather than defaulting to English — matching `Alert`'s `reloadLabel` / `dismissLabel`. The kit must not own module locale catalogs, and a silent English fallback is the exact bug this prop exists to prevent.

## Release

**0.6.20, not 0.6.19.** `main` was already bumped to 0.6.19 but never tagged (newest tag is `v0.6.18`), which is why the Dialog title-margin fix (#366) has never reached a browser. This release carries everything accumulated since `v0.6.18`.

Both new names are re-exported from `src/index.ts`. `package.json` exposes only `"."` with no deep-import wildcard, so the barrel is the entire public API — a component left out of it ships inside the tarball but is not importable, as notch-grid v2 did in 0.3.4.

## Verification

- `pnpm test` — **844 passed** across 78 files, including `SkeletonRegion.test.tsx` and `skeletonPreview.test.ts` (both confirmed present in the run output, not assumed)
- `pnpm typecheck` — clean
- `pnpm components validate` — all 68 components have valid metadata
- `pnpm build`, then `grep` of the built `dist/index.js` for both `skeletonPreview` and `SkeletonRegion` — present. A passing suite does not prove the barrel export landed, so this was checked against the build output.