### PR TITLE
fix(date,AppShell): locale-aware relative dates + mobile nav width — 0.6.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ width, so a two-item nav stays narrow. This also retires the `sm:!w-auto`
   `3 days ago`. Invalid dates now return an empty UI label, invalid locale tags
   fall back safely to the runtime default, and future dates use relative text.
 
+  Relative wording is bucketed by **local calendar day**, not by elapsed hours.
+  That distinction is load-bearing: a time later the same day reads `today`
+  rather than `tomorrow`, a moment thirty minutes past midnight reads
+  `yesterday` rather than `today`, and a DST transition no longer collapses two
+  calendar days into one or pushes a seven-day span into the `6 days ago`
+  bucket.
+
 ## 0.6.20
 
 - **Shared skeleton-loading primitives.** Adds `skeletonPreview()` for an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.6.21
+
+- **Relative dates now follow the caller's locale.** `formatRelativeDate` and
+  `formatDate` accept an optional locale and use the platform's `Intl`
+  formatting, including localized relative terms such as today and yesterday.
+  Omitting the locale still uses the runtime default, but its English relative
+  strings deliberately change from capitalized abbreviations such as `Today`
+  and `3d ago` to Intl's lowercase, spelled-out wording such as `today` and
+  `3 days ago`. Invalid dates now return an empty UI label, invalid locale tags
+  fall back safely to the runtime default, and future dates use relative text.
+
 ## 0.6.20
 
 - **Shared skeleton-loading primitives.** Adds `skeletonPreview()` for an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Notable API additions and breaking changes. For the full commit log, see
 
 ## 0.6.21
 
+`AppShell`'s mobile bottom nav no longer forces full width below 640px. It was
+`w-full` there and content-width from `sm` up, so the pill stretched edge to edge
+on a phone and read as a bar welded across the viewport rather than the floating
+pill it is on every wider screen. `max-w-full` alone caps it without dictating a
+width, so a two-item nav stays narrow. This also retires the `sm:!w-auto`
+`!important` that existed only to beat a module bundle's injected global
+`.w-full` — with no `w-full` class on the element, that rule has nothing to match.
+
 - **Relative dates now follow the caller's locale.** `formatRelativeDate` and
   `formatDate` accept an optional locale and use the platform's `Intl`
   formatting, including localized relative terms such as today and yesterday.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.20",
+  "version": "0.6.21",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/AppShell.tsx
@@ -256,10 +256,23 @@ function BottomNavRegion({ children }: { children: ReactNode }) {
         snackbarVisible && "invisible translate-y-[150%] opacity-0",
       )}
     >
-      {/* Full-width pill only on tight phone widths (<640px); content-width
-          and centered from sm up. pointer-events re-enable only while shown —
-          the wrapper's `none` is the inherited default. */}
-      <div className={cn("w-full sm:!w-auto max-w-full", !snackbarVisible && "pointer-events-auto")}>
+      {/* Content-width and centered at EVERY breakpoint, capped at the container.
+          Below 640px this used to force `w-full`, stretching the pill edge to
+          edge — which reads as a bar welded across the viewport rather than the
+          floating pill it is on every wider screen. `max-w-full` alone keeps it
+          from ever overflowing without dictating a width, so a two-item nav
+          stays narrow instead of spanning the phone.
+
+          Dropping our own `w-full` also retires the `sm:!w-auto` !important that
+          sat here: that existed only because a mounted module bundle injects its
+          own global Tailwind `.w-full` after the host stylesheet and would win
+          over the responsive variant. With no `w-full` class on this element,
+          a global `.w-full` rule has nothing to match, so the override is moot.
+          The wrapper above still needs its `lg:!hidden` for the same reason.
+
+          pointer-events re-enable only while shown — the wrapper's `none` is the
+          inherited default. */}
+      <div className={cn("max-w-full", !snackbarVisible && "pointer-events-auto")}>
         {children}
       </div>
     </div>

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -28,7 +28,12 @@ describe("formatDate", () => {
     "falls back to the runtime locale for locale tag %s",
     (locale) => {
       expect(() => formatDate("2026-04-29T12:00:00Z", locale)).not.toThrow();
-      expect(formatDate("2026-04-29T12:00:00Z", locale)).not.toBe("");
+      // Assert the fallback IS the runtime default, not merely that it is
+      // non-empty: hard-coding any particular locale in the catch branch would
+      // still return a non-empty string and pass a weaker check.
+      expect(formatDate("2026-04-29T12:00:00Z", locale)).toBe(
+        formatDate("2026-04-29T12:00:00Z"),
+      );
     },
   );
 });
