### PR TITLE
fix(user-identity-card): widen the name/email gap to 1.5 — 0.6.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/display/user-identity-card/UserIdentityCard.test.tsx
+++ b/src/components/ui/display/user-identity-card/UserIdentityCard.test.tsx
@@ -76,7 +76,7 @@ describe("UserIdentityCard", () => {
     const card = openCard();
 
     const email = within(card).getByText("ada@example.com");
-    expect(email.parentElement).toHaveClass("space-y-1");
+    expect(email.parentElement).toHaveClass("space-y-1.5");
   });
 
   it("falls back through Avatar when no avatar URL is available", () => {

--- a/src/components/ui/display/user-identity-card/UserIdentityCard.tsx
+++ b/src/components/ui/display/user-identity-card/UserIdentityCard.tsx
@@ -68,7 +68,7 @@ export function UserIdentityCard({
             them flush reads as one wrapped line. A consumer cannot fix this
             from the outside — it needs a descendant selector, and arbitrary
             variants do not compile into the modules' scoped CSS bundles. */}
-        <div className="min-w-0 flex-1 space-y-1">
+        <div className="min-w-0 flex-1 space-y-1.5">
           <a
             href={href}
             className="block truncate text-sm font-semibold text-on-surface"


### PR DESCRIPTION
Owner review: `space-y-1` was still too tight between the display name and the email. Widens to `space-y-1.5`.

Carries the **`release` label** so 0.6.24 actually publishes — a merged PR without it reports *skipped*, which reads green while the registry stays put. That is exactly what happened to 0.6.23.

## Verification

`Test Files 1 passed · Tests 10 passed`. The existing gap test asserts the class, so it moves with the value rather than silently passing on the old one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)