### PR TITLE
fix(app-shell): keep content spacing inside scrollport — 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mirrorstack-ai/web-ui-kit",
   "packageManager": "pnpm@10.29.3",
-  "version": "0.6.25",
+  "version": "0.7.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/src/components/layout/app-shell/AppShell.test.tsx
+++ b/src/components/layout/app-shell/AppShell.test.tsx
@@ -4,6 +4,16 @@ import { AppShell } from "./AppShell";
 
 afterEach(cleanup);
 
+describe("AppShell content spacing", () => {
+  it("keeps vertical space inside the scrollport instead of shrinking it outside", () => {
+    render(<AppShell>content</AppShell>);
+
+    const main = screen.getByRole("main");
+    expect(main).toHaveClass("overflow-y-auto", "py-4");
+    expect(main.parentElement).not.toHaveClass("py-4");
+  });
+});
+
 describe("AppShell mobile navigation", () => {
   it("hosts mobileNavigation as a pinned bar by default", () => {
     render(

--- a/src/components/layout/app-shell/AppShell.tsx
+++ b/src/components/layout/app-shell/AppShell.tsx
@@ -519,8 +519,8 @@ function AppShellInner({
               </div>
             )}
 
-            <div className="flex-1 min-w-0 flex flex-col h-full overflow-hidden relative py-4">
-              <main className="relative flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
+            <div className="flex-1 min-w-0 flex flex-col h-full overflow-hidden relative">
+              <main className="relative flex-1 min-h-0 overflow-y-auto overflow-x-hidden py-4">
                 <div
                   className={cn(
                     // Responsive gutters — tight on phones, roomier as the


### PR DESCRIPTION
## Summary
- move the AppShell vertical gutter from the clipping flex parent into the scrollable main region
- preserve the existing 16px top and bottom spacing while allowing sticky content to use the full shell height
- bump @mirrorstack-ai/web-ui-kit from 0.6.25 to 0.7.0

## Verification
- pnpm typecheck
- pnpm test (React 19: 892 tests; React 18: 3 tests)
- pnpm components validate
- pnpm build

## Release
This is an intentional minor release. Add the `release` label before merge to publish v0.7.0.