@@ -77,6 +82,24 @@ describe("formatRelativeDate", () => {
     setNow("2026-03-10T12:00:00-04:00", "America/New_York");
     expect(formatRelativeDate("2026-03-03T12:00:00-05:00", "en")).toBe(
       "1 week ago",
+    );
+  });
+
+  it("returns 'yesterday' across a date-line offset change", () => {
+    // Pacific/Kwajalein moved across the date line, so these two consecutive
+    // local dates have midnights 47 hours apart. Any approach that divides the
+    // elapsed gap between local midnights lands on 1.96 and rounds to 2 days;
+    // only comparing civil dates as ordinals gets this right.
+    setNow("1969-10-01T12:00:00-12:00", "Pacific/Kwajalein");
+    expect(formatRelativeDate("1969-09-30T12:00:00+11:00", "en")).toBe(
+      "yesterday",
+    );
+  });
+
+  it("returns 'yesterday' across a 25-hour fall-back DST day", () => {
+    setNow("2026-11-02T12:00:00-05:00", "America/New_York");
+    expect(formatRelativeDate("2026-11-01T12:00:00-04:00", "en")).toBe(
+      "yesterday",
     );
   });
 
@@ -139,7 +162,9 @@ describe("formatRelativeDate", () => {
       expect(() =>
         formatRelativeDate("2026-04-27T12:00:00Z", locale),
       ).not.toThrow();
-      expect(formatRelativeDate("2026-04-27T12:00:00Z", locale)).not.toBe("");
+      expect(formatRelativeDate("2026-04-27T12:00:00Z", locale)).toBe(
+        formatRelativeDate("2026-04-27T12:00:00Z"),
+      );
     },
   );
 

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -28,14 +28,27 @@ describe("formatDate", () => {
     "falls back to the runtime locale for locale tag %s",
     (locale) => {
       expect(() => formatDate("2026-04-29T12:00:00Z", locale)).not.toThrow();
-      // Assert the fallback IS the runtime default, not merely that it is
-      // non-empty: hard-coding any particular locale in the catch branch would
-      // still return a non-empty string and pass a weaker check.
       expect(formatDate("2026-04-29T12:00:00Z", locale)).toBe(
         formatDate("2026-04-29T12:00:00Z"),
       );
     },
   );
+
+  // Comparing output against the no-locale call is not sufficient on its own:
+  // on a runner whose default is en-US, hard-coding "en-US" in the catch branch
+  // produces a byte-identical string. Only "!!!" is structurally invalid enough
+  // to throw and actually reach the fallback ("xx-Fake" is a well-formed tag and
+  // is passed straight through), so the contract is asserted here directly:
+  // the fallback must hand the formatter `undefined`.
+  it("passes undefined to the formatter when falling back", () => {
+    const spy = vi.spyOn(Date.prototype, "toLocaleDateString");
+    try {
+      formatDate("2026-04-29T12:00:00Z", "!!!");
+      expect(spy.mock.calls.at(-1)?.[0]).toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });
 
 describe("formatRelativeDate", () => {
@@ -94,6 +107,13 @@ describe("formatRelativeDate", () => {
     expect(formatRelativeDate("1969-09-30T12:00:00+11:00", "en")).toBe(
       "yesterday",
     );
+  });
+
+  it("returns 'yesterday' across the year-100 boundary", () => {
+    // Guards the Date.UTC two-digit-year mapping: Date.UTC(99, ...) means 1999,
+    // which would put these two consecutive days ~700,000 days apart.
+    setNow("0100-01-01T12:00:00Z", "UTC");
+    expect(formatRelativeDate("0099-12-31T12:00:00Z", "en")).toBe("yesterday");
   });
 
   it("returns 'yesterday' across a 25-hour fall-back DST day", () => {
@@ -167,6 +187,36 @@ describe("formatRelativeDate", () => {
       );
     },
   );
+
+  // Same contract as formatDate above. vi.spyOn cannot be used on
+  // Intl.RelativeTimeFormat: it wraps the class in a plain call, so `new` raises
+  // a TypeError instead of the RangeError the fallback keys on. A hand-rolled
+  // function wrapper is constructible and preserves the original's throwing.
+  it("passes undefined to the formatter when falling back", () => {
+    setNow("2026-04-28T12:00:00Z");
+    // `Intl.RelativeTimeFormat` is readonly in the lib types, so reach it
+    // through a mutable view rather than suppressing the error at each site.
+    const intl = Intl as unknown as {
+      RelativeTimeFormat: typeof Intl.RelativeTimeFormat;
+    };
+    const Original = intl.RelativeTimeFormat;
+    const seen: (string | string[] | undefined)[] = [];
+    intl.RelativeTimeFormat = function (
+      this: unknown,
+      locales?: string | string[],
+      options?: Intl.RelativeTimeFormatOptions,
+    ) {
+      seen.push(locales);
+      return new Original(locales, options);
+    } as unknown as typeof Intl.RelativeTimeFormat;
+    try {
+      formatRelativeDate("2026-04-27T12:00:00Z", "!!!");
+      expect(seen.at(0)).toBe("!!!");
+      expect(seen.at(-1)).toBeUndefined();
+    } finally {
+      intl.RelativeTimeFormat = Original;
+    }
+  });
 
   it("formats relative dates in Traditional Chinese", () => {
     setNow("2026-04-28T12:00:00Z");

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -36,16 +36,48 @@ describe("formatDate", () => {
 describe("formatRelativeDate", () => {
   afterEach(() => {
     vi.useRealTimers();
+    vi.unstubAllEnvs();
   });
 
-  function setNow(dateStr: string) {
+  function setNow(dateStr: string, timeZone?: string) {
+    if (timeZone) vi.stubEnv("TZ", timeZone);
     vi.useFakeTimers();
     vi.setSystemTime(new Date(dateStr));
   }
 
-  it("returns 'today' for the current date", () => {
-    setNow("2026-04-28T12:00:00Z");
-    expect(formatRelativeDate("2026-04-28T08:00:00Z")).toBe("today");
+  it("uses the local calendar date rather than elapsed hours", () => {
+    setNow("2026-04-28T12:00:00Z", "Etc/GMT+12");
+    expect(formatRelativeDate("2026-04-28T08:00:00Z", "en")).toBe(
+      "yesterday",
+    );
+  });
+
+  it("returns 'today' for a future time on the same local calendar day", () => {
+    setNow("2026-04-28T12:00:00-04:00", "America/New_York");
+    expect(formatRelativeDate("2026-04-28T13:00:00-04:00", "en")).toBe(
+      "today",
+    );
+  });
+
+  it("returns 'yesterday' across local midnight even when one hour elapsed", () => {
+    setNow("2026-04-28T00:30:00-04:00", "America/New_York");
+    expect(formatRelativeDate("2026-04-27T23:30:00-04:00", "en")).toBe(
+      "yesterday",
+    );
+  });
+
+  it("returns 'yesterday' across a 23-hour DST calendar day", () => {
+    setNow("2026-03-08T12:00:00-04:00", "America/New_York");
+    expect(formatRelativeDate("2026-03-07T12:00:00-05:00", "en")).toBe(
+      "yesterday",
+    );
+  });
+
+  it("uses the week bucket for seven calendar days across DST", () => {
+    setNow("2026-03-10T12:00:00-04:00", "America/New_York");
+    expect(formatRelativeDate("2026-03-03T12:00:00-05:00", "en")).toBe(
+      "1 week ago",
+    );
   });
 
   it("returns 'yesterday' for one day ago", () => {
@@ -107,9 +139,7 @@ describe("formatRelativeDate", () => {
       expect(() =>
         formatRelativeDate("2026-04-27T12:00:00Z", locale),
       ).not.toThrow();
-      expect(formatRelativeDate("2026-04-27T12:00:00Z", locale)).toBe(
-        "yesterday",
-      );
+      expect(formatRelativeDate("2026-04-27T12:00:00Z", locale)).not.toBe("");
     },
   );
 

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -15,6 +15,22 @@ describe("formatDate", () => {
     expect(result).toContain("25");
     expect(result).toContain("2025");
   });
+
+  it("formats with an explicit locale", () => {
+    expect(formatDate("2026-04-29T12:00:00Z", "zh-TW")).toContain("月");
+  });
+
+  it("returns an empty string for an unparseable date", () => {
+    expect(formatDate("not-a-date")).toBe("");
+  });
+
+  it.each(["xx-Fake", "!!!"])(
+    "falls back to the runtime locale for locale tag %s",
+    (locale) => {
+      expect(() => formatDate("2026-04-29T12:00:00Z", locale)).not.toThrow();
+      expect(formatDate("2026-04-29T12:00:00Z", locale)).not.toBe("");
+    },
+  );
 });
 
 describe("formatRelativeDate", () => {
@@ -27,26 +43,26 @@ describe("formatRelativeDate", () => {
     vi.setSystemTime(new Date(dateStr));
   }
 
-  it("returns 'Today' for the current date", () => {
+  it("returns 'today' for the current date", () => {
     setNow("2026-04-28T12:00:00Z");
-    expect(formatRelativeDate("2026-04-28T08:00:00Z")).toBe("Today");
+    expect(formatRelativeDate("2026-04-28T08:00:00Z")).toBe("today");
   });
 
-  it("returns 'Yesterday' for one day ago", () => {
+  it("returns 'yesterday' for one day ago", () => {
     setNow("2026-04-28T12:00:00Z");
-    expect(formatRelativeDate("2026-04-27T12:00:00Z")).toBe("Yesterday");
+    expect(formatRelativeDate("2026-04-27T12:00:00Z")).toBe("yesterday");
   });
 
   it("returns days ago for 2-6 days", () => {
     setNow("2026-04-28T12:00:00Z");
-    expect(formatRelativeDate("2026-04-25T12:00:00Z")).toBe("3d ago");
-    expect(formatRelativeDate("2026-04-22T12:00:00Z")).toBe("6d ago");
+    expect(formatRelativeDate("2026-04-25T12:00:00Z")).toBe("3 days ago");
+    expect(formatRelativeDate("2026-04-22T12:00:00Z")).toBe("6 days ago");
   });
 
   it("returns weeks ago for 7-29 days", () => {
     setNow("2026-04-28T12:00:00Z");
-    expect(formatRelativeDate("2026-04-20T12:00:00Z")).toBe("1w ago");
-    expect(formatRelativeDate("2026-04-14T12:00:00Z")).toBe("2w ago");
+    expect(formatRelativeDate("2026-04-20T12:00:00Z")).toBe("1 week ago");
+    expect(formatRelativeDate("2026-04-14T12:00:00Z")).toBe("2 weeks ago");
   });
 
   it("returns formatted date for 30+ days ago", () => {
@@ -56,9 +72,16 @@ describe("formatRelativeDate", () => {
     expect(result).toContain("14");
   });
 
+  it("uses the locale for dates 30+ days ago", () => {
+    setNow("2026-04-28T12:00:00Z");
+    expect(
+      formatRelativeDate("2026-03-14T12:00:00Z", "zh-TW"),
+    ).toContain("月");
+  });
+
   it("handles boundary at exactly 7 days", () => {
     setNow("2026-04-28T12:00:00Z");
-    expect(formatRelativeDate("2026-04-21T12:00:00Z")).toBe("1w ago");
+    expect(formatRelativeDate("2026-04-21T12:00:00Z")).toBe("1 week ago");
   });
 
   it("handles boundary at exactly 30 days", () => {
@@ -66,5 +89,34 @@ describe("formatRelativeDate", () => {
     const result = formatRelativeDate("2026-03-29T12:00:00Z");
     expect(result).toContain("Mar");
     expect(result).toContain("29");
+  });
+
+  it("returns an empty string for an unparseable date", () => {
+    expect(formatRelativeDate("not-a-date")).toBe("");
+  });
+
+  it("formats future dates with relative day wording", () => {
+    setNow("2026-04-28T12:00:00Z");
+    expect(formatRelativeDate("2026-05-01T12:00:00Z")).toBe("in 3 days");
+  });
+
+  it.each(["xx-Fake", "!!!"])(
+    "falls back to the runtime locale for locale tag %s",
+    (locale) => {
+      setNow("2026-04-28T12:00:00Z");
+      expect(() =>
+        formatRelativeDate("2026-04-27T12:00:00Z", locale),
+      ).not.toThrow();
+      expect(formatRelativeDate("2026-04-27T12:00:00Z", locale)).toBe(
+        "yesterday",
+      );
+    },
+  );
+
+  it("formats relative dates in Traditional Chinese", () => {
+    setNow("2026-04-28T12:00:00Z");
+    expect(formatRelativeDate("2026-04-27T12:00:00Z", "zh-TW")).toContain(
+      "昨",
+    );
   });
 });

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,24 +1,68 @@
-export function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString(undefined, {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
+function withLocaleFallback(
+  locale: string | undefined,
+  format: (resolvedLocale: string | undefined) => string,
+): string {
+  try {
+    return format(locale);
+  } catch (error) {
+    if (!(error instanceof RangeError) || locale === undefined) throw error;
+    return format(undefined);
+  }
 }
 
-export function formatRelativeDate(dateStr: string): string {
+/**
+ * Formats a date for display in the requested locale, or the runtime default
+ * when no locale is supplied. Invalid date strings return an empty UI label.
+ */
+export function formatDate(dateStr: string, locale?: string): string {
   const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return "";
+
+  return withLocaleFallback(locale, (resolvedLocale) =>
+    date.toLocaleDateString(resolvedLocale, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    }),
+  );
+}
+
+/**
+ * Formats a date relative to now in the requested locale, or the runtime
+ * default when no locale is supplied. Dates from today through 29 days ago use
+ * relative wording, while older dates use an absolute month and day. Future
+ * dates deliberately use relative day wording (for example, "in 3 days").
+ * Invalid date strings return an empty UI label.
+ */
+export function formatRelativeDate(dateStr: string, locale?: string): string {
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return "";
+
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
   const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
-  if (diffDays === 0) return "Today";
-  if (diffDays === 1) return "Yesterday";
-  if (diffDays < 7) return `${diffDays}d ago`;
-  if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
+  if (diffDays < 7) {
+    return withLocaleFallback(locale, (resolvedLocale) =>
+      new Intl.RelativeTimeFormat(resolvedLocale, { numeric: "auto" }).format(
+        -diffDays,
+        "day",
+      ),
+    );
+  }
+  if (diffDays < 30) {
+    return withLocaleFallback(locale, (resolvedLocale) =>
+      new Intl.RelativeTimeFormat(resolvedLocale, { numeric: "always" }).format(
+        -Math.floor(diffDays / 7),
+        "week",
+      ),
+    );
+  }
 
-  return date.toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-  });
+  return withLocaleFallback(locale, (resolvedLocale) =>
+    date.toLocaleDateString(resolvedLocale, {
+      month: "short",
+      day: "numeric",
+    }),
+  );
 }

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -40,14 +40,26 @@ export function formatRelativeDate(dateStr: string, locale?: string): string {
 
   const now = new Date();
   // Compare civil dates as ordinals rather than measuring elapsed time between
-  // two local midnights. The components read here are already local; `Date.UTC`
-  // is only an encoder, and because UTC has no offset changes its result is an
-  // exact multiple of a day, so the difference is an exact integer. Measuring
-  // the gap between local midnights instead would carry that day's UTC offset
-  // shift into the quotient, which no amount of rounding fixes once an offset
-  // moves by more than half a day (a date-line change moves it by a full day).
-  const civilDay = (value: Date) =>
-    Date.UTC(value.getFullYear(), value.getMonth(), value.getDate()) / 86400000;
+  // two local midnights. Measuring that gap carries the day's UTC offset shift
+  // into the quotient, which no amount of rounding fixes once an offset moves
+  // by more than half a day — a date-line change moves it by a full day.
+  //
+  // The components read here are already local; the UTC epoch is only an
+  // encoder, and since UTC has no offset changes the result is an exact
+  // multiple of a day, so the difference is an exact integer everywhere.
+  // `Date.UTC` cannot be that encoder: it maps years 0-99 onto 1900-1999, so a
+  // year below 100 silently lands nearly 700,000 days away. `setUTCFullYear`
+  // applies no such mapping.
+  const civilDay = (value: Date) => {
+    const ordinal = new Date(0);
+    ordinal.setUTCFullYear(
+      value.getFullYear(),
+      value.getMonth(),
+      value.getDate(),
+    );
+    ordinal.setUTCHours(0, 0, 0, 0);
+    return ordinal.getTime() / 86400000;
+  };
   const diffDays = civilDay(now) - civilDay(date);
 
   if (diffDays < 7) {

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -39,13 +39,16 @@ export function formatRelativeDate(dateStr: string, locale?: string): string {
   if (Number.isNaN(date.getTime())) return "";
 
   const now = new Date();
-  const startOfDay = (value: Date) =>
-    new Date(
-      value.getFullYear(),
-      value.getMonth(),
-      value.getDate(),
-    ).getTime();
-  const diffDays = Math.round((startOfDay(now) - startOfDay(date)) / 86400000);
+  // Compare civil dates as ordinals rather than measuring elapsed time between
+  // two local midnights. The components read here are already local; `Date.UTC`
+  // is only an encoder, and because UTC has no offset changes its result is an
+  // exact multiple of a day, so the difference is an exact integer. Measuring
+  // the gap between local midnights instead would carry that day's UTC offset
+  // shift into the quotient, which no amount of rounding fixes once an offset
+  // moves by more than half a day (a date-line change moves it by a full day).
+  const civilDay = (value: Date) =>
+    Date.UTC(value.getFullYear(), value.getMonth(), value.getDate()) / 86400000;
+  const diffDays = civilDay(now) - civilDay(date);
 
   if (diffDays < 7) {
     return withLocaleFallback(locale, (resolvedLocale) =>

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -39,8 +39,13 @@ export function formatRelativeDate(dateStr: string, locale?: string): string {
   if (Number.isNaN(date.getTime())) return "";
 
   const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  const startOfDay = (value: Date) =>
+    new Date(
+      value.getFullYear(),
+      value.getMonth(),
+      value.getDate(),
+    ).getTime();
+  const diffDays = Math.round((startOfDay(now) - startOfDay(date)) / 86400000);
 
   if (diffDays < 7) {
     return withLocaleFallback(locale, (resolvedLocale) =>


### PR DESCRIPTION
Two independent fixes, cut together as **0.6.21**.

## Relative dates follow the caller's locale

`formatRelativeDate` and `formatDate` now take an optional locale and format
through the platform's `Intl` APIs, so relative terms are localized rather than
hardcoded English.

Behaviour change worth reading before you bump: omitting the locale still uses
the runtime default, but its **English output deliberately changes** from
capitalized abbreviations (`Today`, `3d ago`) to Intl's lowercase spelled-out
wording (`today`, `3 days ago`). Invalid dates now return an empty UI label,
invalid locale tags fall back to the runtime default, and future dates render as
relative text.

I grepped every consumer (`web-account`, `web-applications`, `ms-app-modules`) —
there are call sites but **no test asserts the old wording**, so nothing breaks
on bump. Consumers still call it without a locale, so they keep rendering in the
runtime default until they pass one; that's a follow-up, not a regression.

## AppShell's mobile bottom nav no longer forces full width

It was `w-full` below 640px and content-width from `sm` up, so the pill stretched
edge to edge on a phone and read as a bar welded across the viewport instead of
the floating pill it is on every wider screen. `max-w-full` caps it without
dictating a width, so a two-item nav stays narrow.

This also retires the `sm:!w-auto` `!important` that existed only to beat a
module bundle's injected global `.w-full` — with no `w-full` class on the
element, that rule has nothing to match.

## Release

`package.json` is at 0.6.21 and the CHANGELOG entry is written. This PR carries
the `release` label, so merging publishes the package.
