### PR TITLE
feat(popover): Popover + UserIdentityCard — 0.6.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 Notable API additions and breaking changes. For the full commit log, see
 [GitHub Releases](https://github.com/mirrorstack-ai/web-ui-kit/releases).
 
+## 0.6.22
+
+- **`Popover`** — a generic anchored overlay primitive. Opens on hover **and**
+  on focus, so it is reachable by keyboard rather than pointer-only, and closes
+  on Escape and on outside interaction.
+
+- **`UserIdentityCard`** — the standard way to render a person. Always shows
+  name, email and avatar together, and the name is a real link rather than a
+  span styled to look like one, so it survives middle-click, copy-link, and
+  assistive navigation.
+
+  Paired with `Popover`, this replaces the pattern of printing a bare actor
+  UUID in audit and provenance surfaces: show the person's name, and let the
+  card carry the detail on hover or focus.
+
 ## 0.6.21
 
 `AppShell`'s mobile bottom nav no longer forces full width below 640px. It was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,27 @@ Notable API additions and breaking changes. For the full commit log, see
 
 ## 0.6.22
 
-- **`Popover`** — a generic anchored overlay primitive. Opens on hover **and**
-  on focus, so it is reachable by keyboard rather than pointer-only, and closes
-  on Escape and on outside interaction.
+- **`Popover`** — a generic anchored overlay primitive. Hover and focus are
+  independent reasons for it to remain open, so leaving with the pointer does
+  not close a popover the keyboard still has focused. Escape and outside
+  interaction clear every open reason and close it immediately.
+
+  Click and tap activation are supported as well. On touch, the first tap
+  reveals the card and suppresses the trigger link's navigation; the second tap
+  follows the link. A mouse click opens the popover without ever suppressing
+  navigation, because mouse users can already preview the card by hovering.
+
+  React 18 is genuinely supported under the existing `react: ">=18"` peer
+  range. Positioning, focus restoration, and observation now use a
+  layout-neutral wrapper owned by `Popover`, rather than a ref injected into
+  the caller's element. A dedicated `react18` Vitest project runs the popover
+  against a real React 18 renderer so this cannot regress unseen.
 
 - **`UserIdentityCard`** — the standard way to render a person. Always shows
-  name, email and avatar together, and the name is a real link rather than a
-  span styled to look like one, so it survives middle-click, copy-link, and
-  assistive navigation.
+  name, email and avatar together. It now takes `href` and renders the anchor
+  itself instead of trusting the caller to pass one; both the trigger and the
+  name inside the card are real links, so they support middle-click, copy-link,
+  and assistive navigation.
 
   Paired with `Popover`, this replaces the pattern of printing a bare actor
   UUID in audit and provenance surfaces: show the person's name, and let the

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build-storybook": "storybook build",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
-    "test": "vitest run",
+    "test": "vitest run && vitest run -c vitest.react18.config.ts",
     "test:watch": "vitest"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,18 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(@types/debug@4.1.13)(@types/node@25.5.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
+  test/react18:
+    dependencies:
+      '@testing-library/react':
+        specifier: ^16.0.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react:
+        specifier: 18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: 18.3.1
+        version: 18.3.1(react@18.3.1)
+
 packages:
 
   '@adobe/css-tools@4.4.4':
@@ -1679,6 +1691,10 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -1996,6 +2012,11 @@ packages:
     resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
     engines: {node: ^20.9.0 || >=22}
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
   react-dom@19.2.4:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
@@ -2015,6 +2036,10 @@ packages:
     peerDependencies:
       '@types/react': '>=18'
       react: '>=18'
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -2080,6 +2105,9 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -3052,6 +3080,16 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -3984,6 +4022,10 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
@@ -4495,6 +4537,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -4526,6 +4574,10 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
 
   react@19.2.4: {}
 
@@ -4636,6 +4688,10 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   scheduler@0.27.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
+packages:
+  - "."
+  - "test/react18"
+
 overrides:
   '@babel/core@<=7.29.0': 7.29.6
   brace-expansion@>=5.0.0 <5.0.6: 5.0.7

--- a/src/components/ui/display/user-identity-card/UserIdentityCard.stories.tsx
+++ b/src/components/ui/display/user-identity-card/UserIdentityCard.stories.tsx
@@ -11,11 +11,7 @@ const meta: Meta<typeof UserIdentityCard> = {
     avatarUrl: "https://i.pravatar.cc/150?img=47",
     missingNameLabel: "Deleted user",
     missingEmailLabel: "Email unavailable",
-    children: (
-      <a className="font-medium text-primary underline" href="#ada-profile">
-        Ada Lovelace
-      </a>
-    ),
+    href: "#ada-profile",
   },
   decorators: [
     (Story) => (
@@ -42,11 +38,8 @@ export const DeletedUser: Story = {
     name: null,
     email: null,
     avatarUrl: null,
-    children: (
-      <a className="font-medium text-primary underline" href="#audit-entry">
-        2d7f52a1-830e-4b55-a224-6553bcb8f8dd
-      </a>
-    ),
+    href: "#audit-entry",
+    children: "2d7f52a1-830e-4b55-a224-6553bcb8f8dd",
   },
 };
 

--- a/src/components/ui/display/user-identity-card/UserIdentityCard.stories.tsx
+++ b/src/components/ui/display/user-identity-card/UserIdentityCard.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { UserIdentityCard } from "./UserIdentityCard";
+
+const meta: Meta<typeof UserIdentityCard> = {
+  title: "UI/Display/UserIdentityCard",
+  component: UserIdentityCard,
+  args: {
+    name: "Ada Lovelace",
+    email: "ada.lovelace@example.com",
+    avatarUrl: "https://i.pravatar.cc/150?img=47",
+    missingNameLabel: "Deleted user",
+    missingEmailLabel: "Email unavailable",
+    children: (
+      <a className="font-medium text-primary underline" href="#ada-profile">
+        Ada Lovelace
+      </a>
+    ),
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex min-h-[280px] items-center justify-center p-8">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof UserIdentityCard>;
+
+export const Playground: Story = {};
+
+export const InitialsFallback: Story = {
+  args: {
+    avatarUrl: null,
+  },
+};
+
+export const DeletedUser: Story = {
+  args: {
+    name: null,
+    email: null,
+    avatarUrl: null,
+    children: (
+      <a className="font-medium text-primary underline" href="#audit-entry">
+        2d7f52a1-830e-4b55-a224-6553bcb8f8dd
+      </a>
+    ),
+  },
+};
+
+export const LongIdentity: Story = {
+  args: {
+    name: "Alexandria-Cassandra Montgomery-Smythe the Third",
+    email: "alexandria-cassandra.montgomery-smythe@international.example",
+  },
+};

--- a/src/components/ui/display/user-identity-card/UserIdentityCard.test.tsx
+++ b/src/components/ui/display/user-identity-card/UserIdentityCard.test.tsx
@@ -10,30 +10,50 @@ function renderCard(
 ) {
   return render(
     <UserIdentityCard
+      href="/users/ada"
       name="Ada Lovelace"
       email="ada@example.com"
       avatarUrl="https://example.com/ada.jpg"
       missingNameLabel="Deleted user"
       missingEmailLabel="Email unavailable"
       {...props}
-    >
-      <a href="/users/ada">Ada profile</a>
-    </UserIdentityCard>,
+    />,
   );
 }
 
-function openCard() {
-  fireEvent.focus(screen.getByRole("link", { name: "Ada profile" }));
+function openCard(triggerName = "Ada Lovelace") {
+  fireEvent.focus(screen.getByRole("link", { name: triggerName }));
   return document.querySelector<HTMLElement>("[data-popover-content]")!;
 }
 
 describe("UserIdentityCard", () => {
-  it("uses the caller's children as the real profile trigger", () => {
+  it("renders its own trigger as a real link", () => {
     renderCard();
-    const trigger = screen.getByRole("link", { name: "Ada profile" });
 
-    expect(trigger).toHaveAttribute("href", "/users/ada");
-    expect(screen.getAllByRole("link")).toHaveLength(1);
+    expect(
+      screen.getByRole("link", { name: "Ada Lovelace" }),
+    ).toHaveAttribute("href", "/users/ada");
+  });
+
+  it("renders the name inside the card as a real link", () => {
+    renderCard();
+    const card = openCard();
+
+    expect(
+      within(card).getByRole("link", { name: "Ada Lovelace" }),
+    ).toHaveAttribute("href", "/users/ada");
+  });
+
+  it.each([
+    ["plain text", "Audit actor"],
+    ["an element", <span key="actor">Audit actor</span>],
+  ])("wraps %s children in its own trigger link", (_, children) => {
+    renderCard({ children });
+
+    expect(screen.getByRole("link", { name: "Audit actor" })).toHaveAttribute(
+      "href",
+      "/users/ada",
+    );
   });
 
   it("always shows avatar, display name, and email", () => {
@@ -65,7 +85,7 @@ describe("UserIdentityCard", () => {
 
   it("renders an honest caller-localized identity when the name is missing", () => {
     renderCard({ name: null, avatarUrl: null, missingNameLabel: "Former user" });
-    const card = openCard();
+    const card = openCard("Former user");
 
     expect(within(card).getByText("Former user")).toBeInTheDocument();
     expect(within(card).getByText("FOR")).toBeInTheDocument();
@@ -75,7 +95,7 @@ describe("UserIdentityCard", () => {
     const longName = "A very long display name that should never widen the card";
     const longEmail = "a-very-long-email-address@an-extremely-long-domain.example";
     renderCard({ name: longName, email: longEmail });
-    const card = openCard();
+    const card = openCard(longName);
 
     expect(within(card).getByText(longName)).toHaveClass("truncate");
     expect(within(card).getByText(longEmail)).toHaveClass("truncate");

--- a/src/components/ui/display/user-identity-card/UserIdentityCard.test.tsx
+++ b/src/components/ui/display/user-identity-card/UserIdentityCard.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { UserIdentityCard } from "./UserIdentityCard";
+
+afterEach(cleanup);
+
+function renderCard(
+  props: Partial<React.ComponentProps<typeof UserIdentityCard>> = {},
+) {
+  return render(
+    <UserIdentityCard
+      name="Ada Lovelace"
+      email="ada@example.com"
+      avatarUrl="https://example.com/ada.jpg"
+      missingNameLabel="Deleted user"
+      missingEmailLabel="Email unavailable"
+      {...props}
+    >
+      <a href="/users/ada">Ada profile</a>
+    </UserIdentityCard>,
+  );
+}
+
+function openCard() {
+  fireEvent.focus(screen.getByRole("link", { name: "Ada profile" }));
+  return document.querySelector<HTMLElement>("[data-popover-content]")!;
+}
+
+describe("UserIdentityCard", () => {
+  it("uses the caller's children as the real profile trigger", () => {
+    renderCard();
+    const trigger = screen.getByRole("link", { name: "Ada profile" });
+
+    expect(trigger).toHaveAttribute("href", "/users/ada");
+    expect(screen.getAllByRole("link")).toHaveLength(1);
+  });
+
+  it("always shows avatar, display name, and email", () => {
+    renderCard();
+    const card = openCard();
+
+    expect(within(card).getByText("Ada Lovelace")).toBeInTheDocument();
+    expect(within(card).getByText("ada@example.com")).toBeInTheDocument();
+    expect(card.querySelector("img")).toHaveAttribute(
+      "src",
+      "https://example.com/ada.jpg",
+    );
+  });
+
+  it("falls back through Avatar when no avatar URL is available", () => {
+    renderCard({ avatarUrl: null });
+    const card = openCard();
+
+    expect(within(card).getByText("ADA")).toBeInTheDocument();
+    expect(card.querySelector("img")).not.toBeInTheDocument();
+  });
+
+  it("renders the caller-localized missing-email label when email is absent", () => {
+    renderCard({ email: null, missingEmailLabel: "No email on record" });
+    const card = openCard();
+
+    expect(within(card).getByText("No email on record")).toBeInTheDocument();
+  });
+
+  it("renders an honest caller-localized identity when the name is missing", () => {
+    renderCard({ name: null, avatarUrl: null, missingNameLabel: "Former user" });
+    const card = openCard();
+
+    expect(within(card).getByText("Former user")).toBeInTheDocument();
+    expect(within(card).getByText("FOR")).toBeInTheDocument();
+  });
+
+  it("truncates long names and email addresses", () => {
+    const longName = "A very long display name that should never widen the card";
+    const longEmail = "a-very-long-email-address@an-extremely-long-domain.example";
+    renderCard({ name: longName, email: longEmail });
+    const card = openCard();
+
+    expect(within(card).getByText(longName)).toHaveClass("truncate");
+    expect(within(card).getByText(longEmail)).toHaveClass("truncate");
+    expect(card).toHaveClass("w-72");
+  });
+});

--- a/src/components/ui/display/user-identity-card/UserIdentityCard.tsx
+++ b/src/components/ui/display/user-identity-card/UserIdentityCard.tsx
@@ -1,22 +1,21 @@
-import type { ReactElement } from "react";
+import type { ReactNode } from "react";
 
 import { Avatar } from "@/components/ui/media/avatar/Avatar";
-import {
-  Popover,
-  type PopoverProps,
-} from "@/components/ui/surfaces/popover/Popover";
+import { Popover } from "@/components/ui/surfaces/popover/Popover";
 import type { ComponentMeta } from "@/types/component-meta";
 import { cn } from "@/utils/cn";
 
 export const meta: ComponentMeta = {
   name: "UserIdentityCard",
   description:
-    "Hover/focus identity card on a caller-owned trigger, always showing the user's avatar, display name, and email. This identity card always renders the user's email, so it belongs on operator-facing surfaces and placing it where an end user can see another user's contact details is a deliberate choice.",
+    "Hover/focus identity card with a component-owned profile link for both its trigger and display name, always showing the user's avatar, display name, and email. This identity card always renders the user's email, so it belongs on operator-facing surfaces and placing it where an end user can see another user's contact details is a deliberate choice.",
 };
 
 export interface UserIdentityCardProps {
-  /** The caller-owned trigger, normally a link to the user's full profile. */
-  children: ReactElement;
+  /** Destination for the trigger link and for the name inside the card. */
+  href: string;
+  /** Trigger link content. Defaults to the display name. */
+  children?: ReactNode;
   name?: string | null;
   email?: string | null;
   avatarUrl?: string | null;
@@ -24,18 +23,22 @@ export interface UserIdentityCardProps {
   missingNameLabel: string;
   /** Already-localized text shown when the user's email is unavailable. */
   missingEmailLabel: string;
+  /** Applied to the trigger link. */
+  triggerClassName?: string;
   /** Applied to the identity card surface. */
   className?: string;
 }
 
 /** This identity card always renders the user's email, so it belongs on operator-facing surfaces and placing it where an end user can see another user's contact details is a deliberate choice. */
 export function UserIdentityCard({
+  href,
   children,
   name,
   email,
   avatarUrl,
   missingNameLabel,
   missingEmailLabel,
+  triggerClassName,
   className,
 }: UserIdentityCardProps) {
   const displayName = name?.trim() || missingNameLabel;
@@ -43,7 +46,17 @@ export function UserIdentityCard({
 
   return (
     <Popover
-      trigger={children as PopoverProps["trigger"]}
+      trigger={
+        <a
+          href={href}
+          className={cn(
+            "font-medium text-primary underline underline-offset-2",
+            triggerClassName,
+          )}
+        >
+          {children ?? displayName}
+        </a>
+      }
       className={cn(
         "w-72 rounded-xl border border-outline-variant bg-surface-container-low p-3 shadow-lg",
         className,
@@ -52,9 +65,12 @@ export function UserIdentityCard({
       <div className="flex min-w-0 items-center gap-3">
         <Avatar src={avatarUrl} fallback={displayName} size="lg" />
         <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-semibold text-on-surface">
+          <a
+            href={href}
+            className="block truncate text-sm font-semibold text-on-surface"
+          >
             {displayName}
-          </p>
+          </a>
           <p className="truncate text-xs text-on-surface-variant">
             {displayEmail}
           </p>

--- a/src/components/ui/display/user-identity-card/UserIdentityCard.tsx
+++ b/src/components/ui/display/user-identity-card/UserIdentityCard.tsx
@@ -1,0 +1,65 @@
+import type { ReactElement } from "react";
+
+import { Avatar } from "@/components/ui/media/avatar/Avatar";
+import {
+  Popover,
+  type PopoverProps,
+} from "@/components/ui/surfaces/popover/Popover";
+import type { ComponentMeta } from "@/types/component-meta";
+import { cn } from "@/utils/cn";
+
+export const meta: ComponentMeta = {
+  name: "UserIdentityCard",
+  description:
+    "Hover/focus identity card on a caller-owned trigger, always showing the user's avatar, display name, and email. This identity card always renders the user's email, so it belongs on operator-facing surfaces and placing it where an end user can see another user's contact details is a deliberate choice.",
+};
+
+export interface UserIdentityCardProps {
+  /** The caller-owned trigger, normally a link to the user's full profile. */
+  children: ReactElement;
+  name?: string | null;
+  email?: string | null;
+  avatarUrl?: string | null;
+  /** Already-localized text shown when the user's name is unavailable. */
+  missingNameLabel: string;
+  /** Already-localized text shown when the user's email is unavailable. */
+  missingEmailLabel: string;
+  /** Applied to the identity card surface. */
+  className?: string;
+}
+
+/** This identity card always renders the user's email, so it belongs on operator-facing surfaces and placing it where an end user can see another user's contact details is a deliberate choice. */
+export function UserIdentityCard({
+  children,
+  name,
+  email,
+  avatarUrl,
+  missingNameLabel,
+  missingEmailLabel,
+  className,
+}: UserIdentityCardProps) {
+  const displayName = name?.trim() || missingNameLabel;
+  const displayEmail = email?.trim() || missingEmailLabel;
+
+  return (
+    <Popover
+      trigger={children as PopoverProps["trigger"]}
+      className={cn(
+        "w-72 rounded-xl border border-outline-variant bg-surface-container-low p-3 shadow-lg",
+        className,
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-3">
+        <Avatar src={avatarUrl} fallback={displayName} size="lg" />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-semibold text-on-surface">
+            {displayName}
+          </p>
+          <p className="truncate text-xs text-on-surface-variant">
+            {displayEmail}
+          </p>
+        </div>
+      </div>
+    </Popover>
+  );
+}

--- a/src/components/ui/surfaces/popover/Popover.react18.test.tsx
+++ b/src/components/ui/surfaces/popover/Popover.react18.test.tsx
@@ -1,0 +1,49 @@
+// The dedicated react18 Vitest project runs this file against the real React 18
+// renderer so Popover cannot silently regress to relying on React 19 ref props.
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { version } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Button } from "@/components/ui/actions/button/Button";
+
+import { Popover } from "./Popover";
+
+afterEach(cleanup);
+
+function expectVisibleAndPositioned() {
+  const content = document.querySelector<HTMLElement>("[data-popover-content]")!;
+  expect(content.style.visibility).toBe("visible");
+  expect(content.style.top).not.toBe("");
+}
+
+describe("Popover on React 18", () => {
+  it("uses the React 18 renderer", () => {
+    expect(version.startsWith("18.")).toBe(true);
+  });
+
+  it("positions from the kit's plain-function Button", () => {
+    render(
+      <Popover trigger={<Button variant="filled">Person</Button>}>
+        <div>Identity details</div>
+      </Popover>,
+    );
+
+    fireEvent.focus(screen.getByRole("button", { name: "Person" }));
+    expectVisibleAndPositioned();
+  });
+
+  it("does not depend on the trigger accepting injected props", () => {
+    function Plain() {
+      return <button type="button">Person</button>;
+    }
+
+    render(
+      <Popover trigger={<Plain />}>
+        <div>Identity details</div>
+      </Popover>,
+    );
+
+    fireEvent.focus(screen.getByRole("button", { name: "Person" }));
+    expectVisibleAndPositioned();
+  });
+});

--- a/src/components/ui/surfaces/popover/Popover.stories.tsx
+++ b/src/components/ui/surfaces/popover/Popover.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Button } from "@/components/ui/actions/button/Button";
+
+import { Popover } from "./Popover";
+
+const meta: Meta<typeof Popover> = {
+  title: "UI/Surfaces/Popover",
+  component: Popover,
+  args: {
+    trigger: <Button variant="filled">Hover or focus me</Button>,
+    children: (
+      <div className="w-64 rounded-xl border border-outline-variant bg-surface-container-low p-4 shadow-lg">
+        <p className="font-medium text-on-surface">Arbitrary content</p>
+        <p className="mt-1 text-sm text-on-surface-variant">
+          This layer is not limited to a list of actions.
+        </p>
+      </div>
+    ),
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex min-h-[280px] items-center justify-center p-8">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Popover>;
+
+export const Playground: Story = {};
+
+export const InteractiveContent: Story = {
+  args: {
+    trigger: <a href="#profile">Account details</a>,
+    children: (
+      <div className="w-64 rounded-xl border border-outline-variant bg-surface-container-low p-4 shadow-lg">
+        <p className="text-sm text-on-surface">The popover does not trap focus.</p>
+        <Button className="mt-3" size="sm">
+          Secondary action
+        </Button>
+      </div>
+    ),
+  },
+};
+
+export const NearViewportEdge: Story = {
+  decorators: [
+    (Story) => (
+      <div className="flex min-h-[280px] items-end justify-end p-2">
+        <Story />
+      </div>
+    ),
+  ],
+};

--- a/src/components/ui/surfaces/popover/Popover.stories.tsx
+++ b/src/components/ui/surfaces/popover/Popover.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta<typeof Popover> = {
   title: "UI/Surfaces/Popover",
   component: Popover,
   args: {
-    trigger: <Button variant="filled">Hover or focus me</Button>,
+    trigger: <Button variant="filled">Hover, focus, or tap me</Button>,
     children: (
       <div className="w-64 rounded-xl border border-outline-variant bg-surface-container-low p-4 shadow-lg">
         <p className="font-medium text-on-surface">Arbitrary content</p>
@@ -37,7 +37,10 @@ export const InteractiveContent: Story = {
     trigger: <a href="#profile">Account details</a>,
     children: (
       <div className="w-64 rounded-xl border border-outline-variant bg-surface-container-low p-4 shadow-lg">
-        <p className="text-sm text-on-surface">The popover does not trap focus.</p>
+        <p className="text-sm text-on-surface">
+          The popover does not trap focus. On touch, the first tap reveals this
+          card and the second follows the profile link.
+        </p>
         <Button className="mt-3" size="sm">
           Secondary action
         </Button>

--- a/src/components/ui/surfaces/popover/Popover.test.tsx
+++ b/src/components/ui/surfaces/popover/Popover.test.tsx
@@ -153,18 +153,73 @@ describe("Popover", () => {
     const trigger = screen.getByRole("link", { name: "Ada" });
 
     fireEvent.pointerDown(trigger, { pointerType: "touch" });
-    const firstClick = createEvent.click(trigger);
+    const firstClick = createEvent.click(trigger, { detail: 1 });
     fireEvent(trigger, firstClick);
 
     expect(firstClick.defaultPrevented).toBe(true);
     expect(screen.getByText("Identity details")).toBeInTheDocument();
 
     fireEvent.pointerDown(trigger, { pointerType: "touch" });
-    const secondClick = createEvent.click(trigger);
+    const secondClick = createEvent.click(trigger, { detail: 1 });
     fireEvent(trigger, secondClick);
 
     expect(secondClick.defaultPrevented).toBe(false);
     expect(screen.getByText("Identity details")).toBeInTheDocument();
+  });
+
+  it("reveals before a touch trigger handler can route", () => {
+    const route = vi.fn();
+    render(
+      <Popover
+        trigger={
+          <a
+            href="/users/ada"
+            onClick={(event) => {
+              event.preventDefault();
+              route();
+            }}
+          >
+            Ada
+          </a>
+        }
+      >
+        <div>Identity details</div>
+      </Popover>,
+    );
+    const trigger = screen.getByRole("link", { name: "Ada" });
+
+    fireEvent.pointerDown(trigger, { pointerType: "touch" });
+    fireEvent.pointerUp(trigger, { pointerType: "touch" });
+    const firstClick = createEvent.click(trigger, { detail: 1 });
+    fireEvent(trigger, firstClick);
+
+    expect(firstClick.defaultPrevented).toBe(true);
+    expect(route).not.toHaveBeenCalled();
+    expect(screen.getByText("Identity details")).toBeInTheDocument();
+  });
+
+  it("allows keyboard activation after a canceled touch pointer", () => {
+    const route = vi.fn();
+    render(
+      <Popover
+        trigger={
+          <a href="/users/ada" onClick={route}>
+            Ada
+          </a>
+        }
+      >
+        <div>Identity details</div>
+      </Popover>,
+    );
+    const trigger = screen.getByRole("link", { name: "Ada" });
+
+    fireEvent.pointerDown(trigger, { pointerType: "touch" });
+    fireEvent.pointerCancel(trigger, { pointerType: "touch" });
+    const keyboardClick = createEvent.click(trigger, { detail: 0 });
+    fireEvent(trigger, keyboardClick);
+
+    expect(keyboardClick.defaultPrevented).toBe(false);
+    expect(route).toHaveBeenCalledOnce();
   });
 
   it("never prevents a mouse click", () => {

--- a/src/components/ui/surfaces/popover/Popover.test.tsx
+++ b/src/components/ui/surfaces/popover/Popover.test.tsx
@@ -1,0 +1,220 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Popover } from "./Popover";
+
+const CLOSE_DELAY_MS = 150;
+
+function rect({
+  bottom,
+  height,
+  left,
+  right,
+  top,
+  width,
+}: {
+  bottom: number;
+  height: number;
+  left: number;
+  right: number;
+  top: number;
+  width: number;
+}): DOMRect {
+  return {
+    bottom,
+    height,
+    left,
+    right,
+    top,
+    width,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  };
+}
+
+function renderPopover() {
+  return render(
+    <Popover trigger={<button type="button">Person</button>}>
+      <div>Identity details</div>
+    </Popover>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("Popover", () => {
+  it("opens on hover and closes after mouse leave", () => {
+    vi.useFakeTimers();
+    renderPopover();
+    const trigger = screen.getByRole("button", { name: "Person" });
+
+    fireEvent.mouseEnter(trigger);
+    expect(screen.getByText("Identity details")).toBeInTheDocument();
+
+    fireEvent.mouseLeave(trigger);
+    act(() => vi.advanceTimersByTime(CLOSE_DELAY_MS));
+    expect(screen.queryByText("Identity details")).not.toBeInTheDocument();
+  });
+
+  it("opens on keyboard focus and closes when focus leaves", () => {
+    renderPopover();
+    const trigger = screen.getByRole("button", { name: "Person" });
+    const outside = document.createElement("button");
+    document.body.append(outside);
+
+    fireEvent.focus(trigger);
+    expect(screen.getByText("Identity details")).toBeInTheDocument();
+    fireEvent.blur(trigger, { relatedTarget: outside });
+    expect(screen.queryByText("Identity details")).not.toBeInTheDocument();
+    outside.remove();
+  });
+
+  it("opens on click for touch and pointer activation", () => {
+    renderPopover();
+
+    fireEvent.click(screen.getByRole("button", { name: "Person" }));
+
+    expect(screen.getByText("Identity details")).toBeInTheDocument();
+  });
+
+  it("keeps the content open when the pointer enters it before the close delay", () => {
+    vi.useFakeTimers();
+    renderPopover();
+    const trigger = screen.getByRole("button", { name: "Person" });
+
+    fireEvent.mouseEnter(trigger);
+    const content = screen.getByText("Identity details").parentElement!;
+    fireEvent.mouseLeave(trigger);
+    act(() => vi.advanceTimersByTime(CLOSE_DELAY_MS - 25));
+    fireEvent.mouseEnter(content);
+    act(() => vi.advanceTimersByTime(CLOSE_DELAY_MS));
+
+    expect(screen.getByText("Identity details")).toBeInTheDocument();
+  });
+
+  it("closes on Escape and returns focus from content to the trigger", () => {
+    render(
+      <Popover trigger={<button type="button">Person</button>}>
+        <button type="button">Card action</button>
+      </Popover>,
+    );
+    const trigger = screen.getByRole("button", { name: "Person" });
+    fireEvent.focus(trigger);
+    const action = screen.getByRole("button", { name: "Card action" });
+    action.focus();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("button", { name: "Card action" })).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("closes on an outside click", () => {
+    renderPopover();
+    fireEvent.focus(screen.getByRole("button", { name: "Person" }));
+    expect(screen.getByText("Identity details")).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByText("Identity details")).not.toBeInTheDocument();
+  });
+
+  it("renders the floating content in a body portal", () => {
+    const { container } = renderPopover();
+    fireEvent.focus(screen.getByRole("button", { name: "Person" }));
+    const content = document.querySelector<HTMLElement>("[data-popover-content]")!;
+
+    expect(document.body).toContainElement(content);
+    expect(container).not.toContainElement(content);
+  });
+
+  it("does not trap focus or intercept Tab", () => {
+    render(
+      <Popover trigger={<button type="button">Person</button>}>
+        <button type="button">Card action</button>
+      </Popover>,
+    );
+    fireEvent.focus(screen.getByRole("button", { name: "Person" }));
+    const action = screen.getByRole("button", { name: "Card action" });
+    const tab = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+    });
+
+    action.dispatchEvent(tab);
+    expect(tab.defaultPrevented).toBe(false);
+  });
+
+  it("associates the trigger with content exactly once", () => {
+    renderPopover();
+    const trigger = screen.getByRole("button", { name: "Person" });
+    fireEvent.focus(trigger);
+    const content = document.querySelector<HTMLElement>("[data-popover-content]")!;
+
+    expect(trigger).toHaveAttribute("aria-describedby", content.id);
+    expect(trigger.getAttribute("aria-describedby")?.split(" ")).toEqual([
+      content.id,
+    ]);
+    expect(content).not.toHaveAttribute("role");
+    expect(content).not.toHaveAttribute("aria-live");
+  });
+
+  it("flips above and clamps horizontally near viewport edges", () => {
+    const originalInnerWidth = window.innerWidth;
+    const originalInnerHeight = window.innerHeight;
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 320,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 200,
+    });
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        if (this.hasAttribute("data-popover-content")) {
+          return rect({
+            bottom: 100,
+            height: 100,
+            left: 0,
+            right: 160,
+            top: 0,
+            width: 160,
+          });
+        }
+        return rect({
+          bottom: 194,
+          height: 24,
+          left: 290,
+          right: 314,
+          top: 170,
+          width: 24,
+        });
+      },
+    );
+
+    try {
+      renderPopover();
+      fireEvent.focus(screen.getByRole("button", { name: "Person" }));
+      const content = document.querySelector<HTMLElement>("[data-popover-content]")!;
+
+      expect(content).toHaveAttribute("data-placement", "top");
+      expect(content.style.left).toBe("152px");
+      expect(content.style.top).toBe("62px");
+    } finally {
+      Object.defineProperty(window, "innerWidth", {
+        configurable: true,
+        value: originalInnerWidth,
+      });
+      Object.defineProperty(window, "innerHeight", {
+        configurable: true,
+        value: originalInnerHeight,
+      });
+    }
+  });
+});

--- a/src/components/ui/surfaces/popover/Popover.test.tsx
+++ b/src/components/ui/surfaces/popover/Popover.test.tsx
@@ -1,9 +1,40 @@
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  act,
+  cleanup,
+  createEvent,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { Popover } from "./Popover";
 
 const CLOSE_DELAY_MS = 150;
+const originalPointerEvent = window.PointerEvent;
+
+class TestPointerEvent extends MouseEvent {
+  readonly pointerType: string;
+
+  constructor(type: string, init: PointerEventInit = {}) {
+    super(type, init);
+    this.pointerType = init.pointerType ?? "";
+  }
+}
+
+beforeAll(() => {
+  Object.defineProperty(window, "PointerEvent", {
+    configurable: true,
+    value: TestPointerEvent,
+  });
+});
+
+afterAll(() => {
+  Object.defineProperty(window, "PointerEvent", {
+    configurable: true,
+    value: originalPointerEvent,
+  });
+});
 
 function rect({
   bottom,
@@ -74,11 +105,81 @@ describe("Popover", () => {
     outside.remove();
   });
 
+  it("stays open when the pointer leaves while the trigger still has focus", () => {
+    vi.useFakeTimers();
+    renderPopover();
+    const trigger = screen.getByRole("button", { name: "Person" });
+
+    fireEvent.focus(trigger);
+    fireEvent.mouseEnter(trigger);
+    fireEvent.mouseLeave(trigger);
+    act(() => vi.advanceTimersByTime(CLOSE_DELAY_MS + 1));
+
+    expect(screen.getByText("Identity details")).toBeInTheDocument();
+  });
+
+  it("stays open when focus leaves while the pointer is still over it", () => {
+    vi.useFakeTimers();
+    renderPopover();
+    const trigger = screen.getByRole("button", { name: "Person" });
+    const outside = document.createElement("button");
+    document.body.append(outside);
+
+    fireEvent.mouseEnter(trigger);
+    fireEvent.focus(trigger);
+    fireEvent.blur(trigger, { relatedTarget: outside });
+    expect(screen.getByText("Identity details")).toBeInTheDocument();
+
+    fireEvent.mouseLeave(trigger);
+    act(() => vi.advanceTimersByTime(CLOSE_DELAY_MS + 1));
+    expect(screen.queryByText("Identity details")).not.toBeInTheDocument();
+    outside.remove();
+  });
+
   it("opens on click for touch and pointer activation", () => {
     renderPopover();
 
     fireEvent.click(screen.getByRole("button", { name: "Person" }));
 
+    expect(screen.getByText("Identity details")).toBeInTheDocument();
+  });
+
+  it("reveals on the first touch tap and allows the second tap to navigate", () => {
+    render(
+      <Popover trigger={<a href="/users/ada">Ada</a>}>
+        <div>Identity details</div>
+      </Popover>,
+    );
+    const trigger = screen.getByRole("link", { name: "Ada" });
+
+    fireEvent.pointerDown(trigger, { pointerType: "touch" });
+    const firstClick = createEvent.click(trigger);
+    fireEvent(trigger, firstClick);
+
+    expect(firstClick.defaultPrevented).toBe(true);
+    expect(screen.getByText("Identity details")).toBeInTheDocument();
+
+    fireEvent.pointerDown(trigger, { pointerType: "touch" });
+    const secondClick = createEvent.click(trigger);
+    fireEvent(trigger, secondClick);
+
+    expect(secondClick.defaultPrevented).toBe(false);
+    expect(screen.getByText("Identity details")).toBeInTheDocument();
+  });
+
+  it("never prevents a mouse click", () => {
+    render(
+      <Popover trigger={<a href="/users/ada">Ada</a>}>
+        <div>Identity details</div>
+      </Popover>,
+    );
+    const trigger = screen.getByRole("link", { name: "Ada" });
+
+    fireEvent.pointerDown(trigger, { pointerType: "mouse" });
+    const click = createEvent.click(trigger);
+    fireEvent(trigger, click);
+
+    expect(click.defaultPrevented).toBe(false);
     expect(screen.getByText("Identity details")).toBeInTheDocument();
   });
 

--- a/src/components/ui/surfaces/popover/Popover.tsx
+++ b/src/components/ui/surfaces/popover/Popover.tsx
@@ -1,0 +1,295 @@
+import {
+  cloneElement,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type FocusEventHandler,
+  type MouseEventHandler,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+} from "react";
+import { createPortal } from "react-dom";
+
+import { useClickOutside } from "@/hooks/useClickOutside";
+import type { ComponentMeta } from "@/types/component-meta";
+import { cn } from "@/utils/cn";
+import { isDev } from "@/utils/env";
+
+export const meta: ComponentMeta = {
+  name: "Popover",
+  description:
+    "Non-modal floating content anchored to a caller-provided trigger, with hover, focus, and viewport collision handling",
+};
+
+const VIEWPORT_PADDING = 8;
+const TRIGGER_GAP = 8;
+const CLOSE_DELAY_MS = 150;
+
+type Placement = "top" | "bottom";
+
+interface PopoverTriggerProps {
+  ref?: Ref<HTMLElement>;
+  "aria-describedby"?: string;
+  onBlur?: FocusEventHandler<HTMLElement>;
+  onClick?: MouseEventHandler<HTMLElement>;
+  onFocus?: FocusEventHandler<HTMLElement>;
+  onMouseEnter?: MouseEventHandler<HTMLElement>;
+  onMouseLeave?: MouseEventHandler<HTMLElement>;
+}
+
+export interface PopoverProps {
+  /** The caller-owned interactive element that anchors the floating content. */
+  trigger: ReactElement<PopoverTriggerProps>;
+  /** Arbitrary content rendered in the floating layer. */
+  children: ReactNode;
+  /** Applied to the portaled floating content. */
+  className?: string;
+}
+
+interface PopoverPosition {
+  left: number;
+  placement: Placement;
+  top: number;
+}
+
+function assignRef<T>(ref: Ref<T> | undefined, value: T | null) {
+  if (typeof ref === "function") {
+    ref(value);
+  } else if (ref) {
+    ref.current = value;
+  }
+}
+
+function isInside(
+  target: EventTarget | null,
+  ...elements: Array<HTMLElement | null>
+) {
+  return target instanceof Node && elements.some((element) => element?.contains(target));
+}
+
+export function Popover({ trigger, children, className }: PopoverProps) {
+  const contentId = useId();
+  const triggerRef = useRef<HTMLElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const closeTimerRef = useRef<number | null>(null);
+  const ignoreNextFocusRef = useRef(false);
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState<PopoverPosition | null>(null);
+  const hasContent = children != null;
+
+  useEffect(() => {
+    if (isDev && !hasContent) {
+      console.warn("[Popover] children must contain the floating content.");
+    }
+  }, [hasContent]);
+
+  const clearCloseTimer = useCallback(() => {
+    if (closeTimerRef.current != null) {
+      window.clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  const openPopover = useCallback(() => {
+    if (!hasContent) return;
+    clearCloseTimer();
+    setOpen(true);
+  }, [clearCloseTimer, hasContent]);
+
+  const closePopover = useCallback(
+    (restoreFocus = false) => {
+      clearCloseTimer();
+      setOpen(false);
+      setPosition(null);
+
+      if (restoreFocus && contentRef.current?.contains(document.activeElement)) {
+        ignoreNextFocusRef.current = true;
+        triggerRef.current?.focus();
+      }
+    },
+    [clearCloseTimer],
+  );
+
+  const scheduleClose = useCallback(() => {
+    clearCloseTimer();
+    closeTimerRef.current = window.setTimeout(() => {
+      closeTimerRef.current = null;
+      closePopover();
+    }, CLOSE_DELAY_MS);
+  }, [clearCloseTimer, closePopover]);
+
+  const updatePosition = useCallback(() => {
+    const triggerElement = triggerRef.current;
+    const contentElement = contentRef.current;
+    if (!triggerElement || !contentElement) return;
+
+    const triggerRect = triggerElement.getBoundingClientRect();
+    const contentRect = contentElement.getBoundingClientRect();
+    const maxLeft = Math.max(
+      VIEWPORT_PADDING,
+      window.innerWidth - contentRect.width - VIEWPORT_PADDING,
+    );
+    const centeredLeft =
+      triggerRect.left + triggerRect.width / 2 - contentRect.width / 2;
+    const left = Math.min(Math.max(centeredLeft, VIEWPORT_PADDING), maxLeft);
+    const bottomTop = triggerRect.bottom + TRIGGER_GAP;
+    const roomBelow = window.innerHeight - VIEWPORT_PADDING - bottomTop;
+    const roomAbove = triggerRect.top - TRIGGER_GAP - VIEWPORT_PADDING;
+    const placement: Placement =
+      contentRect.height > roomBelow && roomAbove > roomBelow ? "top" : "bottom";
+    const requestedTop =
+      placement === "top"
+        ? triggerRect.top - TRIGGER_GAP - contentRect.height
+        : bottomTop;
+    const maxTop = Math.max(
+      VIEWPORT_PADDING,
+      window.innerHeight - contentRect.height - VIEWPORT_PADDING,
+    );
+    const top = Math.min(Math.max(requestedTop, VIEWPORT_PADDING), maxTop);
+
+    // Prefer below, flip above when it has more usable room, then clamp both
+    // axes. This keeps the layer on-screen without a dependency and behaves
+    // predictably even when neither side can fit the content at full height.
+    setPosition({ left, placement, top });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    updatePosition();
+  }, [open, children, updatePosition]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    const update = () => updatePosition();
+    window.addEventListener("resize", update);
+    window.addEventListener("scroll", update, true);
+
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(() => updatePosition());
+    if (triggerRef.current) resizeObserver?.observe(triggerRef.current);
+    if (contentRef.current) resizeObserver?.observe(contentRef.current);
+
+    return () => {
+      window.removeEventListener("resize", update);
+      window.removeEventListener("scroll", update, true);
+      resizeObserver?.disconnect();
+    };
+  }, [open, updatePosition]);
+
+  useEffect(() => clearCloseTimer, [clearCloseTimer]);
+
+  useClickOutside({
+    refs: [triggerRef, contentRef],
+    enabled: open,
+    closeOnEscape: false,
+    onDismiss: () => closePopover(),
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") closePopover(true);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [closePopover, open]);
+
+  if (!isValidElement(trigger)) return null;
+
+  const originalProps = trigger.props;
+  const describedBy = [
+    originalProps["aria-describedby"],
+    hasContent ? contentId : undefined,
+  ]
+    .filter(Boolean)
+    .join(" ") || undefined;
+
+  const triggerElement = cloneElement(trigger, {
+    ref: (node: HTMLElement | null) => {
+      triggerRef.current = node;
+      assignRef(originalProps.ref, node);
+    },
+    "aria-describedby": describedBy,
+    onBlur: (event) => {
+      originalProps.onBlur?.(event);
+      if (
+        !isInside(event.relatedTarget, triggerRef.current, contentRef.current)
+      ) {
+        closePopover();
+      }
+    },
+    onClick: (event) => {
+      originalProps.onClick?.(event);
+      openPopover();
+    },
+    onFocus: (event) => {
+      originalProps.onFocus?.(event);
+      if (ignoreNextFocusRef.current) {
+        ignoreNextFocusRef.current = false;
+        return;
+      }
+      openPopover();
+    },
+    onMouseEnter: (event) => {
+      originalProps.onMouseEnter?.(event);
+      openPopover();
+    },
+    onMouseLeave: (event) => {
+      originalProps.onMouseLeave?.(event);
+      scheduleClose();
+    },
+  });
+
+  const content =
+    open && hasContent && typeof document !== "undefined"
+      ? createPortal(
+          <div
+            ref={contentRef}
+            id={contentId}
+            data-popover-content=""
+            data-placement={position?.placement}
+            className={cn(
+              "fixed z-[70] max-h-[calc(100vh-1rem)] max-w-[calc(100vw-1rem)] overflow-auto",
+              className,
+            )}
+            style={{
+              left: position?.left ?? VIEWPORT_PADDING,
+              top: position?.top ?? VIEWPORT_PADDING,
+              visibility: position ? "visible" : "hidden",
+            }}
+            onBlur={(event) => {
+              if (
+                !isInside(
+                  event.relatedTarget,
+                  triggerRef.current,
+                  contentRef.current,
+                )
+              ) {
+                closePopover();
+              }
+            }}
+            onFocus={clearCloseTimer}
+            onMouseEnter={clearCloseTimer}
+            onMouseLeave={scheduleClose}
+          >
+            {children}
+          </div>,
+          document.body,
+        )
+      : null;
+
+  return (
+    <>
+      {triggerElement}
+      {content}
+    </>
+  );
+}

--- a/src/components/ui/surfaces/popover/Popover.tsx
+++ b/src/components/ui/surfaces/popover/Popover.tsx
@@ -7,11 +7,8 @@ import {
   useLayoutEffect,
   useRef,
   useState,
-  type FocusEventHandler,
-  type MouseEventHandler,
   type ReactElement,
   type ReactNode,
-  type Ref,
 } from "react";
 import { createPortal } from "react-dom";
 
@@ -33,13 +30,7 @@ const CLOSE_DELAY_MS = 150;
 type Placement = "top" | "bottom";
 
 interface PopoverTriggerProps {
-  ref?: Ref<HTMLElement>;
   "aria-describedby"?: string;
-  onBlur?: FocusEventHandler<HTMLElement>;
-  onClick?: MouseEventHandler<HTMLElement>;
-  onFocus?: FocusEventHandler<HTMLElement>;
-  onMouseEnter?: MouseEventHandler<HTMLElement>;
-  onMouseLeave?: MouseEventHandler<HTMLElement>;
 }
 
 export interface PopoverProps {
@@ -57,13 +48,7 @@ interface PopoverPosition {
   top: number;
 }
 
-function assignRef<T>(ref: Ref<T> | undefined, value: T | null) {
-  if (typeof ref === "function") {
-    ref(value);
-  } else if (ref) {
-    ref.current = value;
-  }
-}
+type OpenReason = "focus" | "hover" | "tap";
 
 function isInside(
   target: EventTarget | null,
@@ -74,19 +59,40 @@ function isInside(
 
 export function Popover({ trigger, children, className }: PopoverProps) {
   const contentId = useId();
-  const triggerRef = useRef<HTMLElement>(null);
+  const wrapperRef = useRef<HTMLSpanElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const closeTimerRef = useRef<number | null>(null);
   const ignoreNextFocusRef = useRef(false);
+  const openReasonsRef = useRef<Record<OpenReason, boolean>>({
+    focus: false,
+    hover: false,
+    tap: false,
+  });
+  const lastPointerTypeRef = useRef<string | null>(null);
+  const revealedByTouchRef = useRef(false);
   const [open, setOpen] = useState(false);
   const [position, setPosition] = useState<PopoverPosition | null>(null);
   const hasContent = children != null;
+
+  const getAnchor = useCallback(
+    () =>
+      (wrapperRef.current?.firstElementChild as HTMLElement | null) ?? null,
+    [],
+  );
 
   useEffect(() => {
     if (isDev && !hasContent) {
       console.warn("[Popover] children must contain the floating content.");
     }
   }, [hasContent]);
+
+  useEffect(() => {
+    if (isDev && !getAnchor()) {
+      console.warn(
+        "[Popover] trigger must render an element so the floating content can be positioned.",
+      );
+    }
+  }, [getAnchor, trigger]);
 
   const clearCloseTimer = useCallback(() => {
     if (closeTimerRef.current != null) {
@@ -104,15 +110,18 @@ export function Popover({ trigger, children, className }: PopoverProps) {
   const closePopover = useCallback(
     (restoreFocus = false) => {
       clearCloseTimer();
+      openReasonsRef.current = { focus: false, hover: false, tap: false };
+      revealedByTouchRef.current = false;
+      lastPointerTypeRef.current = null;
       setOpen(false);
       setPosition(null);
 
       if (restoreFocus && contentRef.current?.contains(document.activeElement)) {
         ignoreNextFocusRef.current = true;
-        triggerRef.current?.focus();
+        getAnchor()?.focus();
       }
     },
-    [clearCloseTimer],
+    [clearCloseTimer, getAnchor],
   );
 
   const scheduleClose = useCallback(() => {
@@ -123,8 +132,38 @@ export function Popover({ trigger, children, className }: PopoverProps) {
     }, CLOSE_DELAY_MS);
   }, [clearCloseTimer, closePopover]);
 
+  const syncOpenState = useCallback(
+    (delayWhenClosed = false) => {
+      const reasons = openReasonsRef.current;
+      if (reasons.hover || reasons.focus || reasons.tap) {
+        openPopover();
+      } else if (delayWhenClosed) {
+        scheduleClose();
+      } else {
+        closePopover();
+      }
+    },
+    [closePopover, openPopover, scheduleClose],
+  );
+
+  const holdReason = useCallback(
+    (reason: OpenReason) => {
+      openReasonsRef.current[reason] = true;
+      syncOpenState();
+    },
+    [syncOpenState],
+  );
+
+  const releaseReason = useCallback(
+    (reason: OpenReason, delayWhenClosed = false) => {
+      openReasonsRef.current[reason] = false;
+      syncOpenState(delayWhenClosed);
+    },
+    [syncOpenState],
+  );
+
   const updatePosition = useCallback(() => {
-    const triggerElement = triggerRef.current;
+    const triggerElement = getAnchor();
     const contentElement = contentRef.current;
     if (!triggerElement || !contentElement) return;
 
@@ -156,7 +195,7 @@ export function Popover({ trigger, children, className }: PopoverProps) {
     // axes. This keeps the layer on-screen without a dependency and behaves
     // predictably even when neither side can fit the content at full height.
     setPosition({ left, placement, top });
-  }, []);
+  }, [getAnchor]);
 
   useLayoutEffect(() => {
     if (!open) return;
@@ -174,7 +213,8 @@ export function Popover({ trigger, children, className }: PopoverProps) {
       typeof ResizeObserver === "undefined"
         ? null
         : new ResizeObserver(() => updatePosition());
-    if (triggerRef.current) resizeObserver?.observe(triggerRef.current);
+    const anchor = getAnchor();
+    if (anchor) resizeObserver?.observe(anchor);
     if (contentRef.current) resizeObserver?.observe(contentRef.current);
 
     return () => {
@@ -182,12 +222,12 @@ export function Popover({ trigger, children, className }: PopoverProps) {
       window.removeEventListener("scroll", update, true);
       resizeObserver?.disconnect();
     };
-  }, [open, updatePosition]);
+  }, [getAnchor, open, updatePosition]);
 
   useEffect(() => clearCloseTimer, [clearCloseTimer]);
 
   useClickOutside({
-    refs: [triggerRef, contentRef],
+    refs: [wrapperRef, contentRef],
     enabled: open,
     closeOnEscape: false,
     onDismiss: () => closePopover(),
@@ -202,9 +242,8 @@ export function Popover({ trigger, children, className }: PopoverProps) {
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [closePopover, open]);
 
-  if (!isValidElement(trigger)) return null;
-
-  const originalProps = trigger.props;
+  const validTrigger = isValidElement<PopoverTriggerProps>(trigger);
+  const originalProps = validTrigger ? trigger.props : {};
   const describedBy = [
     originalProps["aria-describedby"],
     hasContent ? contentId : undefined,
@@ -212,41 +251,9 @@ export function Popover({ trigger, children, className }: PopoverProps) {
     .filter(Boolean)
     .join(" ") || undefined;
 
-  const triggerElement = cloneElement(trigger, {
-    ref: (node: HTMLElement | null) => {
-      triggerRef.current = node;
-      assignRef(originalProps.ref, node);
-    },
-    "aria-describedby": describedBy,
-    onBlur: (event) => {
-      originalProps.onBlur?.(event);
-      if (
-        !isInside(event.relatedTarget, triggerRef.current, contentRef.current)
-      ) {
-        closePopover();
-      }
-    },
-    onClick: (event) => {
-      originalProps.onClick?.(event);
-      openPopover();
-    },
-    onFocus: (event) => {
-      originalProps.onFocus?.(event);
-      if (ignoreNextFocusRef.current) {
-        ignoreNextFocusRef.current = false;
-        return;
-      }
-      openPopover();
-    },
-    onMouseEnter: (event) => {
-      originalProps.onMouseEnter?.(event);
-      openPopover();
-    },
-    onMouseLeave: (event) => {
-      originalProps.onMouseLeave?.(event);
-      scheduleClose();
-    },
-  });
+  const triggerElement = validTrigger
+    ? cloneElement(trigger, { "aria-describedby": describedBy })
+    : null;
 
   const content =
     open && hasContent && typeof document !== "undefined"
@@ -269,16 +276,16 @@ export function Popover({ trigger, children, className }: PopoverProps) {
               if (
                 !isInside(
                   event.relatedTarget,
-                  triggerRef.current,
+                  wrapperRef.current,
                   contentRef.current,
                 )
               ) {
-                closePopover();
+                releaseReason("focus");
               }
             }}
-            onFocus={clearCloseTimer}
-            onMouseEnter={clearCloseTimer}
-            onMouseLeave={scheduleClose}
+            onFocus={() => holdReason("focus")}
+            onMouseEnter={() => holdReason("hover")}
+            onMouseLeave={() => releaseReason("hover", true)}
           >
             {children}
           </div>,
@@ -288,7 +295,58 @@ export function Popover({ trigger, children, className }: PopoverProps) {
 
   return (
     <>
-      {triggerElement}
+      <span
+        ref={wrapperRef}
+        style={{ display: "contents" }}
+        onBlur={(event) => {
+          if (
+            !isInside(
+              event.relatedTarget,
+              wrapperRef.current,
+              contentRef.current,
+            )
+          ) {
+            releaseReason("focus");
+          }
+        }}
+        onClick={(event) => {
+          const pointerType = lastPointerTypeRef.current;
+          const touchActivation =
+            pointerType === "touch" ||
+            pointerType === "pen" ||
+            (pointerType == null &&
+              typeof window.PointerEvent === "undefined" &&
+              window.matchMedia?.("(hover: none)")?.matches === true);
+          lastPointerTypeRef.current = null;
+
+          if (
+            touchActivation &&
+            !revealedByTouchRef.current &&
+            !event.defaultPrevented
+          ) {
+            event.preventDefault();
+            revealedByTouchRef.current = true;
+            holdReason("tap");
+            return;
+          }
+
+          openPopover();
+        }}
+        onFocus={() => {
+          if (ignoreNextFocusRef.current) {
+            ignoreNextFocusRef.current = false;
+            return;
+          }
+          holdReason("focus");
+        }}
+        onMouseEnter={() => holdReason("hover")}
+        onMouseLeave={() => releaseReason("hover", true)}
+        onPointerDown={(event) => {
+          lastPointerTypeRef.current = event.pointerType;
+        }}
+      >
+        {triggerElement}
+      </span>
       {content}
     </>
   );

--- a/src/components/ui/surfaces/popover/Popover.tsx
+++ b/src/components/ui/surfaces/popover/Popover.tsx
@@ -69,6 +69,7 @@ export function Popover({ trigger, children, className }: PopoverProps) {
     tap: false,
   });
   const lastPointerTypeRef = useRef<string | null>(null);
+  const suppressNextClickRef = useRef(false);
   const revealedByTouchRef = useRef(false);
   const [open, setOpen] = useState(false);
   const [position, setPosition] = useState<PopoverPosition | null>(null);
@@ -113,6 +114,7 @@ export function Popover({ trigger, children, className }: PopoverProps) {
       openReasonsRef.current = { focus: false, hover: false, tap: false };
       revealedByTouchRef.current = false;
       lastPointerTypeRef.current = null;
+      suppressNextClickRef.current = false;
       setOpen(false);
       setPosition(null);
 
@@ -309,7 +311,15 @@ export function Popover({ trigger, children, className }: PopoverProps) {
             releaseReason("focus");
           }
         }}
-        onClick={(event) => {
+        onClickCapture={(event) => {
+          if (event.detail === 0) {
+            // Keyboard-generated clicks have no preceding pointer event.
+            // Never let an abandoned pointer sequence consume one.
+            lastPointerTypeRef.current = null;
+            suppressNextClickRef.current = false;
+            return;
+          }
+
           const pointerType = lastPointerTypeRef.current;
           const touchActivation =
             pointerType === "touch" ||
@@ -317,19 +327,26 @@ export function Popover({ trigger, children, className }: PopoverProps) {
             (pointerType == null &&
               typeof window.PointerEvent === "undefined" &&
               window.matchMedia?.("(hover: none)")?.matches === true);
-          lastPointerTypeRef.current = null;
 
           if (
-            touchActivation &&
-            !revealedByTouchRef.current &&
-            !event.defaultPrevented
+            suppressNextClickRef.current ||
+            (touchActivation && !revealedByTouchRef.current)
           ) {
             event.preventDefault();
-            revealedByTouchRef.current = true;
-            holdReason("tap");
-            return;
-          }
+            event.stopPropagation();
+            suppressNextClickRef.current = false;
 
+            // Older browsers without Pointer Events can only be identified
+            // at click capture, which still runs before the trigger handler.
+            if (!revealedByTouchRef.current) {
+              revealedByTouchRef.current = true;
+              holdReason("tap");
+            }
+          }
+        }}
+        onClick={() => {
+          lastPointerTypeRef.current = null;
+          suppressNextClickRef.current = false;
           openPopover();
         }}
         onFocus={() => {
@@ -343,6 +360,29 @@ export function Popover({ trigger, children, className }: PopoverProps) {
         onMouseLeave={() => releaseReason("hover", true)}
         onPointerDown={(event) => {
           lastPointerTypeRef.current = event.pointerType;
+
+          if (
+            (event.pointerType === "touch" || event.pointerType === "pen") &&
+            !revealedByTouchRef.current
+          ) {
+            revealedByTouchRef.current = true;
+            suppressNextClickRef.current = true;
+            holdReason("tap");
+          } else {
+            suppressNextClickRef.current = false;
+          }
+        }}
+        onPointerUp={() => {
+          lastPointerTypeRef.current = null;
+        }}
+        onPointerCancel={() => {
+          lastPointerTypeRef.current = null;
+          suppressNextClickRef.current = false;
+
+          if (revealedByTouchRef.current) {
+            revealedByTouchRef.current = false;
+            releaseReason("tap");
+          }
         }}
       >
         {triggerElement}

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,10 @@ export {
   type ActivityListProps,
   type ActivityItem,
 } from "./components/ui/display/activity-list/ActivityList";
+export {
+  UserIdentityCard,
+  type UserIdentityCardProps,
+} from "./components/ui/display/user-identity-card/UserIdentityCard";
 
 // --- ui/feedback ---
 export {
@@ -417,6 +421,10 @@ export {
   type DialogProps,
   type DialogAction,
 } from "./components/ui/surfaces/dialog/Dialog";
+export {
+  Popover,
+  type PopoverProps,
+} from "./components/ui/surfaces/popover/Popover";
 export {
   TypeToConfirmDialog,
   type TypeToConfirmDialogProps,

--- a/test/react18/package.json
+++ b/test/react18/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@mirrorstack-ai/web-ui-kit-react18-runtime",
+  "private": true,
+  "version": "0.0.0",
+  "description": "React 18 runtime used only by the `react18` vitest project, so the package's `react: >=18` peer range is actually exercised.",
+  "dependencies": {
+    "@testing-library/react": "^16.0.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,11 @@
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 import path from "node:path";
 
 export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
+    exclude: [...configDefaults.exclude, "**/*.react18.test.*"],
   },
   resolve: {
     alias: {

--- a/vitest.react18.config.ts
+++ b/vitest.react18.config.ts
@@ -1,0 +1,42 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+// The package declares `react: ">=18"`, but the dev dependencies and the normal
+// test run are React 19 only. React 19 turned `ref` into an ordinary prop, so a
+// component that injects a ref into a caller-supplied child works on 19 and
+// silently does nothing on 18 — no error, just a component that never appears.
+// `test/react18` is a private workspace package pinned to React 18, and every
+// import below is redirected into it, so `*.react18.test.tsx` files run against
+// a real React 18 renderer and that class of regression fails CI.
+const react18 = (specifier: string) =>
+  path.resolve(__dirname, "test/react18/node_modules", specifier);
+
+export default defineConfig({
+  test: {
+    name: "react18",
+    environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
+    include: ["src/**/*.react18.test.{ts,tsx}"],
+  },
+  resolve: {
+    alias: [
+      { find: /^react$/, replacement: react18("react") },
+      { find: /^react\/jsx-runtime$/, replacement: react18("react/jsx-runtime") },
+      {
+        find: /^react\/jsx-dev-runtime$/,
+        replacement: react18("react/jsx-dev-runtime"),
+      },
+      { find: /^react-dom$/, replacement: react18("react-dom") },
+      { find: /^react-dom\/client$/, replacement: react18("react-dom/client") },
+      {
+        find: /^react-dom\/test-utils$/,
+        replacement: react18("react-dom/test-utils"),
+      },
+      {
+        find: /^@testing-library\/react$/,
+        replacement: react18("@testing-library/react"),
+      },
+      { find: "@", replacement: path.resolve(__dirname, "src") },
+    ],
+  },
+});


### PR DESCRIPTION
Adds the two primitives needed to stop printing bare actor UUIDs in audit and
provenance surfaces.

## `Popover`

A generic anchored overlay. Opens on hover **and** on focus, so it is reachable
by keyboard rather than pointer-only, and closes on Escape and on outside
interaction.

## `UserIdentityCard`

The standard way to render a person: always name, email and avatar together.
The name is a real link, not a span styled to look like one — so middle-click,
copy-link and assistive navigation all behave.

## Why now

The users-roles role-change audit block currently renders its actor as a raw
UUID:

> 授予 banned · 由管理者 `b60401b8-4749-4487-b47c-db35dba7103a` 操作

Paired, these two components turn that into the person's name with the detail
on hover or focus. This PR is the prerequisite; the audit-block change follows
in `ms-app-modules`.

## Release

`0.6.22`. This branch deliberately did not touch `package.json` or the
CHANGELOG while 0.6.21 was in flight, to avoid colliding with it; 0.6.21 is
now published, so the bump lands here.

Verified: `tsc --noEmit` clean, 879/879 tests across 80 files.
