### PR TITLE
chore: publish 0.6.23 + document the release-label requirement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,33 @@ src/hooks/                                   Hooks
 src/utils/                                   Helpers
 ```
 
+## Publishing a release
+
+🔴 **A merged PR does NOT publish.** `.github/workflows/release.yml` only runs when the PR
+carries the **`release` label**:
+
+```yaml
+if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+```
+
+Without the label the job reports **skipped**, which is not a failure and shows up green — so
+the version silently stays where it was while everything looks fine. Bumping `package.json` is
+not enough on its own.
+
+Two things that make this hard to notice:
+
+- The workflow triggers on `pull_request: closed`, so its runs are tagged with the **head
+  branch**, not `main`. `gh run list --branch main` shows nothing and looks like it never ran.
+- Adding the label *after* merging and re-running does **not** work: the re-run replays the
+  original event payload, so the label is still absent and it skips again. Land a new PR that
+  has the label from the start.
+
+Verify a release by the published version, never by a green run:
+
+```bash
+npm view @mirrorstack-ai/web-ui-kit version
+```
+
 ## Core manifest pointer automation
 
 After a PR merges to protected `main`, a successful terminal `CI` run triggers


### PR DESCRIPTION
## Why this PR exists

web-ui-kit **0.6.23 never published.** `package.json` was bumped and #370 merged green, but `release.yml` is gated on a `release` label:

```yaml
if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
```

Without the label the job reports **skipped** — not failed — so the whole PR reads green while the registry stays at 0.6.22. Same shape as the `stage-branch-purity` skip that jammed the platform pipeline for three days.

**This PR carries the `release` label**, so merging it publishes 0.6.23 from the already-bumped `package.json`.

## Two details that made it hard to spot, now written down

- The workflow triggers on `pull_request: closed`, so its runs are tagged with the **head branch**, not `main`. `gh run list --branch main` shows nothing and looks like it never ran.
- Adding the label after merging and re-running does **not** work — I tried. The re-run replays the original event payload, so the label is still absent and it skips again.

Also records the only trustworthy check: `npm view @mirrorstack-ai/web-ui-kit version`, never a green run.

## What ships in 0.6.23

`UserIdentityCard` gains `space-y-1` between the display name and the email (#370), which stacked flush and read as one wrapped line. That cannot be fixed by a consumer — it needs a descendant selector, and arbitrary variants do not compile into the app modules' scoped CSS bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)