### PR TITLE
fix(user-identity-card): separate the name from the email — 0.6.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.22",
+  "version": "0.6.23",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/display/user-identity-card/UserIdentityCard.test.tsx
+++ b/src/components/ui/display/user-identity-card/UserIdentityCard.test.tsx
@@ -68,6 +68,17 @@ describe("UserIdentityCard", () => {
     );
   });
 
+  // A consumer cannot restore this from the outside: it needs a descendant
+  // selector, and arbitrary variants do not compile into the app modules'
+  // scoped CSS bundles. So the separation has to be owned here.
+  it("separates the name from the email rather than stacking them flush", () => {
+    renderCard();
+    const card = openCard();
+
+    const email = within(card).getByText("ada@example.com");
+    expect(email.parentElement).toHaveClass("space-y-1");
+  });
+
   it("falls back through Avatar when no avatar URL is available", () => {
     renderCard({ avatarUrl: null });
     const card = openCard();

--- a/src/components/ui/display/user-identity-card/UserIdentityCard.tsx
+++ b/src/components/ui/display/user-identity-card/UserIdentityCard.tsx
@@ -64,7 +64,11 @@ export function UserIdentityCard({
     >
       <div className="flex min-w-0 items-center gap-3">
         <Avatar src={avatarUrl} fallback={displayName} size="lg" />
-        <div className="min-w-0 flex-1">
+        {/* space-y-1: the name and email are two distinct facts, and stacking
+            them flush reads as one wrapped line. A consumer cannot fix this
+            from the outside — it needs a descendant selector, and arbitrary
+            variants do not compile into the modules' scoped CSS bundles. */}
+        <div className="min-w-0 flex-1 space-y-1">
           <a
             href={href}
             className="block truncate text-sm font-semibold text-on-surface"


### PR DESCRIPTION
## What

The identity card stacked the display name directly on the email with no separation, so the two read as one wrapped line:

```
Nothing Chang
稽核資料未包含電子郵件
```

Adds `space-y-1` to the text column.

## Why it belongs in the kit, not the consumer

A consumer **cannot** fix this from the outside. It needs a descendant selector, and arbitrary variants like `[&_p]:mt-1` **do not compile into the app modules' scoped CSS bundles** — I verified this empirically: after `build:css`, zero `[&_p]` selectors are emitted, so the class silently does nothing while looking correct in source.

Padding *is* consumer-overridable (`cn` uses `twMerge`, so `className="p-4"` beats the built-in `p-3`), which is why only the gap needed a kit change.

## Verification

`Test Files 1 passed · Tests 10 passed` (9 → 10).

**Mutation proof:** removing `space-y-1` compiles cleanly and fails exactly the new test:
`× separates the name from the email rather than stacking them flush`. Reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)