### PR TITLE
fix(navigation-rail): paint the hover label above main content — 0.6.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.23",
+  "version": "0.6.24",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/ui/navigation/navigation-rail/NavigationRail.test.tsx
+++ b/src/components/ui/navigation/navigation-rail/NavigationRail.test.tsx
@@ -10,6 +10,19 @@ describe("NavigationRail", () => {
     expect(screen.getByText("Nav")).toBeInTheDocument();
   });
 
+  // The hover label pill overflows the rail. overflow-visible stops it being
+  // CLIPPED, but without a stacking context of its own it still paints UNDER
+  // main content — which is how the label ended up half-hidden behind the page.
+  it("establishes a stacking context so the overflowing label paints above content", () => {
+    const { container } = render(<NavigationRail><span>Nav</span></NavigationRail>);
+    const root = container.firstElementChild;
+
+    expect(root).toHaveClass("relative");
+    expect(root).toHaveClass("z-30");
+    // Must stay under the z-50 overlay tier or the rail covers dialogs.
+    expect(root).not.toHaveClass("z-50");
+  });
+
   it("renders logo and header", () => {
     render(
       <NavigationRail logo={<span>Logo</span>} header={<span>Header</span>}>

--- a/src/components/ui/navigation/navigation-rail/NavigationRail.tsx
+++ b/src/components/ui/navigation/navigation-rail/NavigationRail.tsx
@@ -33,7 +33,14 @@ export function NavigationRail({
   const horizontal = orientation === "horizontal";
   return (
     <div
-      className={cn("overflow-visible", horizontal ? "px-2 pb-2" : "pl-2 py-4", className)}
+      className={cn(
+        // relative + z-30: the hover label pill overflows the rail, and without a
+        // stacking context of its own it paints UNDER main content. Stays below
+        // the z-50 overlay tier so dialogs and snackbars still win.
+        "relative z-30 overflow-visible",
+        horizontal ? "px-2 pb-2" : "pl-2 py-4",
+        className,
+      )}
     >
       <div
         className={cn(


### PR DESCRIPTION
The nav rail's hover label pill renders **underneath** page content, so it appears half-hidden behind the main column.

## Diagnosis

`overflow-visible` was already set on both rail containers, so the label was never *clipped* — it was **painted under**. Neither rail div was positioned or z-indexed, so the overflowing label had no stacking context to lift it above content.

`relative z-30` on the rail root fixes it. `z-30` is deliberate: above content, below the `z-50` overlay tier this kit uses for dialogs/snackbars, so the rail can never cover a modal.

The button's internal `z-10` icon / `z-0` label ordering is unaffected — those now resolve inside the rail's own stacking context.

## Verification

`Test Files 1 passed · Tests 8 passed` (7 → 8).

**Mutation proof:** dropping `relative z-30` compiles cleanly and fails exactly the new test. Reverted.

Carries the `release` label so 0.6.24 publishes — without it the Release job reports *skipped*, which reads green while the registry stays put.

🤖 Generated with [Claude Code](https://claude.com/claude-code)